### PR TITLE
Add camielstee-db as co-owner of databricks, jobs, and pipelines skills

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 * @lennartkats-db @databricks/eng-apps-devex
 /skills/ @lennartkats-db # net-new skills must be approved by @lennartkats-db
-/skills/databricks/ @lennartkats-db @databricks/eng-apps-devex
+/skills/databricks/ @lennartkats-db @camielstee-db @databricks/eng-apps-devex
 /skills/databricks-apps/ @databricks/eng-apps-devex
-/skills/databricks-jobs/ @lennartkats-db @databricks/eng-lakeflow-authoring
-/skills/databricks-pipelines/ @lennartkats-db @databricks/eng-lakeflow-authoring
+/skills/databricks-jobs/ @lennartkats-db @camielstee-db
+/skills/databricks-pipelines/ @lennartkats-db @camielstee-db
 /.github/CODEOWNERS @lennartkats-db @fjakobs


### PR DESCRIPTION
This adds camielstee-db and removes the stale eng-lakeflow-authoring entry from the CODEOWNERS file.