### PR TITLE
Add skills key to plugin.json for marketplace discovery

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,5 +2,10 @@
   "name": "databricks-skills",
   "description": "Databricks skills for CLI, Apps, Unity Catalog, Model Serving, Asset Bundles, and more.",
   "version": "0.1.0",
-  "author": "Databricks"
+  "author": {
+    "name": "Databricks"
+  },
+  "repository": "https://github.com/databricks/databricks-agent-skills",
+  "keywords": ["databricks", "cli", "apps", "unity-catalog", "model-serving", "asset-bundles", "external"],
+  "skills": "./skills/"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,6 +6,6 @@
     "name": "Databricks"
   },
   "repository": "https://github.com/databricks/databricks-agent-skills",
-  "keywords": ["databricks", "cli", "apps", "unity-catalog", "model-serving", "asset-bundles", "external"],
+  "keywords": ["databricks", "cli", "apps", "etl", "data-engineering", "spark", "data-pipelines", "unity-catalog", "model-serving", "asset-bundles"],
   "skills": "./skills/"
 }


### PR DESCRIPTION
## Summary

- Adds `"skills": "./skills/"` to `.claude-plugin/plugin.json` — required for Claude Code plugin marketplaces to discover and index skill definitions
- Normalizes `author` from a plain string (`"Databricks"`) to the standard object format (`{"name": "Databricks"}`)
- Adds `repository` and `keywords` metadata for richer marketplace listings

## Why

Claude Code plugin marketplaces use the `skills` key in `plugin.json` to locate skill definitions. Without it, catalog generators skip the plugin entirely — meaning the two skill sets (`databricks` and `databricks-apps`) aren't discoverable through any marketplace that indexes this repo.

The `author` field as a plain string can also cause parsing issues in marketplaces that expect the standard object format.

## Test plan

- [ ] Verify `claude plugin marketplace add` still works with the updated `plugin.json`
- [ ] Confirm marketplace catalog generators can now discover skills in `./skills/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)