### PR TITLE
Add files array to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,14 +1,41 @@
 {
   "version": "1",
-  "updated_at": "2026-01-27T14:12:53Z",
+  "updated_at": "2026-02-13T10:52:05Z",
   "skills": {
     "databricks": {
       "version": "0.1.0",
-      "updated_at": "2026-01-27T13:49:12Z"
+      "updated_at": "2026-02-12T16:39:16Z",
+      "files": [
+        "SKILL.md",
+        "ai-bi-dashboards.md",
+        "asset-bundles.md",
+        "clusters.md",
+        "data-exploration.md",
+        "databricks-cli-auth.md",
+        "databricks-cli-install.md",
+        "dbfs.md",
+        "dbsql.md",
+        "genie.md",
+        "jobs.md",
+        "lakeflow.md",
+        "model-serving.md",
+        "secrets.md",
+        "unity-catalog.md",
+        "workspace.md"
+      ]
     },
     "databricks-apps": {
       "version": "0.1.0",
-      "updated_at": "2026-01-27T13:49:12Z"
+      "updated_at": "2026-02-12T16:39:16Z",
+      "files": [
+        "SKILL.md",
+        "references/appkit/appkit-sdk.md",
+        "references/appkit/frontend.md",
+        "references/appkit/overview.md",
+        "references/appkit/sql-queries.md",
+        "references/appkit/trpc.md",
+        "references/testing.md"
+      ]
     }
   }
 }

--- a/scripts/generate_manifest.py
+++ b/scripts/generate_manifest.py
@@ -68,9 +68,16 @@ def generate_manifest(repo_root: Path) -> dict:
         if not skill_md.exists():
             continue
 
+        files = sorted(
+            str(f.relative_to(item))
+            for f in item.rglob("*")
+            if f.is_file()
+        )
+
         skills[item.name] = {
             "version": extract_version_from_skill(item),
             "updated_at": get_skill_updated_at(item),
+            "files": files,
         }
 
     return {


### PR DESCRIPTION
## Summary
- Generate per-skill `files` array in `manifest.json` so consumers can discover files without calling the GitHub API
- Needed by databricks/cli to simplify the skills installer (dropping GitHub API + auth in favor of raw URLs)

## Test plan
- [x] `python scripts/generate_manifest.py validate` passes