### PR TITLE
Add Cursor plugin support and installation docs

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "databricks-skills",
+  "displayName": "Databricks Skills",
+  "description": "Databricks skills for CLI, Apps, Unity Catalog, Model Serving, Asset Bundles, and more.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Databricks"
+  },
+  "skills": "./skills/"
+}

--- a/README.md
+++ b/README.md
@@ -1,14 +1,24 @@
 # Databricks Agent Skills
 
-Skills for AI coding assistants (Claude Code, etc.) that provide Databricks-specific guidance.
+Skills for AI coding assistants (Claude Code, Cursor, etc.) that provide Databricks-specific guidance.
 
 ## Installation
+
+**For Claude Code:**
 
 ```bash
 databricks experimental aitools skills install
 ```
 
 This installs skills to `~/.claude/skills/` for use with Claude Code.
+
+**For Cursor:**
+
+Run this command in chat:
+
+```text
+/add-plugin databricks-skills
+```
 
 ## Available Skills
 


### PR DESCRIPTION
## Summary
- add a Cursor plugin manifest at `.cursor-plugin/plugin.json` for `databricks-skills`
- keep existing Claude Code install instructions and add Cursor install command usage
- document `/add-plugin databricks-skills` in the README installation section

## Test plan
- [x] Review `.cursor-plugin/plugin.json` for expected metadata and `skills` path
- [x] Verify README installation section includes both Claude and Cursor instructions

Made with [Cursor](https://cursor.com)