### PR TITLE
Align AppKit docs with scaffold defaults and placeholder conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This installs skills to `~/.claude/skills/` for use with Claude Code.
 
 ## Available Skills
 
+- **databricks** - Core Databricks CLI guidance (auth, profiles, data exploration, jobs, UC, and more)
 - **databricks-apps** - Build full-stack TypeScript apps on Databricks using AppKit
 
 ## Structure
@@ -32,8 +33,9 @@ When experimenting with new skill variations, create a "subskill" that reference
 
 ```markdown
 ---
-name: "ai-databricks-apps"
+name: "databricks-apps-chatbots"
 description: "Databricks apps with AI features"
+parent: databricks-apps
 ---
 
 # AI powered Databricks Apps

--- a/skills/databricks-apps/SKILL.md
+++ b/skills/databricks-apps/SKILL.md
@@ -33,7 +33,7 @@ These apply regardless of framework:
 - **Smoke tests**: ALWAYS update `tests/smoke.spec.ts` selectors BEFORE running validation. Default template checks for "Minimal Databricks App" heading and "hello world" text — these WILL fail in your custom app. See [testing guide](references/testing.md).
 - **Authentication**: covered by parent `databricks` skill
 
-## Project Structure (after `databricks apps init --features analytics`)
+## Project Structure (after `databricks apps init --version 0.5.4 --features analytics`)
 - `client/src/App.tsx` — main React component (start here)
 - `config/queries/*.sql` — SQL query files (queryKey = filename without .sql)
 - `server/server.ts` — backend entry (tRPC routers)
@@ -76,7 +76,7 @@ npx @databricks/appkit docs <path>       # then use paths from the index
 
 **Scaffold** (requires `--warehouse-id`, see parent skill; DO NOT use `npx`):
 ```bash
-databricks apps init --description "<DESC>" --features analytics --warehouse-id <ID> --name <NAME> --run none --profile <PROFILE>
+databricks apps init --version 0.5.4 --description "<DESC>" --features analytics --warehouse-id <ID> --name <NAME> --run none --profile <PROFILE>
 ```
 
 **READ [AppKit Overview](references/appkit/overview.md)** for project structure, workflow, and pre-implementation checklist.

--- a/skills/databricks-apps/references/appkit/appkit-sdk.md
+++ b/skills/databricks-apps/references/appkit/appkit-sdk.md
@@ -8,10 +8,10 @@ Template enforces `noUnusedLocals` - remove unused imports immediately or build 
 
 ```typescript
 // ✅ CORRECT - use import type for types
-import type { MyInterface, MyType } from '../../shared/types';
+import type { MyInterface, MyType } from './types';
 
 // ❌ WRONG - will fail compilation
-import { MyInterface, MyType } from '../../shared/types';
+import { MyInterface, MyType } from './types';
 ```
 
 ## Server Setup

--- a/skills/databricks-apps/references/appkit/overview.md
+++ b/skills/databricks-apps/references/appkit/overview.md
@@ -4,25 +4,18 @@ AppKit is the recommended way to build Databricks Apps - provides type-safe SQL 
 
 ## Workflow
 
-1. **Scaffold**: See parent SKILL.md for `databricks apps init` command
+1. **Scaffold**: `databricks apps init --version 0.5.4 --description "<DESC>" --features analytics --warehouse-id <ID> --name <NAME> --run none --profile <PROFILE>` (analytics is the recommended default; see parent SKILL.md for context)
 2. **Develop**: `cd <NAME> && npm install && npm run dev`
 3. **Validate**: `databricks apps validate`
 4. **Deploy**: `databricks apps deploy --profile <PROFILE>`
 
 ## Data Discovery (Before Writing SQL)
 
-```bash
-# 1. get warehouse id
-databricks experimental aitools tools get-default-warehouse --profile <PROFILE>
+Use the parent `databricks` skill for discovery/query commands:
+- `databricks` skill -> **Data Exploration — Use AI Tools**
+- `Data Exploration` reference in the `databricks` skill for detailed guidance
 
-# 2. explore table structure
-databricks experimental aitools tools discover-schema catalog.schema.table --profile <PROFILE>
-
-# 3. test query
-databricks experimental aitools tools query "SELECT * FROM catalog.schema.table LIMIT 5" --profile <PROFILE>
-```
-
-Do NOT manually iterate through `catalogs list` → `schemas list` → `tables list`.
+Do NOT manually iterate through `catalogs list`, then `schemas list`, then `tables list`.
 
 ## Pre-Implementation Checklist
 
@@ -50,7 +43,7 @@ Before running `databricks apps validate`, complete these steps:
 ```
 my-app/
 ├── server/
-│   ├── index.ts              # Backend entry point (AppKit)
+│   ├── server.ts             # Backend entry point (AppKit)
 │   └── .env                  # Optional local dev env vars (do not commit)
 ├── client/
 │   ├── index.html
@@ -70,9 +63,9 @@ my-app/
 | Task | File |
 |------|------|
 | Build UI | `client/src/App.tsx` |
-| Add SQL query | `config/queries/<name>.sql` |
+| Add SQL query | `config/queries/<NAME>.sql` |
 | Add API endpoint | `server/server.ts` (tRPC) |
-| Add shared types | `shared/types.ts` |
+| Add shared helpers (optional) | create `shared/types.ts` or `client/src/lib/formatters.ts` |
 | Fix smoke test | `tests/smoke.spec.ts` |
 
 ## Type Safety

--- a/skills/databricks-apps/references/appkit/sql-queries.md
+++ b/skills/databricks-apps/references/appkit/sql-queries.md
@@ -62,10 +62,21 @@ export const querySchemas = {
 
 **Helper Functions:**
 
-Use the helpers from `shared/types.ts` for consistent formatting:
+Create app-specific helpers for consistent numeric formatting (for example in `client/src/lib/formatters.ts`):
 
 ```typescript
-import { toNumber, formatCurrency, formatPercent } from '../../shared/types';
+// client/src/lib/formatters.ts
+export const toNumber = (value: number | string): number => Number(value);
+export const formatCurrency = (value: number | string): string =>
+  `$${Number(value).toFixed(2)}`;
+export const formatPercent = (value: number | string): string =>
+  `${Number(value).toFixed(1)}%`;
+```
+
+Use them wherever you render query results:
+
+```typescript
+import { toNumber, formatCurrency, formatPercent } from './formatters'; // adjust import path to your file layout
 
 // Convert to number
 const amount = toNumber(row.amount);  // "123.45" → 123.45

--- a/skills/databricks-apps/references/appkit/trpc.md
+++ b/skills/databricks-apps/references/appkit/trpc.md
@@ -12,8 +12,10 @@ Use tRPC ONLY for:
 
 ## Server-side Pattern
 
+Default scaffold puts server code in `server/server.ts`. You can keep routes there or extract a separate `server/trpc.ts` module as your app grows.
+
 ```typescript
-// server/trpc.ts
+// server/server.ts
 import { initTRPC } from '@trpc/server';
 import { getExecutionContext } from '@databricks/appkit';
 import { z } from 'zod';

--- a/skills/databricks/SKILL.md
+++ b/skills/databricks/SKILL.md
@@ -54,13 +54,13 @@ databricks apps list  # profile not set!
 
 ```bash
 # discover table structure (columns, types, sample data, stats)
-databricks experimental aitools tools discover-schema catalog.schema.table --profile <profile>
+databricks experimental aitools tools discover-schema catalog.schema.table --profile <PROFILE>
 
 # run ad-hoc SQL queries
-databricks experimental aitools tools query "SELECT * FROM table LIMIT 10" --profile <profile>
+databricks experimental aitools tools query "SELECT * FROM table LIMIT 10" --profile <PROFILE>
 
 # find the default warehouse
-databricks experimental aitools tools get-default-warehouse --profile <profile>
+databricks experimental aitools tools get-default-warehouse --profile <PROFILE>
 ```
 
 See [Data Exploration](data-exploration.md) for details.
@@ -71,27 +71,27 @@ See [Data Exploration](data-exploration.md) for details.
 
 ```bash
 # current user
-databricks current-user me --profile <profile>
+databricks current-user me --profile <PROFILE>
 
 # list resources
-databricks apps list --profile <profile>
-databricks jobs list --profile <profile>
-databricks clusters list --profile <profile>
-databricks warehouses list --profile <profile>
-databricks pipelines list --profile <profile>
-databricks serving-endpoints list --profile <profile>
+databricks apps list --profile <PROFILE>
+databricks jobs list --profile <PROFILE>
+databricks clusters list --profile <PROFILE>
+databricks warehouses list --profile <PROFILE>
+databricks pipelines list --profile <PROFILE>
+databricks serving-endpoints list --profile <PROFILE>
 
 # ⚠️ Unity Catalog — POSITIONAL arguments (NOT flags!)
-databricks catalogs list --profile <profile>
+databricks catalogs list --profile <PROFILE>
 
 # ✅ CORRECT: positional args
-databricks schemas list <catalog> --profile <profile>
-databricks tables list <catalog> <schema> --profile <profile>
-databricks tables get <catalog>.<schema>.<table> --profile <profile>
+databricks schemas list <CATALOG> --profile <PROFILE>
+databricks tables list <CATALOG> <SCHEMA> --profile <PROFILE>
+databricks tables get <CATALOG>.<SCHEMA>.<TABLE> --profile <PROFILE>
 
 # ❌ WRONG: these flags/commands DON'T EXIST
-# databricks schemas list --catalog-name <catalog>    ← WILL FAIL
-# databricks tables list --catalog <catalog>           ← WILL FAIL
+# databricks schemas list --catalog-name <CATALOG>    ← WILL FAIL
+# databricks tables list --catalog <CATALOG>           ← WILL FAIL
 # databricks sql-warehouses list                       ← doesn't exist, use `warehouses list`
 # databricks execute-statement                         ← doesn't exist, use `experimental aitools tools query`
 # databricks sql execute                               ← doesn't exist, use `experimental aitools tools query`
@@ -100,15 +100,15 @@ databricks tables get <catalog>.<schema>.<table> --profile <profile>
 # databricks schemas list --help
 
 # get details
-databricks apps get <name> --profile <profile>
-databricks jobs get --job-id <id> --profile <profile>
-databricks clusters get --cluster-id <id> --profile <profile>
+databricks apps get <NAME> --profile <PROFILE>
+databricks jobs get --job-id <ID> --profile <PROFILE>
+databricks clusters get --cluster-id <ID> --profile <PROFILE>
 
 # bundles
-databricks bundle init --profile <profile>
-databricks bundle validate --profile <profile>
-databricks bundle deploy -t <target> --profile <profile>
-databricks bundle run <resource> -t <target> --profile <profile>
+databricks bundle init --profile <PROFILE>
+databricks bundle validate --profile <PROFILE>
+databricks bundle deploy -t <TARGET> --profile <PROFILE>
+databricks bundle run <RESOURCE> -t <TARGET> --profile <PROFILE>
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
- Align Databricks Apps docs with current AppKit scaffold behavior (`server/server.ts`) and analytics-first init guidance pinned to `--version 0.5.4`.
- Remove stale path assumptions by replacing repo-specific parent-skill links and making shared helper guidance explicit/optional.
- Standardize placeholder casing in core `databricks` and `databricks-apps` docs to reduce ambiguous command generation.

## Test plan
- [x] Run `rg` checks to verify stale references (`server/index.ts`, `../../shared/types`, repo-path links) are removed.
- [x] Confirm placeholder casing normalization in `skills/databricks/SKILL.md` and `skills/databricks-apps/references/appkit/overview.md`.
- [x] Review `git diff` for all doc changes included in this PR.

Made with [Cursor](https://cursor.com)