### PR TITLE
Point to AppKit's `llms.txt` in the Databricks Apps skill

### DIFF
--- a/skills/databricks-apps/SKILL.md
+++ b/skills/databricks-apps/SKILL.md
@@ -39,6 +39,19 @@ These apply regardless of framework:
 
 TypeScript/React framework with type-safe SQL queries and built-in components.
 
+**Official Documentation** - Use CLI for up-to-date API reference:
+
+```bash
+npx @databricks/appkit docs <path>
+```
+
+Examples:
+- View main documentation: `npx @databricks/appkit docs`
+- View API reference: `npx @databricks/appkit docs ./docs/docs/api.md`
+- View component docs: `npx @databricks/appkit docs ./docs/docs/api/appkit-ui/components/Sidebar.md`
+
+The CLI will display the documentation content directly in the terminal.
+
 **Scaffold** (requires `--warehouse-id`, see parent skill for discovery):
 ```bash
 databricks apps init --description "<DESC>" --features analytics --warehouse-id <ID> --name <NAME> --run none --profile <PROFILE>

--- a/skills/databricks-apps/SKILL.md
+++ b/skills/databricks-apps/SKILL.md
@@ -39,20 +39,21 @@ These apply regardless of framework:
 
 TypeScript/React framework with type-safe SQL queries and built-in components.
 
-**Official Documentation** - Use CLI for up-to-date API reference:
+**Official Documentation** - View API reference (docs only, NOT for scaffolding):
 
 ```bash
+# ONLY for viewing documentation - do NOT use for init/scaffold
 npx @databricks/appkit docs <path>
 ```
 
-Examples:
-- View main documentation: `npx @databricks/appkit docs`
-- View API reference: `npx @databricks/appkit docs ./docs/docs/api.md`
-- View component docs: `npx @databricks/appkit docs ./docs/docs/api/appkit-ui/components/Sidebar.md`
+**IMPORTANT**: ALWAYS run `npx @databricks/appkit docs` (no path) FIRST to see available pages. DO NOT guess paths - use the index to find correct paths.
 
-The CLI will display the documentation content directly in the terminal.
+Examples of known paths:
+- Root index: `npx @databricks/appkit docs`
+- API reference: `npx @databricks/appkit docs ./docs/docs/api.md`
+- Component docs: `npx @databricks/appkit docs ./docs/docs/api/appkit-ui/components/Sidebar.md`
 
-**Scaffold** (requires `--warehouse-id`, see parent skill for discovery):
+**Scaffold** (requires `--warehouse-id`, see parent skill; DO NOT use `npx`):
 ```bash
 databricks apps init --description "<DESC>" --features analytics --warehouse-id <ID> --name <NAME> --run none --profile <PROFILE>
 ```

--- a/skills/databricks-apps/references/appkit/appkit-sdk.md
+++ b/skills/databricks-apps/references/appkit/appkit-sdk.md
@@ -16,23 +16,7 @@ import { MyInterface, MyType } from '../../shared/types';
 
 ## Server Setup
 
-```typescript
-import { createApp, server, analytics } from '@databricks/app-kit';
-
-const app = await createApp({
-  plugins: [
-    server({ autoStart: false }),
-    analytics(),
-  ],
-});
-
-// Extend with custom tRPC endpoints if needed
-app.server.extend((express: Application) => {
-  express.use('/trpc', [appRouterMiddleware()]);
-});
-
-await app.server.start();
-```
+For server configuration, see: `npx @databricks/appkit docs ./docs/docs/plugins.md`
 
 ## useAnalyticsQuery Hook
 
@@ -59,21 +43,22 @@ function MyComponent() {
 }
 ```
 
-**⚠️ CRITICAL: This is NOT React Query**
+**Conditional Query Options:**
 
-| React Query Pattern | AppKit Pattern |
-|---------------------|----------------|
-| `{ enabled: !!id }` | ❌ NOT SUPPORTED - Use conditional rendering |
-| `refetch()` | ❌ NOT SUPPORTED - Change parameters or re-mount |
-| `onSuccess` callback | ❌ NOT SUPPORTED - Use useEffect on data |
+| Approach | When to use |
+|----------|-------------|
+| `{ autoStart: false }` | Prevent query from running on mount, start manually later |
+| Conditional rendering | Only mount component when data is needed |
 
-**Conditional Query Pattern:**
+**Option 1: Use `autoStart: false`**
 
 ```typescript
-// ❌ WRONG - enabled option doesn't exist
-const { data } = useAnalyticsQuery('details', params, { enabled: !!selectedId });
+const { data, loading, error } = useAnalyticsQuery('details', params, { autoStart: false });
+```
 
-// ✅ CORRECT - Use conditional rendering
+**Option 2: Conditional rendering**
+
+```typescript
 function ParentComponent() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
 

--- a/skills/databricks-apps/references/appkit/frontend.md
+++ b/skills/databricks-apps/references/appkit/frontend.md
@@ -41,22 +41,9 @@ Available: `AreaChart`, `BarChart`, `LineChart`, `PieChart`, `RadarChart`, `Data
 
 **Chart Props Reference:**
 
-| Prop | Type | Description |
-|------|------|-------------|
-| `queryKey` | string | Query file name (without .sql) |
-| `parameters` | Record<string, SQLTypeMarker> | Query parameters |
-| `xKey` | string | X-axis field (auto-detected if not provided) |
-| `yKey` | string \| string[] | Y-axis field(s) (auto-detected if not provided) |
-| `colors` | string[] | Custom color palette |
-| `height` | number | Chart height in pixels (default: 300) |
-| `showLegend` | boolean | Show legend |
-| `stacked` | boolean | Stack bars/areas (BarChart, AreaChart) |
-| `orientation` | "vertical" \| "horizontal" | Chart orientation (BarChart) |
-| `smooth` | boolean | Smooth line curves (LineChart, AreaChart) |
-| `showSymbol` | boolean | Show data point markers (LineChart) |
-| `innerRadius` | number | Inner radius for donut effect (PieChart, 0-100%) |
-| `showLabels` | boolean | Show labels on slices (PieChart, default: true) |
-| `labelPosition` | "outside" \| "inside" \| "center" | Label position (PieChart) |
+For full props API, see: `npx @databricks/appkit docs ./docs/docs/api/appkit-ui/data/BarChart.md`
+
+Common props: `queryKey`, `parameters`, `xKey`, `yKey`, `colors`, `height`, `showLegend`, `stacked`
 
 **Basic Usage:**
 

--- a/skills/databricks-apps/references/appkit/frontend.md
+++ b/skills/databricks-apps/references/appkit/frontend.md
@@ -43,8 +43,6 @@ Available: `AreaChart`, `BarChart`, `LineChart`, `PieChart`, `RadarChart`, `Data
 
 For full props API, see: `npx @databricks/appkit docs ./docs/docs/api/appkit-ui/data/BarChart.md`
 
-Common props: `queryKey`, `parameters`, `xKey`, `yKey`, `colors`, `height`, `showLegend`, `stacked`
-
 **Basic Usage:**
 
 ```typescript

--- a/skills/databricks-apps/references/appkit/overview.md
+++ b/skills/databricks-apps/references/appkit/overview.md
@@ -23,25 +23,7 @@ Before writing App.tsx, complete these steps:
 
 ## Project Structure
 
-```
-my-app/
-├── client/                    # React frontend
-│   ├── src/
-│   │   ├── App.tsx           # ← Main app component (start here)
-│   │   ├── appKitTypes.d.ts  # AUTO-GENERATED query types
-│   │   └── main.tsx          # Entry point
-│   └── vite.config.ts
-├── server/
-│   └── server.ts             # AppKit server + tRPC routes
-├── config/
-│   └── queries/              # SQL files
-│       └── my_query.sql      # → queryKey: "my_query"
-├── shared/
-│   └── types.ts              # Shared interfaces, helpers
-├── tests/
-│   └── smoke.spec.ts         # ⚠️ Update selectors after customizing!
-└── databricks.yml            # Deployment config
-```
+For full project layout, see official docs: `npx @databricks/appkit docs ./docs/docs/development/project-setup.md`
 
 **Key files to modify:**
 | Task | File |
@@ -54,21 +36,12 @@ my-app/
 
 ## Type Safety
 
-**Types are AUTO-GENERATED** - no manual schema files needed!
+For type generation details, see: `npx @databricks/appkit docs ./docs/docs/development/type-generation.md`
 
+**Quick workflow:**
 1. Add/modify SQL in `config/queries/`
 2. Run `npm run dev` (watches) or `npm run typegen`
 3. Types appear in `client/src/appKitTypes.d.ts`
-
-**Optional Zod validation** - create `config/queries/schema.ts`:
-```typescript
-import { z } from 'zod';
-export const querySchemas = {
-  my_query: z.array(z.object({
-    amount: z.coerce.number(),  // z.coerce handles string/number from SQL
-  })),
-};
-```
 
 ## Adding Visualizations
 
@@ -98,7 +71,7 @@ import { BarChart } from '@databricks/appkit-ui/react';
 2. **Numeric types**: SQL numbers may return as strings. Always convert: `Number(row.amount)`
 3. **Type imports**: Use `import type { ... }` (verbatimModuleSyntax enabled).
 4. **Charts are ECharts**: No Recharts children - use props (`xKey`, `yKey`, `colors`).
-5. **No `enabled` option**: `useAnalyticsQuery` isn't React Query - use conditional rendering.
+5. **Conditional queries**: Use `autoStart: false` option or conditional rendering to control query execution.
 
 ## Decision Tree
 

--- a/skills/databricks-apps/references/appkit/overview.md
+++ b/skills/databricks-apps/references/appkit/overview.md
@@ -23,7 +23,24 @@ Before writing App.tsx, complete these steps:
 
 ## Project Structure
 
-For full project layout, see official docs: `npx @databricks/appkit docs ./docs/docs/development/project-setup.md`
+```
+my-app/
+├── server/
+│   ├── index.ts              # Backend entry point (AppKit)
+│   └── .env                  # Optional local dev env vars (do not commit)
+├── client/
+│   ├── index.html
+│   ├── vite.config.ts
+│   └── src/
+│       ├── main.tsx
+│       └── App.tsx           # <- Main app component (start here)
+├── config/
+│   └── queries/
+│       └── my_query.sql      # -> queryKey: "my_query"
+├── app.yaml                  # Deployment config
+├── package.json
+└── tsconfig.json
+```
 
 **Key files to modify:**
 | Task | File |
@@ -40,7 +57,7 @@ For type generation details, see: `npx @databricks/appkit docs ./docs/docs/devel
 
 **Quick workflow:**
 1. Add/modify SQL in `config/queries/`
-2. Run `npm run dev` (watches) or `npm run typegen`
+2. Run `npm run typegen`
 3. Types appear in `client/src/appKitTypes.d.ts`
 
 ## Adding Visualizations

--- a/skills/databricks-apps/references/appkit/sql-queries.md
+++ b/skills/databricks-apps/references/appkit/sql-queries.md
@@ -10,13 +10,9 @@
 
 ## Type Generation
 
-**Types are AUTO-GENERATED** from SQL files - no manual schema required!
+For full type generation details, see: `npx @databricks/appkit docs ./docs/docs/development/type-generation.md`
 
-1. Add/modify SQL files in `config/queries/`
-2. Run `npm run dev` (auto-regenerates on changes) or `npm run typegen`
-3. Types appear in `client/src/appKitTypes.d.ts`
-
-**DO NOT** manually edit `client/src/appKitTypes.d.ts`.
+**Quick workflow:** Add SQL files → Run `npm run dev` or `npm run typegen` → Types appear in `client/src/appKitTypes.d.ts`
 
 ## Query Schemas (Optional)
 
@@ -83,19 +79,21 @@ const percent = formatPercent(row.rate);  // "85.5" → "85.5%"
 
 ## Available sql.* Helpers
 
+For full API reference, see: `npx @databricks/appkit docs ./docs/docs/api/appkit/Variable.sql.md`
+
 ```typescript
 import { sql } from "@databricks/appkit-ui/js";
 
 // ✅ These exist:
 sql.string(value)      // For STRING parameters
 sql.number(value)      // For NUMERIC parameters (INT, BIGINT, DOUBLE, DECIMAL)
+sql.boolean(value)     // For BOOLEAN parameters
 sql.date(value)        // For DATE parameters (YYYY-MM-DD format)
 sql.timestamp(value)   // For TIMESTAMP parameters
 sql.binary(value)      // For BINARY (returns hex string, use UNHEX() in SQL)
 
 // ❌ These DO NOT exist:
 // sql.null()     - use sentinel values instead
-// sql.boolean()  - use sql.number(1/0) or sql.string("true"/"false")
 // sql.array()    - use comma-separated sql.string() and split in SQL
 // sql.int()      - use sql.number()
 // sql.float()    - use sql.number()

--- a/skills/databricks-apps/references/appkit/sql-queries.md
+++ b/skills/databricks-apps/references/appkit/sql-queries.md
@@ -12,7 +12,7 @@
 
 For full type generation details, see: `npx @databricks/appkit docs ./docs/docs/development/type-generation.md`
 
-**Quick workflow:** Add SQL files → Run `npm run dev` or `npm run typegen` → Types appear in `client/src/appKitTypes.d.ts`
+**Quick workflow:** Add SQL files → Run `npm run typegen` → Types appear in `client/src/appKitTypes.d.ts`
 
 ## Query Schemas (Optional)
 


### PR DESCRIPTION
This PR points agent to use AppKit `llms.txt` file (and markdown files), which is embedded in the locally installed AppKit npm packages, as well as available globally via the same `npx` command.

Related discussion: https://databricks.slack.com/archives/C09BCFBGMC4/p1769701983981889