### PR TITLE
Improve skills based on trajectory analysis

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,23 +1,23 @@
 {
   "version": "1",
-  "updated_at": "2026-02-13T10:52:05Z",
+  "updated_at": "2026-02-26T11:37:31Z",
   "skills": {
     "databricks": {
       "version": "0.1.0",
-      "updated_at": "2026-02-12T16:39:16Z",
+      "updated_at": "2026-02-26T11:36:38Z",
       "files": [
         "SKILL.md",
         "asset-bundles.md",
+        "data-exploration.md",
         "databricks-cli-auth.md",
         "databricks-cli-install.md"
       ]
     },
     "databricks-apps": {
       "version": "0.1.0",
-      "updated_at": "2026-02-12T16:39:16Z",
+      "updated_at": "2026-02-26T11:36:23Z",
       "files": [
         "SKILL.md",
-        "data-exploration.md",
         "references/appkit/appkit-sdk.md",
         "references/appkit/frontend.md",
         "references/appkit/overview.md",

--- a/skills/databricks-apps/SKILL.md
+++ b/skills/databricks-apps/SKILL.md
@@ -40,6 +40,10 @@ These apply regardless of framework:
 - `tests/smoke.spec.ts` — smoke test (⚠️ MUST UPDATE selectors for your app)
 - `client/src/appKitTypes.d.ts` — auto-generated types (`npm run typegen`)
 
+## Data Discovery
+
+Before writing any SQL, use the parent `databricks` skill for data exploration — search `information_schema` by keyword, then batch `discover-schema` for the tables you need. Do NOT skip this step.
+
 ## Development Workflow (FOLLOW THIS ORDER)
 
 1. Create SQL files in `config/queries/`

--- a/skills/databricks-apps/SKILL.md
+++ b/skills/databricks-apps/SKILL.md
@@ -119,12 +119,8 @@ databricks apps init --name my-app-name --features analytics --set "..." --profi
 
 ### Directory Naming
 
-`databricks apps init` creates directories in kebab-case (e.g., `my-app-name`).
-App names must be lowercase with hyphens only (≤26 chars). If you need a different directory name, rename after scaffolding:
-
-```bash
-mv my-app-name my_app_name
-```
+`databricks apps init` creates directories in kebab-case matching the app name.
+App names must be lowercase with hyphens only (≤26 chars).
 
 ### Other Frameworks
 

--- a/skills/databricks-apps/SKILL.md
+++ b/skills/databricks-apps/SKILL.md
@@ -106,6 +106,26 @@ npx @databricks/appkit docs <path>       # then use paths from the index
 
 **READ [AppKit Overview](references/appkit/overview.md)** for project structure, workflow, and pre-implementation checklist.
 
+### Common Scaffolding Mistakes
+
+```bash
+# ❌ WRONG: name is NOT a positional argument
+databricks apps init --features analytics my-app-name
+# → "unknown command" error
+
+# ✅ CORRECT: use --name flag
+databricks apps init --name my-app-name --features analytics --set "..." --profile <PROFILE>
+```
+
+### Directory Naming
+
+`databricks apps init` creates directories in kebab-case (e.g., `my-app-name`).
+App names must be lowercase with hyphens only (≤26 chars). If you need a different directory name, rename after scaffolding:
+
+```bash
+mv my-app-name my_app_name
+```
+
 ### Other Frameworks
 
 Databricks Apps supports any framework that can run as a web server (Flask, FastAPI, Streamlit, Gradio, etc.). Use standard framework documentation - this skill focuses on AppKit.

--- a/skills/databricks-apps/SKILL.md
+++ b/skills/databricks-apps/SKILL.md
@@ -28,7 +28,7 @@ Build apps that deploy to Databricks Apps platform.
 These apply regardless of framework:
 
 - **Deployment**: `databricks apps deploy --profile <PROFILE>` (⚠️ USER CONSENT REQUIRED)
-- **Validation**: `databricks apps validate` before deploying
+- **Validation**: `databricks apps validate --profile <PROFILE>` before deploying
 - **App name**: Must be ≤26 characters, lowercase letters/numbers/hyphens only (no underscores). dev- prefix adds 4 chars, max 30 total.
 - **Smoke tests**: ALWAYS update `tests/smoke.spec.ts` selectors BEFORE running validation. Default template checks for "Minimal Databricks App" heading and "hello world" text — these WILL fail in your custom app. See [testing guide](references/testing.md).
 - **Authentication**: covered by parent `databricks` skill
@@ -51,7 +51,7 @@ Before writing any SQL, use the parent `databricks` skill for data exploration �
 3. Read `client/src/appKitTypes.d.ts` to see generated types
 4. **THEN** write `App.tsx` using the generated types
 5. Update `tests/smoke.spec.ts` selectors
-6. Run `databricks apps validate`
+6. Run `databricks apps validate --profile <PROFILE>`
 
 **DO NOT** write UI code before running typegen — types won't exist and you'll waste time on compilation errors.
 
@@ -99,6 +99,7 @@ npx @databricks/appkit docs <path>       # then use paths from the index
      --set <plugin1>.<resourceKey>.<field>=<value> \
      --set <plugin2>.<resourceKey>.<field>=<value> \
      --description "<DESC>" --run none --profile <PROFILE>
+   # --run none: skip auto-run after scaffolding (review code first)
    # With custom template:
    databricks apps init --template <GIT_URL> --name <NAME> --features ... --set ... --profile <PROFILE>
    ```

--- a/skills/databricks-apps/references/appkit/frontend.md
+++ b/skills/databricks-apps/references/appkit/frontend.md
@@ -85,7 +85,7 @@ DataTable fetches data automatically — don't pass `data` or `columns` props.
 | `BarChart` | `queryKey`, `parameters`, `xKey`, `yKey`, `colors`, `height` | Categorical comparisons |
 | `LineChart` | `queryKey`, `parameters`, `xKey`, `yKey`, `colors` | Time series, trends |
 | `AreaChart` | `queryKey`, `parameters`, `xKey`, `yKey` | Cumulative/stacked trends |
-| `PieChart` | `queryKey`, `parameters`, `nameKey`, `valueKey` | Part-of-whole |
+| `PieChart` | `queryKey`, `parameters`, `xKey`, `yKey`, `innerRadius`, `showLabels` | Part-of-whole |
 | `DataTable` | `queryKey`, `parameters`, `transform` | Tabular data display |
 
 ### UI Components (`@databricks/appkit-ui/react`)

--- a/skills/databricks-apps/references/appkit/frontend.md
+++ b/skills/databricks-apps/references/appkit/frontend.md
@@ -74,6 +74,35 @@ DataTable fetches data automatically — don't pass `data` or `columns` props.
 />
 ```
 
+## Available Components (Quick Reference)
+
+**For full prop details**: `npx @databricks/appkit docs` → navigate to `./docs/docs/api/appkit-ui/data/` for charts/tables, `./docs/docs/api/appkit-ui/ui/` for UI components.
+
+### Data Components (`@databricks/appkit-ui/react`)
+
+| Component | Key Props | Use For |
+|-----------|-----------|---------|
+| `BarChart` | `queryKey`, `parameters`, `xKey`, `yKey`, `colors`, `height` | Categorical comparisons |
+| `LineChart` | `queryKey`, `parameters`, `xKey`, `yKey`, `colors` | Time series, trends |
+| `AreaChart` | `queryKey`, `parameters`, `xKey`, `yKey` | Cumulative/stacked trends |
+| `PieChart` | `queryKey`, `parameters`, `nameKey`, `valueKey` | Part-of-whole |
+| `DataTable` | `queryKey`, `parameters`, `transform` | Tabular data display |
+
+### UI Components (`@databricks/appkit-ui/react`)
+
+| Component | Common Props |
+|-----------|-------------|
+| `Card`, `CardHeader`, `CardTitle`, `CardContent` | Standard container |
+| `Badge` | `variant`: "default" \| "secondary" \| "destructive" \| "outline" |
+| `Button` | `variant`, `size`, `onClick` |
+| `Input` | `placeholder`, `value`, `onChange` |
+| `Select`, `SelectTrigger`, `SelectContent`, `SelectItem` | Dropdown; `SelectItem` value cannot be "" |
+| `Skeleton` | `className` — use for loading states |
+| `Separator` | Visual divider |
+| `Tabs`, `TabsList`, `TabsTrigger`, `TabsContent` | Tabbed interface |
+
+All data components **require `parameters={{}}`** even when the query has no params.
+
 ## Layout Structure
 
 ```tsx

--- a/skills/databricks-apps/references/appkit/overview.md
+++ b/skills/databricks-apps/references/appkit/overview.md
@@ -11,18 +11,9 @@ AppKit is the recommended way to build Databricks Apps - provides type-safe SQL 
 
 ## Data Discovery (Before Writing SQL)
 
-```bash
-# 1. get warehouse id
-databricks experimental aitools tools get-default-warehouse --profile <PROFILE>
+**Use the parent `databricks` skill for all data discovery.** See [Data Exploration](../../../databricks/data-exploration.md) for full details including keyword search, schema discovery, and query execution.
 
-# 2. explore table structure
-databricks experimental aitools tools discover-schema catalog.schema.table --profile <PROFILE>
-
-# 3. test query
-databricks experimental aitools tools query "SELECT * FROM catalog.schema.table LIMIT 5" --profile <PROFILE>
-```
-
-Do NOT manually iterate through `catalogs list` → `schemas list` → `tables list`.
+Do NOT manually iterate through `catalogs list` → `schemas list` → `tables list` — use `information_schema` keyword search instead (documented in the data exploration guide).
 
 ## Pre-Implementation Checklist
 
@@ -40,10 +31,12 @@ Before writing App.tsx, complete these steps:
 
 Before running `databricks apps validate`, complete these steps:
 
-1. ✅ Update `tests/smoke.spec.ts` heading selector to match your app title
-2. ✅ Update or remove the 'hello world' text assertion
-3. ✅ Verify `npm run typegen` has been run after all SQL files are finalized
-4. ✅ Ensure all numeric SQL values use `Number()` conversion in display code
+1. ✅ Run `npx tsc --noEmit` to catch TypeScript errors early
+2. ✅ Run `npm run lint` to catch unused imports/variables
+3. ✅ Update `tests/smoke.spec.ts` heading selector to match your app title
+4. ✅ Update or remove the 'hello world' text assertion
+5. ✅ Verify `npm run typegen` has been run after all SQL files are finalized
+6. ✅ Ensure all numeric SQL values use `Number()` conversion in display code
 
 ## Project Structure
 
@@ -101,14 +94,16 @@ import { BarChart } from '@databricks/appkit-ui/react';
 
 **Always use AppKit docs as the source of truth for API details.** Run `npx @databricks/appkit docs` (no args) to see the full index, then navigate to specific pages. Do not guess paths.
 
-## References - READ BEFORE Writing Code
+## References — Read As Needed (NOT all upfront)
 
-| Before doing... | READ |
-|-----------------|------|
-| Creating SQL files | [SQL Queries](sql-queries.md) - parameterization, sql.* helpers |
-| Using `useAnalyticsQuery` | [AppKit SDK](appkit-sdk.md) - memoization, conditional queries |
-| Adding charts/tables | [Frontend](frontend.md) - anti-patterns and gotchas |
-| Adding API endpoints | [tRPC](trpc.md) - mutations, Databricks API calls |
+| When you're about to... | Read THIS |
+|-------------------------|-----------|
+| Write SQL files | [SQL Queries](sql-queries.md) — parameterization, dialect, sql.* helpers |
+| Use `useAnalyticsQuery` | [AppKit SDK](appkit-sdk.md) — memoization, conditional queries |
+| Add chart/table components | [Frontend](frontend.md) — component quick reference, anti-patterns |
+| Add API mutation endpoints | [tRPC](trpc.md) — only if you need server-side logic |
+
+**Do NOT read all docs upfront.** Read this overview first, then reference specific docs as you work.
 
 ## Critical Rules
 

--- a/skills/databricks-apps/references/appkit/overview.md
+++ b/skills/databricks-apps/references/appkit/overview.md
@@ -11,9 +11,7 @@ AppKit is the recommended way to build Databricks Apps - provides type-safe SQL 
 
 ## Data Discovery (Before Writing SQL)
 
-**Use the parent `databricks` skill for all data discovery.** See [Data Exploration](../../../databricks/data-exploration.md) for full details including keyword search, schema discovery, and query execution.
-
-Do NOT manually iterate through `catalogs list` → `schemas list` → `tables list` — use `information_schema` keyword search instead (documented in the data exploration guide).
+**Use the parent `databricks` skill for data discovery** (table search, schema exploration, query execution).
 
 ## Pre-Implementation Checklist
 
@@ -29,14 +27,12 @@ Before writing App.tsx, complete these steps:
 
 ## Post-Implementation Checklist
 
-Before running `databricks apps validate`, complete these steps:
+Before running `databricks apps validate`:
 
-1. ✅ Run `npx tsc --noEmit` to catch TypeScript errors early
-2. ✅ Run `npm run lint` to catch unused imports/variables
-3. ✅ Update `tests/smoke.spec.ts` heading selector to match your app title
-4. ✅ Update or remove the 'hello world' text assertion
-5. ✅ Verify `npm run typegen` has been run after all SQL files are finalized
-6. ✅ Ensure all numeric SQL values use `Number()` conversion in display code
+1. ✅ Update `tests/smoke.spec.ts` heading selector to match your app title
+2. ✅ Update or remove the 'hello world' text assertion
+3. ✅ Verify `npm run typegen` has been run after all SQL files are finalized
+4. ✅ Ensure all numeric SQL values use `Number()` conversion in display code
 
 ## Project Structure
 
@@ -94,16 +90,14 @@ import { BarChart } from '@databricks/appkit-ui/react';
 
 **Always use AppKit docs as the source of truth for API details.** Run `npx @databricks/appkit docs` (no args) to see the full index, then navigate to specific pages. Do not guess paths.
 
-## References — Read As Needed (NOT all upfront)
+## References
 
-| When you're about to... | Read THIS |
-|-------------------------|-----------|
+| When you're about to... | Read |
+|-------------------------|------|
 | Write SQL files | [SQL Queries](sql-queries.md) — parameterization, dialect, sql.* helpers |
 | Use `useAnalyticsQuery` | [AppKit SDK](appkit-sdk.md) — memoization, conditional queries |
 | Add chart/table components | [Frontend](frontend.md) — component quick reference, anti-patterns |
 | Add API mutation endpoints | [tRPC](trpc.md) — only if you need server-side logic |
-
-**Do NOT read all docs upfront.** Read this overview first, then reference specific docs as you work.
 
 ## Critical Rules
 

--- a/skills/databricks-apps/references/appkit/sql-queries.md
+++ b/skills/databricks-apps/references/appkit/sql-queries.md
@@ -121,6 +121,17 @@ Databricks uses Databricks SQL (based on Spark SQL), NOT PostgreSQL/MySQL. Commo
 
 Always check date ranges before writing date-filtered queries.
 
+## Before Running `npm run typegen`
+
+Verify each SQL file before running typegen:
+
+- [ ] Uses Databricks SQL syntax (NOT PostgreSQL) — check dialect table above
+- [ ] `DATEDIFF` has 3 arguments: `DATEDIFF(DAY, start, end)`
+- [ ] Uses `LOWER(col) LIKE LOWER(pattern)` instead of `ILIKE`
+- [ ] Column aliases in `ORDER BY` match `SELECT` aliases exactly
+- [ ] Date columns are not passed to numeric functions like `ROUND()`
+- [ ] Date range filters use actual data dates (NOT `CURRENT_DATE()` on historical data — check date ranges first)
+
 ## Query Parameterization
 
 SQL queries can accept parameters to make them dynamic and reusable.

--- a/skills/databricks-apps/references/appkit/sql-queries.md
+++ b/skills/databricks-apps/references/appkit/sql-queries.md
@@ -99,7 +99,7 @@ sql.binary(value)      // For BINARY (returns hex string, use UNHEX() in SQL)
 // sql.float()    - use sql.number()
 ```
 
-**For nullable parameters**, use sentinel values or empty strings - see "Optional Parameters" section below.
+**For nullable string parameters**, use sentinel values or empty strings. **For nullable date parameters**, use sentinel dates only (empty strings cause validation errors) — see "Optional Date Parameters" section below.
 
 ## Databricks SQL Dialect
 

--- a/skills/databricks-apps/references/testing.md
+++ b/skills/databricks-apps/references/testing.md
@@ -40,6 +40,8 @@ The template includes a smoke test at `tests/smoke.spec.ts` that verifies the ap
 
 ```typescript
 // tests/smoke.spec.ts - update these selectors:
+// ⚠️ PLAYWRIGHT STRICT MODE: each selector must match exactly ONE element.
+// Use { exact: true }, .first(), or role-based selectors. See "Playwright Strict Mode" below.
 
 // ❌ Template default - will fail after customization
 await expect(page.getByRole('heading', { name: 'Minimal Databricks App' })).toBeVisible();

--- a/skills/databricks-apps/references/testing.md
+++ b/skills/databricks-apps/references/testing.md
@@ -61,15 +61,25 @@ await expect(page.locator('h1').first()).toBeVisible({ timeout: 30000 });  // Or
 
 Playwright uses strict mode by default — selectors matching multiple elements WILL FAIL.
 
+### Selector Priority (use in this order)
+
+1. ✅ `getByRole('heading', { name: 'Your App Title' })` — headings (most reliable)
+2. ✅ `getByRole('button', { name: 'Submit' })` — interactive elements
+3. ✅ `getByText('Unique text', { exact: true })` — exact match for unique strings
+4. ⚠️ `getByText('Common text').first()` — last resort for repeated text
+5. ❌ `getByText('Revenue')` — NEVER without `exact` or `.first()` (strict mode will fail)
+
+**Common mistake**: text like "Revenue" may appear in a heading, a card, AND a description. Always verify your selector targets exactly ONE element.
+
 ```typescript
 // ❌ FAILS if "Revenue" appears in multiple places (heading + card + description)
 await expect(page.getByText('Revenue')).toBeVisible();
 
-// ✅ Use exact matching
-await expect(page.getByText('Revenue', { exact: true })).toBeVisible();
-
 // ✅ Use role-based selectors for headings
 await expect(page.getByRole('heading', { name: 'Revenue Dashboard' })).toBeVisible();
+
+// ✅ Use exact matching
+await expect(page.getByText('Revenue', { exact: true })).toBeVisible();
 
 // ✅ Use .first() as last resort
 await expect(page.getByText('Revenue').first()).toBeVisible();

--- a/skills/databricks/SKILL.md
+++ b/skills/databricks/SKILL.md
@@ -65,7 +65,7 @@ databricks experimental aitools tools query "SELECT * FROM table LIMIT 10" --pro
 databricks experimental aitools tools get-default-warehouse --profile <profile>
 ```
 
-See [Data Exploration](../databricks-apps/data-exploration.md) for details.
+See [Data Exploration](data-exploration.md) for details.
 
 ## Quick Reference
 
@@ -127,12 +127,12 @@ databricks bundle run <resource> -t <target> --profile <profile>
 |------|------------------------|
 | First time setup | [CLI Installation](databricks-cli-install.md) |
 | Auth issues / new workspace | [CLI Authentication](databricks-cli-auth.md) |
-| Exploring tables/schemas | [Data Exploration](../databricks-apps/data-exploration.md) |
+| Exploring tables/schemas | [Data Exploration](data-exploration.md) |
 | Deploying jobs/pipelines | [Asset Bundles](asset-bundles.md) |
 
 ## Reference Guides
 
 - [CLI Installation](databricks-cli-install.md)
 - [CLI Authentication](databricks-cli-auth.md)
-- [Data Exploration](../databricks-apps/data-exploration.md)
+- [Data Exploration](data-exploration.md)
 - [Asset Bundles](asset-bundles.md)

--- a/skills/databricks/asset-bundles.md
+++ b/skills/databricks/asset-bundles.md
@@ -571,5 +571,5 @@ targets:
 
 ## Related Topics
 
-- [Data Exploration](../databricks-apps/data-exploration.md) - Validate data exposed by bundle deployments
+- [Data Exploration](data-exploration.md) - Validate data exposed by bundle deployments
 - Apps - Define app resources (use `databricks-apps` skill for full app development)

--- a/skills/databricks/data-exploration.md
+++ b/skills/databricks/data-exploration.md
@@ -32,7 +32,7 @@ The `databricks experimental aitools tools` command group provides tools for dat
 
 ## Prerequisites
 
-1. **Authenticated Databricks CLI** - see [CLI Authentication Guide](../databricks/databricks-cli-auth.md) for OAuth2 setup and profile configuration
+1. **Authenticated Databricks CLI** - see [CLI Authentication Guide](databricks-cli-auth.md) for OAuth2 setup and profile configuration
 2. **Access to Unity Catalog tables** with appropriate read permissions
 3. **SQL Warehouse** (for query command - auto-detected unless `DATABRICKS_WAREHOUSE_ID` is set)
 
@@ -327,4 +327,4 @@ Both commands support:
 
 ## Related Commands
 
-- **[Asset Bundles](../databricks/asset-bundles.md)** - Deploy SQL, pipeline, and app resources as code
+- **[Asset Bundles](asset-bundles.md)** - Deploy SQL, pipeline, and app resources as code

--- a/skills/databricks/data-exploration.md
+++ b/skills/databricks/data-exploration.md
@@ -2,6 +2,22 @@
 
 Tools for discovering table schemas and executing SQL queries in Databricks.
 
+## Finding Tables by Keyword
+
+**⚠️ START HERE if you don't know which catalog/schema contains your data.**
+
+Use `information_schema` to search for tables by keyword — do NOT manually iterate through `catalogs list` → `schemas list` → `tables list`. Manual enumeration wastes 10+ steps.
+
+```bash
+# Find tables matching a keyword
+databricks experimental aitools tools query \
+  "SELECT table_catalog, table_schema, table_name FROM system.information_schema.tables WHERE table_name LIKE '%keyword%'" \
+  --profile <PROFILE>
+
+# Then discover schema for the tables you found
+databricks experimental aitools tools discover-schema catalog.schema.table1 catalog.schema.table2 --profile <PROFILE>
+```
+
 ## Overview
 
 The `databricks experimental aitools tools` command group provides tools for data discovery and exploration:

--- a/skills/databricks/databricks-cli-auth.md
+++ b/skills/databricks/databricks-cli-auth.md
@@ -506,19 +506,19 @@ For headless containers, use service principal authentication instead.
 
 ```bash
 # List workspaces
-databricks workspace list /
+databricks workspace list / --profile <PROFILE>
 
 # List jobs
-databricks jobs list
+databricks jobs list --profile <PROFILE>
 
 # List clusters
-databricks clusters list
+databricks clusters list --profile <PROFILE>
 
 # Get current user info
-databricks current-user me
+databricks current-user me --profile <PROFILE>
 
 # Test connection
-databricks workspace export /Users/<username> --format SOURCE
+databricks workspace export /Users/<username> --format SOURCE --profile <PROFILE>
 ```
 
 ## References


### PR DESCRIPTION
## Summary

- **Move data-exploration.md to databricks skill** — data discovery is not app-specific. Added `information_schema` keyword search at the top so agents stop manually enumerating catalogs
- **Add component quick-reference table** to frontend.md — agents spent 10-28 steps trying to find chart/table props via docs CLI
- **Simplify references table** in overview.md — removed imperative "READ BEFORE" language
- **Add `apps init` anti-pattern** — name is `--name` flag, not positional arg (verified against CLI source)
- **Add directory naming note** — `apps init` outputs kebab-case
- **Add pre-typegen SQL checklist** — common dialect mistakes (DATEDIFF arity, ILIKE, date ranges)
- **Add smoke test selector priority** — ranked guide to avoid Playwright strict mode violations
- **Slim down overview.md** — data discovery delegates to databricks skill, post-impl checklist only lists manual steps (validate handles tsc/lint)

## Test plan

- [ ] Verify manifest validates: `python3.13 scripts/generate_manifest.py validate`
- [ ] Verify all internal links resolve correctly
- [ ] Run through an AppKit app build to confirm improved flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)