### PR TITLE
Update AppKit documentation commands, UI components and type generation reference

### DIFF
--- a/skills/databricks-apps/SKILL.md
+++ b/skills/databricks-apps/SKILL.md
@@ -72,11 +72,14 @@ TypeScript/React framework with type-safe SQL queries and built-in components.
 **Official Documentation** — the source of truth for all API details:
 
 ```bash
-npx @databricks/appkit docs              # ← ALWAYS start here to see available pages
-npx @databricks/appkit docs <path>       # then use paths from the index
+npx @databricks/appkit docs                              # ← ALWAYS start here to see available pages
+npx @databricks/appkit docs <query>                      # view a section by name or doc path
+npx @databricks/appkit docs --full                       # full index with all API entries
+npx @databricks/appkit docs "appkit-ui API reference"    # example: section by name
+npx @databricks/appkit docs ./docs/plugins/analytics.md  # example: specific doc file
 ```
 
-**DO NOT guess doc paths.** Run without args first, pick from the index. Docs are the authority on component props, hook signatures, and server APIs — skill files only cover anti-patterns and gotchas.
+**DO NOT guess doc paths.** Run without args first, pick from the index. The `<query>` argument accepts both section names (from the index) and file paths. Docs are the authority on component props, hook signatures, and server APIs — skill files only cover anti-patterns and gotchas.
 
 **App Manifest and Scaffolding**
 

--- a/skills/databricks-apps/references/appkit/appkit-sdk.md
+++ b/skills/databricks-apps/references/appkit/appkit-sdk.md
@@ -16,11 +16,11 @@ import { MyInterface, MyType } from './types';
 
 ## Server Setup
 
-For server configuration, see: `npx @databricks/appkit docs ./docs/docs/plugins.md`
+For server configuration, see: `npx @databricks/appkit docs ./docs/plugins.md`
 
 ## useAnalyticsQuery Hook
 
-**ONLY use when displaying data in a custom way that isn't a chart or table.** For charts/tables, pass `queryKey` directly to the component — don't double-fetch.
+**ONLY use when displaying data in a custom way that isn't a chart or table.** For charts/tables, pass `queryKey` directly to the component — don't double-fetch. Charts also accept a `format` option (`"json"` | `"arrow"` | `"auto"`, default `"auto"`) to control the data transfer format.
 
 Use cases:
 - Custom HTML layouts (cards, lists, grids)

--- a/skills/databricks-apps/references/appkit/overview.md
+++ b/skills/databricks-apps/references/appkit/overview.md
@@ -66,7 +66,7 @@ my-app/
 
 ## Type Safety
 
-For type generation details, see: `npx @databricks/appkit docs ./docs/docs/development/type-generation.md`
+For type generation details, see: `npx @databricks/appkit docs ./docs/development/type-generation.md`
 
 **Quick workflow:**
 1. Add/modify SQL in `config/queries/`
@@ -83,12 +83,26 @@ SELECT category, COUNT(*) as count FROM my_table GROUP BY category
 **Step 2**: Use component (types auto-generated!)
 ```typescript
 import { BarChart } from '@databricks/appkit-ui/react';
+// Query mode: fetches data automatically
 <BarChart queryKey="my_data" parameters={{}} />
+
+// Data mode: pass static data directly (no queryKey/parameters needed)
+<BarChart data={myData} xKey="category" yKey="count" />
 ```
 
 ## AppKit Official Documentation
 
-**Always use AppKit docs as the source of truth for API details.** Run `npx @databricks/appkit docs` (no args) to see the full index, then navigate to specific pages. Do not guess paths.
+**Always use AppKit docs as the source of truth for API details.**
+
+```bash
+npx @databricks/appkit docs                              # index (start here)
+npx @databricks/appkit docs <query>                      # section by name or doc path
+npx @databricks/appkit docs --full                       # full index with all API entries
+npx @databricks/appkit docs "appkit-ui API reference"    # example: section by name
+npx @databricks/appkit docs ./docs/plugins/analytics.md  # example: specific doc file
+```
+
+Do not guess paths — run without args first, then pick from the index.
 
 ## References
 
@@ -104,8 +118,9 @@ import { BarChart } from '@databricks/appkit-ui/react';
 1. **SQL for data retrieval**: Use `config/queries/` + visualization components. Never tRPC for SELECT.
 2. **Numeric types**: SQL numbers may return as strings. Always convert: `Number(row.amount)`
 3. **Type imports**: Use `import type { ... }` (verbatimModuleSyntax enabled).
-4. **Charts are ECharts**: No Recharts children - use props (`xKey`, `yKey`, `colors`).
-5. **Conditional queries**: Use `autoStart: false` option or conditional rendering to control query execution.
+4. **Charts are ECharts**: No Recharts children — use props (`xKey`, `yKey`, `colors`). `xKey`/`yKey` auto-detect from schema if omitted.
+5. **Two data modes**: Charts/tables support query mode (`queryKey` + `parameters`) and data mode (static `data` prop).
+6. **Conditional queries**: Use `autoStart: false` option or conditional rendering to control query execution.
 
 ## Decision Tree
 

--- a/skills/databricks-apps/references/appkit/overview.md
+++ b/skills/databricks-apps/references/appkit/overview.md
@@ -70,7 +70,7 @@ For type generation details, see: `npx @databricks/appkit docs ./docs/developmen
 
 **Quick workflow:**
 1. Add/modify SQL in `config/queries/`
-2. Run `npm run typegen`
+2. Types auto-generate during dev via the Vite plugin (or run `npm run typegen` manually)
 3. Types appear in `client/src/appKitTypes.d.ts`
 
 ## Adding Visualizations
@@ -95,11 +95,8 @@ import { BarChart } from '@databricks/appkit-ui/react';
 **Always use AppKit docs as the source of truth for API details.**
 
 ```bash
-npx @databricks/appkit docs                              # index (start here)
-npx @databricks/appkit docs <query>                      # section by name or doc path
-npx @databricks/appkit docs --full                       # full index with all API entries
-npx @databricks/appkit docs "appkit-ui API reference"    # example: section by name
-npx @databricks/appkit docs ./docs/plugins/analytics.md  # example: specific doc file
+npx @databricks/appkit docs                              # show the docs index (start here)
+npx @databricks/appkit docs <query>                      # look up a section by name or doc path
 ```
 
 Do not guess paths — run without args first, then pick from the index.

--- a/skills/databricks-apps/references/appkit/sql-queries.md
+++ b/skills/databricks-apps/references/appkit/sql-queries.md
@@ -10,9 +10,14 @@
 
 ## Type Generation
 
-For full type generation details, see: `npx @databricks/appkit docs ./docs/docs/development/type-generation.md`
+For full type generation details, see: `npx @databricks/appkit docs ./docs/development/type-generation.md`
 
-**Quick workflow:** Add SQL files → Run `npm run typegen` → Types appear in `client/src/appKitTypes.d.ts`
+**Type generation methods:**
+- **Vite plugin** (recommended): Add `appKitTypesPlugin()` to `client/vite.config.ts` — auto-regenerates types during dev when SQL files change.
+- **CLI**: `npx @databricks/appkit generate-types [rootDir] [outFile] [warehouseId]`
+- **npm script**: `npm run typegen` (if configured in scaffolded project)
+
+**Quick workflow:** Add SQL files → Types auto-generate in dev (or run `npm run typegen`) → Types appear in `client/src/appKitTypes.d.ts`
 
 ## Query Schemas (Optional)
 
@@ -90,7 +95,7 @@ const percent = formatPercent(row.rate);  // "85.5" → "85.5%"
 
 ## Available sql.* Helpers
 
-**Full API reference**: `npx @databricks/appkit docs ./docs/docs/api/appkit/Variable.sql.md` — always check this for the latest available helpers.
+**Full API reference**: `npx @databricks/appkit docs ./docs/api/appkit/Variable.sql.md` — always check this for the latest available helpers.
 
 ```typescript
 import { sql } from "@databricks/appkit-ui/js";

--- a/skills/databricks-apps/references/appkit/sql-queries.md
+++ b/skills/databricks-apps/references/appkit/sql-queries.md
@@ -12,12 +12,9 @@
 
 For full type generation details, see: `npx @databricks/appkit docs ./docs/development/type-generation.md`
 
-**Type generation methods:**
-- **Vite plugin** (recommended): Add `appKitTypesPlugin()` to `client/vite.config.ts` — auto-regenerates types during dev when SQL files change.
-- **CLI**: `npx @databricks/appkit generate-types [rootDir] [outFile] [warehouseId]`
-- **npm script**: `npm run typegen` (if configured in scaffolded project)
+**Type generation:** Types are auto-regenerated during dev whenever SQL files change.
 
-**Quick workflow:** Add SQL files → Types auto-generate in dev (or run `npm run typegen`) → Types appear in `client/src/appKitTypes.d.ts`
+**Quick workflow:** Add SQL files → Types auto-generate during dev → Types appear in `client/src/appKitTypes.d.ts`
 
 ## Query Schemas (Optional)
 


### PR DESCRIPTION
## Summary

This PR updates UI components, type generation for AppKit, as well as how to access the embedded docs with `npx @databricks/appkit` for upcoming AppKit version.

Related PR: https://github.com/databricks/appkit/pull/142


⚠️ **NOTE:** This PR shouldn't be merged before https://github.com/databricks/appkit/pull/142 (as it needs to be merged and automatically released)
