### PR TITLE
Fix placeholder casing, server.ts rename, shared/types removal

### DIFF
--- a/skills/databricks-apps/references/appkit/appkit-sdk.md
+++ b/skills/databricks-apps/references/appkit/appkit-sdk.md
@@ -8,10 +8,10 @@ Template enforces `noUnusedLocals` - remove unused imports immediately or build 
 
 ```typescript
 // ✅ CORRECT - use import type for types
-import type { MyInterface, MyType } from '../../shared/types';
+import type { MyInterface, MyType } from './types';
 
 // ❌ WRONG - will fail compilation
-import { MyInterface, MyType } from '../../shared/types';
+import { MyInterface, MyType } from './types';
 ```
 
 ## Server Setup

--- a/skills/databricks-apps/references/appkit/overview.md
+++ b/skills/databricks-apps/references/appkit/overview.md
@@ -39,7 +39,7 @@ Before running `databricks apps validate`:
 ```
 my-app/
 ├── server/
-│   ├── index.ts              # Backend entry point (AppKit)
+│   ├── server.ts             # Backend entry point (AppKit)
 │   └── .env                  # Optional local dev env vars (do not commit)
 ├── client/
 │   ├── index.html
@@ -59,9 +59,9 @@ my-app/
 | Task | File |
 |------|------|
 | Build UI | `client/src/App.tsx` |
-| Add SQL query | `config/queries/<name>.sql` |
+| Add SQL query | `config/queries/<NAME>.sql` |
 | Add API endpoint | `server/server.ts` (tRPC) |
-| Add shared types | `shared/types.ts` |
+| Add shared helpers (optional) | create `shared/types.ts` or `client/src/lib/formatters.ts` |
 | Fix smoke test | `tests/smoke.spec.ts` |
 
 ## Type Safety

--- a/skills/databricks-apps/references/appkit/sql-queries.md
+++ b/skills/databricks-apps/references/appkit/sql-queries.md
@@ -62,10 +62,21 @@ export const querySchemas = {
 
 **Helper Functions:**
 
-Use the helpers from `shared/types.ts` for consistent formatting:
+Create app-specific helpers for consistent numeric formatting (for example in `client/src/lib/formatters.ts`):
 
 ```typescript
-import { toNumber, formatCurrency, formatPercent } from '../../shared/types';
+// client/src/lib/formatters.ts
+export const toNumber = (value: number | string): number => Number(value);
+export const formatCurrency = (value: number | string): string =>
+  `$${Number(value).toFixed(2)}`;
+export const formatPercent = (value: number | string): string =>
+  `${Number(value).toFixed(1)}%`;
+```
+
+Use them wherever you render query results:
+
+```typescript
+import { toNumber, formatCurrency, formatPercent } from './formatters'; // adjust import path to your file layout
 
 // Convert to number
 const amount = toNumber(row.amount);  // "123.45" → 123.45

--- a/skills/databricks/SKILL.md
+++ b/skills/databricks/SKILL.md
@@ -56,13 +56,13 @@ databricks apps list  # profile not set!
 
 ```bash
 # discover table structure (columns, types, sample data, stats)
-databricks experimental aitools tools discover-schema catalog.schema.table --profile <profile>
+databricks experimental aitools tools discover-schema catalog.schema.table --profile <PROFILE>
 
 # run ad-hoc SQL queries
-databricks experimental aitools tools query "SELECT * FROM table LIMIT 10" --profile <profile>
+databricks experimental aitools tools query "SELECT * FROM table LIMIT 10" --profile <PROFILE>
 
 # find the default warehouse
-databricks experimental aitools tools get-default-warehouse --profile <profile>
+databricks experimental aitools tools get-default-warehouse --profile <PROFILE>
 ```
 
 See [Data Exploration](data-exploration.md) for details.
@@ -73,27 +73,27 @@ See [Data Exploration](data-exploration.md) for details.
 
 ```bash
 # current user
-databricks current-user me --profile <profile>
+databricks current-user me --profile <PROFILE>
 
 # list resources
-databricks apps list --profile <profile>
-databricks jobs list --profile <profile>
-databricks clusters list --profile <profile>
-databricks warehouses list --profile <profile>
-databricks pipelines list --profile <profile>
-databricks serving-endpoints list --profile <profile>
+databricks apps list --profile <PROFILE>
+databricks jobs list --profile <PROFILE>
+databricks clusters list --profile <PROFILE>
+databricks warehouses list --profile <PROFILE>
+databricks pipelines list --profile <PROFILE>
+databricks serving-endpoints list --profile <PROFILE>
 
 # ⚠️ Unity Catalog — POSITIONAL arguments (NOT flags!)
-databricks catalogs list --profile <profile>
+databricks catalogs list --profile <PROFILE>
 
 # ✅ CORRECT: positional args
-databricks schemas list <catalog> --profile <profile>
-databricks tables list <catalog> <schema> --profile <profile>
-databricks tables get <catalog>.<schema>.<table> --profile <profile>
+databricks schemas list <CATALOG> --profile <PROFILE>
+databricks tables list <CATALOG> <SCHEMA> --profile <PROFILE>
+databricks tables get <CATALOG>.<SCHEMA>.<TABLE> --profile <PROFILE>
 
 # ❌ WRONG: these flags/commands DON'T EXIST
-# databricks schemas list --catalog-name <catalog>    ← WILL FAIL
-# databricks tables list --catalog <catalog>           ← WILL FAIL
+# databricks schemas list --catalog-name <CATALOG>    ← WILL FAIL
+# databricks tables list --catalog <CATALOG>           ← WILL FAIL
 # databricks sql-warehouses list                       ← doesn't exist, use `warehouses list`
 # databricks execute-statement                         ← doesn't exist, use `experimental aitools tools query`
 # databricks sql execute                               ← doesn't exist, use `experimental aitools tools query`
@@ -102,15 +102,15 @@ databricks tables get <catalog>.<schema>.<table> --profile <profile>
 # databricks schemas list --help
 
 # get details
-databricks apps get <name> --profile <profile>
-databricks jobs get --job-id <id> --profile <profile>
-databricks clusters get --cluster-id <id> --profile <profile>
+databricks apps get <NAME> --profile <PROFILE>
+databricks jobs get --job-id <ID> --profile <PROFILE>
+databricks clusters get --cluster-id <ID> --profile <PROFILE>
 
 # bundles
-databricks bundle init --profile <profile>
-databricks bundle validate --profile <profile>
-databricks bundle deploy -t <target> --profile <profile>
-databricks bundle run <resource> -t <target> --profile <profile>
+databricks bundle init --profile <PROFILE>
+databricks bundle validate --profile <PROFILE>
+databricks bundle deploy -t <TARGET> --profile <PROFILE>
+databricks bundle run <RESOURCE> -t <TARGET> --profile <PROFILE>
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
Cherry-picked the still-relevant fixes from #13 (now closed due to conflicts with main's manifest-based scaffold flow):

- **Placeholder casing**: Normalize `<profile>` → `<PROFILE>`, `<catalog>` → `<CATALOG>`, etc. in `databricks/SKILL.md` for consistency
- **`index.ts` → `server.ts`**: Fix backend entry point filename in `overview.md` to match actual AppKit template
- **`shared/types.ts` removal**: Replace references to non-existent `shared/types.ts` with inline formatter helpers in `sql-queries.md`, `appkit-sdk.md`, and `overview.md`

## Test plan
- [x] Verify no remaining lowercase placeholders in `databricks/SKILL.md`
- [x] Verify `server.ts` reference in project structure
- [x] Verify `shared/types.ts` imports replaced with local formatter pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)