### PR TITLE
Improve guidance for installing Databricks CLI when missing

### DIFF
--- a/skills/databricks-apps/SKILL.md
+++ b/skills/databricks-apps/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: databricks-apps
 description: Build apps on Databricks Apps platform. Use when asked to create dashboards, data apps, analytics tools, or visualizations. Invoke BEFORE starting implementation.
-compatibility: Requires databricks CLI (>= 0.250.0)
+compatibility: Requires databricks CLI (>= v0.288.0)
 metadata:
   version: "0.1.0"
 parent: databricks

--- a/skills/databricks/SKILL.md
+++ b/skills/databricks/SKILL.md
@@ -18,14 +18,9 @@ For specific products, use dedicated skills:
 ## Prerequisites
 
 1. **CLI installed**: Run `databricks --version` to check.
-   - **If the CLI is missing or outdated (< v0.288.0): STOP. Do not proceed or work around a missing CLI. Guide the user through installation first.**
-   - Quick install:
-     - **macOS/Linux (Homebrew)**: `brew tap databricks/tap && brew install databricks`
-     - **macOS/Linux (curl fallback)**: `curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh`
-     - **Windows (WinGet)**: `winget install Databricks.DatabricksCLI` (restart terminal after)
-   - Verify: `databricks -v`
-   - **Sandboxed environments (Cursor IDE, containers)**: Install commands write outside the workspace and may be blocked. Present the commands to the user and ask them to run in their own terminal.
-   - For edge cases (no sudo, manual install, troubleshooting): Read the [CLI Installation](databricks-cli-install.md) reference file.
+   - **If the CLI is missing or outdated (< v0.288.0): STOP. Do not proceed or work around a missing CLI.**
+   - **Read the [CLI Installation](databricks-cli-install.md) reference file and follow the instructions to guide the user through installation.**
+   - Note: In sandboxed environments (Cursor IDE, containers), install commands write outside the workspace and may be blocked. Present the install command to the user and ask them to run it in their own terminal.
 
 2. **Authenticated**: `databricks auth profiles`
    - If not: see [CLI Authentication](databricks-cli-auth.md)

--- a/skills/databricks/SKILL.md
+++ b/skills/databricks/SKILL.md
@@ -24,6 +24,7 @@ For specific products, use dedicated skills:
      - **macOS/Linux (curl fallback)**: `curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh`
      - **Windows (WinGet)**: `winget install Databricks.DatabricksCLI` (restart terminal after)
    - Verify: `databricks -v`
+   - **Sandboxed environments (Cursor IDE, containers)**: Install commands write outside the workspace and may be blocked. Present the commands to the user and ask them to run in their own terminal.
    - For edge cases (no sudo, manual install, troubleshooting): Read the [CLI Installation](databricks-cli-install.md) reference file.
 
 2. **Authenticated**: `databricks auth profiles`

--- a/skills/databricks/SKILL.md
+++ b/skills/databricks/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "databricks"
 description: "Databricks CLI operations: auth, profiles, Unity Catalog, data exploration, jobs, pipelines, clusters, model serving, bundles and more. Contains up-to-date guidelines for all Databricks CLI tasks, useful for all Databricks-related tasks."
-compatibility: Requires databricks CLI (>= 0.250.0)
+compatibility: Requires databricks CLI (>= v0.288.0)
 metadata:
   version: "0.1.0"
 ---
@@ -17,8 +17,14 @@ For specific products, use dedicated skills:
 
 ## Prerequisites
 
-1. **CLI installed**: `databricks --version`
-   - If not: see [CLI Installation](databricks-cli-install.md)
+1. **CLI installed**: Run `databricks --version` to check.
+   - **If the CLI is missing or outdated (< v0.288.0): STOP. Do not proceed or work around a missing CLI. Guide the user through installation first.**
+   - Quick install:
+     - **macOS/Linux (Homebrew)**: `brew tap databricks/tap && brew install databricks`
+     - **macOS/Linux (curl fallback)**: `curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh`
+     - **Windows (WinGet)**: `winget install Databricks.DatabricksCLI` (restart terminal after)
+   - Verify: `databricks -v`
+   - For edge cases (no sudo, manual install, troubleshooting): Read the [CLI Installation](databricks-cli-install.md) reference file.
 
 2. **Authenticated**: `databricks auth profiles`
    - If not: see [CLI Authentication](databricks-cli-auth.md)

--- a/skills/databricks/databricks-cli-install.md
+++ b/skills/databricks/databricks-cli-install.md
@@ -4,9 +4,11 @@ Install or update the Databricks CLI on macOS, Windows, or Linux using doc-valid
 
 ## Sandboxed / IDE environments (Cursor, containers)
 
-CLI install commands write to system directories outside the workspace (e.g. `/opt/homebrew/`, `/usr/local/bin/`). In sandboxed environments these writes are blocked.
+CLI install commands often write to system directories outside the workspace (e.g. `/opt/homebrew/`, `/usr/local/bin/`) which are blocked in sandboxed environments.
 
-**Agent behavior**: Do not attempt to run install commands directly. Instead, present the appropriate install command to the user and ask them to run it in their own terminal. After they confirm installation, verify with `databricks -v`.
+**Agent behavior**: Do not attempt to run install commands directly. Present the appropriate command to the user and ask them to run it in their own terminal. After they confirm, verify with `databricks -v`.
+
+For Linux/macOS containers or Cursor: prefer the **Linux manual install to user directory** method (`~/.local/bin`) — it requires no sudo and no writes outside the workspace.
 
 ## Preconditions (always do first)
 1. Determine OS and shell:
@@ -88,7 +90,7 @@ Steps:
 Notes:
 - The download files are `.tar.gz` archives (not `.zip`) with naming pattern: `databricks_cli_<version>_linux_<arch>.tar.gz`
 - Common architectures: `amd64` (x86_64), `arm64` (aarch64)
-- This method works in containerized environments without sudo access
+- This method works in containerized environments and sandboxed IDEs (e.g. Cursor) without sudo access
 
 ### Windows (preferred: WinGet)
 Run in Command Prompt (then restart the terminal session):
@@ -174,5 +176,3 @@ Steps:
 - `databricks: command not found` after installation to `~/.local/bin`:
   - Add to PATH: `export PATH="$HOME/.local/bin:$PATH"`
   - For persistence, add the export command to `~/.bashrc` or `~/.zshrc`.
-- Permission errors in sandboxed IDE (e.g. `/opt/homebrew/Cellar is not writable` in Cursor):
-  - The IDE sandbox blocks writes outside the workspace. Ask the user to run the install command in their own terminal.

--- a/skills/databricks/databricks-cli-install.md
+++ b/skills/databricks/databricks-cli-install.md
@@ -2,6 +2,12 @@
 
 Install or update the Databricks CLI on macOS, Windows, or Linux using doc-validated methods (Homebrew, WinGet, curl install script, manual download, or user directory install for non-sudo environments). Includes verification and common failure recovery.
 
+## Sandboxed / IDE environments (Cursor, containers)
+
+CLI install commands write to system directories outside the workspace (e.g. `/opt/homebrew/`, `/usr/local/bin/`). In sandboxed environments these writes are blocked.
+
+**Agent behavior**: Do not attempt to run install commands directly. Instead, present the appropriate install command to the user and ask them to run it in their own terminal. After they confirm installation, verify with `databricks -v`.
+
 ## Preconditions (always do first)
 1. Determine OS and shell:
    - macOS/Linux: bash/zsh
@@ -168,3 +174,5 @@ Steps:
 - `databricks: command not found` after installation to `~/.local/bin`:
   - Add to PATH: `export PATH="$HOME/.local/bin:$PATH"`
   - For persistence, add the export command to `~/.bashrc` or `~/.zshrc`.
+- Permission errors in sandboxed IDE (e.g. `/opt/homebrew/Cellar is not writable` in Cursor):
+  - The IDE sandbox blocks writes outside the workspace. Ask the user to run the install command in their own terminal.


### PR DESCRIPTION
## Summary

This PR improves guidance for Databricks CLI installation when the skills are added via the Cursor Marketplace.
Also, it bumps the CLI version required in the skills.

## Screenshots

### Before

<img width="565" height="440" alt="image" src="https://github.com/user-attachments/assets/67bbe775-b5d2-489c-9729-ff947303e8ac" />

### After

IMO the best solution - as the commands need to be run outside of the sandbox env, and sometimes also need sudo:

<img width="536" height="647" alt="image" src="https://github.com/user-attachments/assets/8f3f3631-79b3-48cf-87d6-8326f92db349" />


<img width="541" height="565" alt="image" src="https://github.com/user-attachments/assets/e8ed3791-7554-48cd-855f-86b34e9b49d8" />

<img width="528" height="712" alt="image" src="https://github.com/user-attachments/assets/4429d8bf-a205-4614-a78f-c76f15377277" />

<img width="515" height="705" alt="image" src="https://github.com/user-attachments/assets/38fa1d3f-8469-4f4f-8e85-268a3ed17336" />
