### PR TITLE
Reinforce repo policy: CODEOWNERS, security, contributing guidelines

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @databricks/eng-apps-devex

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## Summary
+
+<!-- Brief description of the change -->
+
+## Documentation safety checklist
+
+- [ ] Examples use least-privilege permissions (no unnecessary `ALL PRIVILEGES`, admin tokens, or broad scopes)
+- [ ] Elevated permissions are explicitly called out where required
+- [ ] Sensitive values are obfuscated (placeholder workspace IDs, URLs, no real tokens)
+- [ ] No insecure patterns introduced (e.g. disabled TLS verification, hardcoded credentials)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,15 @@
 
 Please see [SECURITY](./SECURITY) for vulnerability reporting guidelines.
 
+## Documentation Safety
+
+Examples in skills and references must follow secure defaults:
+
+- Use least-privilege permissions — don't suggest `ALL PRIVILEGES` when a narrower grant suffices
+- If an example requires elevated permissions, state it explicitly (e.g. "requires workspace admin")
+- Prefer scoped tokens over broad credentials
+- Obfuscate sensitive values: use placeholder workspace IDs (`1111111111111111`), URLs (`company-workspace.cloud.databricks.com`), and never include real tokens or passwords
+
 ## Developer Certificate of Origin
 
 To contribute to this repository, you must sign off your commits to certify 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,7 @@
+## Security
+
+Please see [SECURITY](./SECURITY) for vulnerability reporting guidelines.
+
 ## Developer Certificate of Origin
 
 To contribute to this repository, you must sign off your commits to certify 

--- a/README.md
+++ b/README.md
@@ -65,3 +65,16 @@ python3 scripts/generate_manifest.py validate
 ```
 
 The manifest is used by the CLI to discover available skills.
+
+## Security
+
+Please see [SECURITY](./SECURITY) for vulnerability reporting guidelines.
+
+## Integrity
+
+All future release tags will be GPG-signed and verifiable via `git tag -v <tag>`.
+
+## Contributing
+
+- All changes require approval from a code owner (see [CODEOWNERS](./.github/CODEOWNERS)).
+- Documentation examples must follow least-privilege defaults — avoid suggesting elevated permissions or broad scopes unless explicitly necessary.


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` — `@databricks/eng-apps-devex` owns all files
- Add security, integrity, and contributing sections to `README.md`
- Reference `SECURITY` from `CONTRIBUTING.md`

Addresses security review feedback: code owner enforcement, signed tag policy, least-privilege documentation defaults.

## Test plan
- [x] CODEOWNERS syntax valid
- [x] All cross-references resolve to existing files