### PR TITLE
Add granular CODEOWNERS for skill directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 * @lennartkats-db @databricks/eng-apps-devex
-/skills/ @lennartkats-db
+/skills/ @lennartkats-db # net-new skills must be approved by @lennartkats-db
 /skills/databricks/ @lennartkats-db @databricks/eng-apps-devex
 /skills/databricks-apps/ @databricks/eng-apps-devex
+/.github/CODEOWNERS @lennartkats-db @fjakobs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
-* @databricks/eng-apps-devex
+* @lennartkats-db @databricks/eng-apps-devex
+/skills/ @lennartkats-db
+/skills/databricks/ @lennartkats-db @databricks/eng-apps-devex
+/skills/databricks-apps/ @databricks/eng-apps-devex


### PR DESCRIPTION
## Summary
- Add per-path ownership rules so net-new skills require @lennartkats-db approval
- Apps team (`@databricks/eng-apps-devex`) owns `databricks-apps` skill, co-owns `databricks` skill and root files
- CODEOWNERS file itself owned by @lennartkats-db and @fjakobs