### PR TITLE
document how to use the manifest file

### DIFF
--- a/skills/databricks-apps/references/appkit/overview.md
+++ b/skills/databricks-apps/references/appkit/overview.md
@@ -4,7 +4,7 @@ AppKit is the recommended way to build Databricks Apps - provides type-safe SQL 
 
 ## Workflow
 
-1. **Scaffold**: See parent SKILL.md for `databricks apps init` command
+1. **Scaffold**: Run `databricks apps manifest`, then `databricks apps init` with `--features` and `--set` as in parent SKILL.md (App Manifest and Scaffolding)
 2. **Develop**: `cd <NAME> && npm install && npm run dev`
 3. **Validate**: `databricks apps validate`
 4. **Deploy**: `databricks apps deploy --profile <PROFILE>`


### PR DESCRIPTION
## Summary

<!-- Brief description of the change -->

## Documentation safety checklist

- [ ] Examples use least-privilege permissions (no unnecessary `ALL PRIVILEGES`, admin tokens, or broad scopes)
- [ ] Elevated permissions are explicitly called out where required
- [ ] Sensitive values are obfuscated (placeholder workspace IDs, URLs, no real tokens)
- [ ] No insecure patterns introduced (e.g. disabled TLS verification, hardcoded credentials)
