### PR TITLE
Add scaffolding guidance to jobs/pipelines SKILL.md files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,6 @@ Skills for AI coding assistants (Claude Code, Cursor, etc.) that provide Databri
 
 ## Installation
 
-### 1. Install the Databricks CLI
-
-If you don't have the Databricks CLI installed (>= v0.288.0), install it first:
-
-- **macOS**: `brew tap databricks/tap && brew install databricks`
-- **Linux**: `curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh`
-- **Windows**: `winget install Databricks.DatabricksCLI`
-
-Verify: `databricks -v`
-
-### 2. Install skills
-
 **For Claude Code:**
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ Skills for AI coding assistants (Claude Code, Cursor, etc.) that provide Databri
 
 ## Installation
 
+### 1. Install the Databricks CLI
+
+If you don't have the Databricks CLI installed (>= v0.288.0), install it first:
+
+- **macOS**: `brew tap databricks/tap && brew install databricks`
+- **Linux**: `curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh`
+- **Windows**: `winget install Databricks.DatabricksCLI`
+
+Verify: `databricks -v`
+
+### 2. Install skills
+
 **For Claude Code:**
 
 ```bash

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
   "version": "1",
-  "updated_at": "2026-03-03T09:35:19Z",
+  "updated_at": "2026-03-06T13:43:58Z",
   "skills": {
     "databricks": {
       "version": "0.1.0",
-      "updated_at": "2026-03-03T09:10:44Z",
+      "updated_at": "2026-03-06T13:43:51Z",
       "files": [
         "SKILL.md",
         "asset-bundles.md",
@@ -15,7 +15,7 @@
     },
     "databricks-apps": {
       "version": "0.1.0",
-      "updated_at": "2026-03-03T09:10:44Z",
+      "updated_at": "2026-03-06T09:31:02Z",
       "files": [
         "SKILL.md",
         "references/appkit/appkit-sdk.md",
@@ -28,15 +28,14 @@
     },
     "databricks-jobs": {
       "version": "0.1.0",
-      "updated_at": "2026-02-28T11:03:28Z",
+      "updated_at": "2026-03-06T13:43:51Z",
       "files": [
         "SKILL.md"
       ]
     },
     "databricks-pipelines": {
       "version": "0.1.0",
-      "updated_at": "2026-03-06T00:00:00Z",
-      "base_revision": "9fe40569f56b",
+      "updated_at": "2026-03-06T13:43:51Z",
       "files": [
         "SKILL.md",
         "references/auto-cdc-python.md",
@@ -48,6 +47,8 @@
         "references/expectations-python.md",
         "references/expectations-sql.md",
         "references/expectations.md",
+        "references/foreach-batch-sink-python.md",
+        "references/foreach-batch-sink.md",
         "references/materialized-view-python.md",
         "references/materialized-view-sql.md",
         "references/materialized-view.md",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "updated_at": "2026-03-06T13:43:58Z",
+  "updated_at": "2026-03-06T15:58:15Z",
   "skills": {
     "databricks": {
       "version": "0.1.0",
@@ -47,8 +47,6 @@
         "references/expectations-python.md",
         "references/expectations-sql.md",
         "references/expectations.md",
-        "references/foreach-batch-sink-python.md",
-        "references/foreach-batch-sink.md",
         "references/materialized-view-python.md",
         "references/materialized-view-sql.md",
         "references/materialized-view.md",

--- a/manifest.json
+++ b/manifest.json
@@ -35,7 +35,8 @@
     },
     "databricks-pipelines": {
       "version": "0.1.0",
-      "updated_at": "2026-03-03T09:35:13Z",
+      "updated_at": "2026-03-06T00:00:00Z",
+      "base_revision": "9fe40569f56b",
       "files": [
         "SKILL.md",
         "references/auto-cdc-python.md",

--- a/skills/databricks-jobs/SKILL.md
+++ b/skills/databricks-jobs/SKILL.md
@@ -31,6 +31,15 @@ After scaffolding, create `CLAUDE.md` and `AGENTS.md` in the project directory. 
 
 This project uses Databricks Asset Bundles for deployment.
 
+## Prerequisites
+
+Install the Databricks CLI (>= v0.288.0) if not already installed:
+- macOS: `brew tap databricks/tap && brew install databricks`
+- Linux: `curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh`
+- Windows: `winget install Databricks.DatabricksCLI`
+
+Verify: `databricks -v`
+
 ## For AI Agents
 
 Read the `databricks` skill for CLI basics, authentication, and deployment workflow.

--- a/skills/databricks-jobs/SKILL.md
+++ b/skills/databricks-jobs/SKILL.md
@@ -13,6 +13,32 @@ parent: databricks
 
 Lakeflow Jobs are scheduled workflows that run notebooks, Python scripts, SQL queries, and other tasks on Databricks.
 
+## Scaffolding a New Job Project
+
+Use `databricks bundle init` with a config file to scaffold non-interactively:
+
+```bash
+databricks bundle init default-python --config-file <(echo '{"project_name": "my_job", "include_job": "yes", "include_pipeline": "no", "include_python": "yes", "personal_schemas": "yes"}') --profile <PROFILE>
+```
+
+- `project_name`: letters, numbers, underscores only
+- `default_catalog`: optional, defaults to workspace default catalog
+
+After scaffolding, create `CLAUDE.md` and `AGENTS.md` in the project directory. These files are essential to provide agents with guidance on how to work with the project. Use this content:
+
+```
+# Databricks Asset Bundles Project
+
+This project uses Databricks Asset Bundles for deployment.
+
+## For AI Agents
+
+Read the `databricks` skill for CLI basics, authentication, and deployment workflow.
+Read the `databricks-jobs` skill for job-specific guidance.
+
+If skills are not available, install them: `databricks experimental aitools skills install`
+```
+
 ## Project Structure
 
 ```

--- a/skills/databricks-jobs/SKILL.md
+++ b/skills/databricks-jobs/SKILL.md
@@ -15,14 +15,13 @@ Lakeflow Jobs are scheduled workflows that run notebooks, Python scripts, SQL qu
 
 ## Scaffolding a New Job Project
 
-Use `databricks bundle init` with a config file to scaffold non-interactively:
+Use `databricks bundle init` with a config file to scaffold non-interactively. This creates a project in the `<project_name>/` directory:
 
 ```bash
-databricks bundle init default-python --config-file <(echo '{"project_name": "my_job", "include_job": "yes", "include_pipeline": "no", "include_python": "yes", "personal_schemas": "yes"}') --profile <PROFILE>
+databricks bundle init default-python --config-file <(echo '{"project_name": "my_job", "include_job": "yes", "include_pipeline": "no", "include_python": "yes", "serverless": "yes"}') --profile <PROFILE> < /dev/null
 ```
 
 - `project_name`: letters, numbers, underscores only
-- `default_catalog`: optional, defaults to workspace default catalog
 
 After scaffolding, create `CLAUDE.md` and `AGENTS.md` in the project directory. These files are essential to provide agents with guidance on how to work with the project. Use this content:
 

--- a/skills/databricks-jobs/SKILL.md
+++ b/skills/databricks-jobs/SKILL.md
@@ -13,19 +13,6 @@ parent: databricks
 
 Lakeflow Jobs are scheduled workflows that run notebooks, Python scripts, SQL queries, and other tasks on Databricks.
 
-## Scaffolding a New Job Project
-
-When starting a new job project, use the CLI to scaffold:
-
-```bash
-databricks experimental aitools tools init-template job --name my_job --profile <PROFILE>
-databricks experimental aitools tools init-template job --name my_job --catalog my_catalog --profile <PROFILE>
-```
-
-- `--name` is required
-- `--catalog` defaults to workspace default catalog
-- Names: letters, numbers, underscores only
-
 ## Project Structure
 
 ```

--- a/skills/databricks-jobs/SKILL.md
+++ b/skills/databricks-jobs/SKILL.md
@@ -13,6 +13,19 @@ parent: databricks
 
 Lakeflow Jobs are scheduled workflows that run notebooks, Python scripts, SQL queries, and other tasks on Databricks.
 
+## Scaffolding a New Job Project
+
+When starting a new job project, use the CLI to scaffold:
+
+```bash
+databricks experimental aitools tools init-template job --name my_job --profile <PROFILE>
+databricks experimental aitools tools init-template job --name my_job --catalog my_catalog --profile <PROFILE>
+```
+
+- `--name` is required
+- `--catalog` defaults to workspace default catalog
+- Names: letters, numbers, underscores only
+
 ## Project Structure
 
 ```

--- a/skills/databricks-pipelines/SKILL.md
+++ b/skills/databricks-pipelines/SKILL.md
@@ -13,23 +13,6 @@ parent: databricks
 
 Lakeflow Spark Declarative Pipelines (formerly Delta Live Tables / DLT) is a framework for building batch and streaming data pipelines.
 
-## Scaffolding a New Pipeline Project
-
-When starting a new pipeline project, use the CLI to scaffold:
-
-```bash
-databricks experimental aitools tools init-template pipeline --name my_pipeline --language python --profile <PROFILE>
-databricks experimental aitools tools init-template pipeline --name my_pipeline --language sql --profile <PROFILE>
-databricks experimental aitools tools init-template pipeline --name my_pipeline --language sql --catalog my_catalog --profile <PROFILE>
-```
-
-- `--name` and `--language` are required
-- `--language`: `python` or `sql`. Ask the user which they prefer:
-  - SQL: Recommended for straightforward transformations (filters, joins, aggregations)
-  - Python: Recommended for complex logic (custom UDFs, ML, advanced processing)
-- `--catalog` defaults to workspace default catalog
-- Names: letters, numbers, underscores only
-
 ## Pipeline Structure
 
 - Follow the medallion architecture pattern (Bronze → Silver → Gold) unless the user specifies otherwise

--- a/skills/databricks-pipelines/SKILL.md
+++ b/skills/databricks-pipelines/SKILL.md
@@ -106,3 +106,17 @@ When a user asks to change a dataset type:
 2. **Deploy**: `databricks bundle deploy -t dev --profile <profile>`
 3. **Run pipeline**: `databricks bundle run <pipeline_name> -t dev --profile <profile>`
 4. **Check status**: `databricks pipelines get --pipeline-id <id> --profile <profile>`
+
+## Pipeline API Reference
+
+Detailed reference guides for each pipeline API. **Read the relevant guide before writing pipeline code.**
+
+- [Write Spark Declarative Pipelines](references/write-spark-declarative-pipelines.md) — Core syntax and rules ([Python](references/python-basics.md), [SQL](references/sql-basics.md))
+- [Streaming Tables](references/streaming-table.md) — Continuous data stream processing ([Python](references/streaming-table-python.md), [SQL](references/streaming-table-sql.md))
+- [Materialized Views](references/materialized-view.md) — Physically stored query results with incremental refresh ([Python](references/materialized-view-python.md), [SQL](references/materialized-view-sql.md))
+- [Views](references/view.md) — Reusable query logic published to Unity Catalog ([SQL](references/view-sql.md))
+- [Temporary Views](references/temporary-view.md) — Pipeline-private views ([Python](references/temporary-view-python.md), [SQL](references/temporary-view-sql.md))
+- [Auto Loader](references/auto-loader.md) — Incrementally ingest files from cloud storage ([Python](references/auto-loader-python.md), [SQL](references/auto-loader-sql.md))
+- [Auto CDC](references/auto-cdc.md) — Process Change Data Capture feeds, SCD Type 1 & 2 ([Python](references/auto-cdc-python.md), [SQL](references/auto-cdc-sql.md))
+- [Expectations](references/expectations.md) — Define and enforce data quality constraints ([Python](references/expectations-python.md), [SQL](references/expectations-sql.md))
+- [Sinks](references/sink.md) — Write to Kafka, Event Hubs, external Delta tables ([Python](references/sink-python.md))

--- a/skills/databricks-pipelines/SKILL.md
+++ b/skills/databricks-pipelines/SKILL.md
@@ -34,6 +34,15 @@ After scaffolding, create `CLAUDE.md` and `AGENTS.md` in the project directory. 
 
 This project uses Databricks Asset Bundles for deployment.
 
+## Prerequisites
+
+Install the Databricks CLI (>= v0.288.0) if not already installed:
+- macOS: `brew tap databricks/tap && brew install databricks`
+- Linux: `curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh`
+- Windows: `winget install Databricks.DatabricksCLI`
+
+Verify: `databricks -v`
+
 ## For AI Agents
 
 Read the `databricks` skill for CLI basics, authentication, and deployment workflow.

--- a/skills/databricks-pipelines/SKILL.md
+++ b/skills/databricks-pipelines/SKILL.md
@@ -13,6 +13,35 @@ parent: databricks
 
 Lakeflow Spark Declarative Pipelines (formerly Delta Live Tables / DLT) is a framework for building batch and streaming data pipelines.
 
+## Scaffolding a New Pipeline Project
+
+Use `databricks bundle init` with a config file to scaffold non-interactively:
+
+```bash
+databricks bundle init lakeflow-pipelines --config-file <(echo '{"project_name": "my_pipeline", "language": "python", "personal_schemas": "yes"}') --profile <PROFILE>
+```
+
+- `project_name`: letters, numbers, underscores only
+- `language`: `python` or `sql`. Ask the user which they prefer:
+  - SQL: Recommended for straightforward transformations (filters, joins, aggregations)
+  - Python: Recommended for complex logic (custom UDFs, ML, advanced processing)
+- `default_catalog`: optional, defaults to workspace default catalog
+
+After scaffolding, create `CLAUDE.md` and `AGENTS.md` in the project directory. These files are essential to provide agents with guidance on how to work with the project. Use this content:
+
+```
+# Databricks Asset Bundles Project
+
+This project uses Databricks Asset Bundles for deployment.
+
+## For AI Agents
+
+Read the `databricks` skill for CLI basics, authentication, and deployment workflow.
+Read the `databricks-pipelines` skill for pipeline-specific guidance.
+
+If skills are not available, install them: `databricks experimental aitools skills install`
+```
+
 ## Pipeline Structure
 
 - Follow the medallion architecture pattern (Bronze → Silver → Gold) unless the user specifies otherwise

--- a/skills/databricks-pipelines/SKILL.md
+++ b/skills/databricks-pipelines/SKILL.md
@@ -87,21 +87,6 @@ resources:
             pipeline_id: ${resources.pipelines.my_pipeline.id}
 ```
 
-## Schema Definition Guidelines
-
-**Start with schema inference by default.** Always begin with automatic schema inference, even when the user requests manual schema definition. Only add explicit schemas when: (1) after successful inference if user requested it (use inferred schema as basis), or (2) when pipeline fails due to missing schema (add minimal required schema only).
-
-## Changing Dataset Types
-
-Changing an existing dataset's type (e.g., streaming table to materialized view, or vice versa) is NOT possible without the user first manually dropping the existing table. Full refresh does NOT help.
-
-When a user asks to change a dataset type:
-
-1. **Explain the limitation clearly**: you MUST explicitly tell the user that changing the type on the same name will cause the pipeline to **FAIL** unless the existing table is manually dropped first. Also state that full refresh does NOT help. Do not skip or soften this warning.
-2. **Rename the dataset by default**: unless the user indicated they already dropped the existing table, create the new dataset with a different name (e.g., append a suffix or use a descriptive new name) so both the old and new datasets can coexist. The old dataset will become inactive once it is no longer defined in code. Do NOT just change the type in-place without renaming — that will fail.
-3. **Update all downstream datasets**: after renaming, update every file that references the old dataset name to use the new name. Also ensure downstream datasets use the correct read semantics for the new type (e.g., `spark.read`/direct reference for materialized view sources, `spark.readStream`/`STREAM()` for streaming table sources). Do NOT change the type of downstream datasets — only update their name references and read method.
-4. **Offer manual drop as a follow-up**: explicitly suggest as a follow-up action that the user can drop the old table themselves and then rename the new dataset back to the original name if they prefer.
-
 ## Running Pipelines
 
 **You must deploy before running.** In local development, code changes only take effect after `databricks bundle deploy`. Always deploy before any run, dry run, or selective refresh.

--- a/skills/databricks-pipelines/SKILL.md
+++ b/skills/databricks-pipelines/SKILL.md
@@ -15,17 +15,16 @@ Lakeflow Spark Declarative Pipelines (formerly Delta Live Tables / DLT) is a fra
 
 ## Scaffolding a New Pipeline Project
 
-Use `databricks bundle init` with a config file to scaffold non-interactively:
+Use `databricks bundle init` with a config file to scaffold non-interactively. This creates a project in the `<project_name>/` directory:
 
 ```bash
-databricks bundle init lakeflow-pipelines --config-file <(echo '{"project_name": "my_pipeline", "language": "python", "personal_schemas": "yes"}') --profile <PROFILE>
+databricks bundle init lakeflow-pipelines --config-file <(echo '{"project_name": "my_pipeline", "language": "python", "serverless": "yes"}') --profile <PROFILE> < /dev/null
 ```
 
 - `project_name`: letters, numbers, underscores only
 - `language`: `python` or `sql`. Ask the user which they prefer:
   - SQL: Recommended for straightforward transformations (filters, joins, aggregations)
   - Python: Recommended for complex logic (custom UDFs, ML, advanced processing)
-- `default_catalog`: optional, defaults to workspace default catalog
 
 After scaffolding, create `CLAUDE.md` and `AGENTS.md` in the project directory. These files are essential to provide agents with guidance on how to work with the project. Use this content:
 

--- a/skills/databricks-pipelines/SKILL.md
+++ b/skills/databricks-pipelines/SKILL.md
@@ -9,11 +9,32 @@ parent: databricks
 
 # Lakeflow Spark Declarative Pipelines Development
 
-**FIRST**: Use the parent `databricks` skill for CLI basics, authentication, profile selection, and data exploration commands.
+**FIRST**: Use the parent `databricks` skill for CLI basics, authentication, profile selection, and data discovery commands.
 
 Lakeflow Spark Declarative Pipelines (formerly Delta Live Tables / DLT) is a framework for building batch and streaming data pipelines.
 
-## Project Structure
+## Scaffolding a New Pipeline Project
+
+When starting a new pipeline project, use the CLI to scaffold:
+
+```bash
+databricks experimental aitools tools init-template pipeline --name my_pipeline --language python --profile <PROFILE>
+databricks experimental aitools tools init-template pipeline --name my_pipeline --language sql --profile <PROFILE>
+databricks experimental aitools tools init-template pipeline --name my_pipeline --language sql --catalog my_catalog --profile <PROFILE>
+```
+
+- `--name` and `--language` are required
+- `--language`: `python` or `sql`. Ask the user which they prefer:
+  - SQL: Recommended for straightforward transformations (filters, joins, aggregations)
+  - Python: Recommended for complex logic (custom UDFs, ML, advanced processing)
+- `--catalog` defaults to workspace default catalog
+- Names: letters, numbers, underscores only
+
+## Pipeline Structure
+
+- Follow the medallion architecture pattern (Bronze → Silver → Gold) unless the user specifies otherwise
+- Use the convention of 1 dataset per file, named after the dataset
+- Place transformation files in a `src/` or `transformations/` folder
 
 ```
 my-pipeline-project/
@@ -26,57 +47,6 @@ my-pipeline-project/
     ├── another_table.py (or .sql)
     └── ...
 ```
-
-By convention, each dataset definition should be in a file named like the dataset, e.g. `src/my_table.py`.
-
-## Adding Transformations
-
-**Python** — Create `.py` files in `src/`:
-
-```python
-from pyspark import pipelines as dp
-
-@dp.table
-def my_table():
-    return spark.read.table("catalog.schema.source")
-```
-
-Note: `from pyspark import pipelines as dp` is the preferred import. `import dlt` also works but is deprecated.
-
-**SQL** — Create `.sql` files in `src/`:
-
-```sql
-CREATE MATERIALIZED VIEW my_view AS
-SELECT * FROM catalog.schema.source
-```
-
-Use `CREATE STREAMING TABLE` for incremental ingestion, `CREATE MATERIALIZED VIEW` for batch transformations.
-
-## Key Concepts
-
-| Concept | Python | SQL | Use Case |
-|---------|--------|-----|----------|
-| Materialized View | `@dp.materialized_view()` | `CREATE MATERIALIZED VIEW` | Batch transformations |
-| Streaming Table | `@dp.table()` (streaming DF) | `CREATE STREAMING TABLE` | Incremental ingestion |
-| Temporary View | `@dp.view()` | `CREATE TEMPORARY VIEW` | Intermediate logic (pipeline-private) |
-| View | — | `CREATE VIEW` | Reusable logic (published to UC) |
-| Auto Loader | `spark.readStream.format("cloudFiles")` | `read_files()` | Ingest from cloud storage |
-| Auto CDC | `dp.create_auto_cdc_flow()` | `AUTO CDC INTO` | Change data capture |
-| Expectations | `@dp.expect()` | `CONSTRAINT ... EXPECT` | Data quality |
-| Sink | `dp.create_sink()` | — | Write to Kafka, Event Hubs, external Delta |
-
-## Critical Rules
-
-### Python
-- Functions MUST return Spark DataFrames — never call `.collect()`, `.count()`, `.toPandas()`, `.save()`, `.saveAsTable()`, `.start()`, `.toTable()`
-- Use `spark.read.table()` / `spark.readStream.table()` to read other datasets
-- Never use `LIVE.` prefix (deprecated)
-
-### SQL
-- Use `CREATE OR REFRESH` syntax
-- Use `STREAM` keyword for streaming reads
-- Use `read_files()` for Auto Loader
-- Never use `LIVE.` prefix or `CREATE LIVE TABLE` (deprecated)
 
 ## Scheduling Pipelines
 
@@ -96,28 +66,31 @@ resources:
             pipeline_id: ${resources.pipelines.my_pipeline.id}
 ```
 
+## Schema Definition Guidelines
+
+**Start with schema inference by default.** Always begin with automatic schema inference, even when the user requests manual schema definition. Only add explicit schemas when: (1) after successful inference if user requested it (use inferred schema as basis), or (2) when pipeline fails due to missing schema (add minimal required schema only).
+
+## Changing Dataset Types
+
+Changing an existing dataset's type (e.g., streaming table to materialized view, or vice versa) is NOT possible without the user first manually dropping the existing table. Full refresh does NOT help.
+
+When a user asks to change a dataset type:
+
+1. **Explain the limitation clearly**: you MUST explicitly tell the user that changing the type on the same name will cause the pipeline to **FAIL** unless the existing table is manually dropped first. Also state that full refresh does NOT help. Do not skip or soften this warning.
+2. **Rename the dataset by default**: unless the user indicated they already dropped the existing table, create the new dataset with a different name (e.g., append a suffix or use a descriptive new name) so both the old and new datasets can coexist. The old dataset will become inactive once it is no longer defined in code. Do NOT just change the type in-place without renaming — that will fail.
+3. **Update all downstream datasets**: after renaming, update every file that references the old dataset name to use the new name. Also ensure downstream datasets use the correct read semantics for the new type (e.g., `spark.read`/direct reference for materialized view sources, `spark.readStream`/`STREAM()` for streaming table sources). Do NOT change the type of downstream datasets — only update their name references and read method.
+4. **Offer manual drop as a follow-up**: explicitly suggest as a follow-up action that the user can drop the old table themselves and then rename the new dataset back to the original name if they prefer.
+
+## Running Pipelines
+
+**You must deploy before running.** In local development, code changes only take effect after `databricks bundle deploy`. Always deploy before any run, dry run, or selective refresh.
+
+- Selective refresh is preferred when you only need to run one table. For selective refresh it is important that dependencies are already materialized.
+- **Full refresh is the most expensive and dangerous option, and can lead to data loss**, so it should be used only when really necessary. Always suggest this as a follow-up that the user explicitly needs to select.
+
 ## Development Workflow
 
 1. **Validate**: `databricks bundle validate --profile <profile>`
 2. **Deploy**: `databricks bundle deploy -t dev --profile <profile>`
 3. **Run pipeline**: `databricks bundle run <pipeline_name> -t dev --profile <profile>`
 4. **Check status**: `databricks pipelines get --pipeline-id <id> --profile <profile>`
-
-## Documentation
-
-- Lakeflow Spark Declarative Pipelines: https://docs.databricks.com/ldp
-- Databricks Asset Bundles: https://docs.databricks.com/dev-tools/bundles/examples
-
-## Pipeline API Reference
-
-Detailed reference guides for each pipeline API:
-
-- **MANDATORY** [Write Spark Declarative Pipelines](references/write-spark-declarative-pipelines.md) - Core syntax and rules ([Python](references/python-basics.md), [SQL](references/sql-basics.md)). **Always read before writing any pipeline code.**
-- [Streaming Tables](references/streaming-table.md) - Continuous data stream processing with exactly-once semantics
-- [Materialized Views](references/materialized-view.md) - Physically stored query results with incremental refresh
-- [Views](references/view.md) - Reusable query logic published to Unity Catalog (SQL only)
-- [Temporary Views](references/temporary-view.md) - Pipeline-private views not published to Unity Catalog
-- [Auto Loader](references/auto-loader.md) - Incrementally ingest files from cloud storage into Delta Lake
-- [Auto CDC](references/auto-cdc.md) - Process Change Data Capture feeds (SCD Type 1 & 2)
-- [Expectations](references/expectations.md) - Define and enforce data quality constraints
-- [Sinks](references/sink.md) - Write to Kafka, Event Hubs, external Delta tables (Python only)


### PR DESCRIPTION
## Summary

- Add `databricks bundle init` scaffolding instructions to SKILL.md files
- Include AGENTS.md/CLAUDE.md creation guidance after scaffolding
- Cleanup the SKILL.md files
- Config params validated against CLI source and tested end-to-end