### PR TITLE
Update Declarative Automation Bundles naming

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "databricks-skills",
-  "description": "Databricks skills for CLI, Apps, Unity Catalog, Model Serving, Asset Bundles, and more.",
+  "description": "Databricks skills for CLI, Apps, Unity Catalog, Model Serving, Declarative Automation Bundles, and more.",
   "version": "0.1.0",
   "author": {
     "name": "Databricks"
   },
   "repository": "https://github.com/databricks/databricks-agent-skills",
-  "keywords": ["databricks", "cli", "apps", "etl", "data-engineering", "spark", "data-pipelines", "unity-catalog", "model-serving", "asset-bundles"],
+  "keywords": ["databricks", "cli", "apps", "etl", "data-engineering", "spark", "data-pipelines", "unity-catalog", "model-serving", "declarative-automation-bundles"],
   "skills": "./skills/"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "databricks-skills",
   "displayName": "Databricks Skills",
-  "description": "Databricks skills for CLI, Apps, Unity Catalog, Model Serving, Asset Bundles, and more.",
+  "description": "Databricks skills for CLI, Apps, Unity Catalog, Model Serving, Declarative Automation Bundles, and more.",
   "version": "0.1.0",
   "author": {
     "name": "Databricks"

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
       "updated_at": "2026-03-11T17:08:20Z",
       "files": [
         "SKILL.md",
-        "asset-bundles.md",
+        "declarative-automation-bundles.md",
         "data-exploration.md",
         "databricks-cli-auth.md",
         "databricks-cli-install.md"

--- a/manifest.json
+++ b/manifest.json
@@ -1,21 +1,21 @@
 {
   "version": "1",
-  "updated_at": "2026-03-12T13:32:45Z",
+  "updated_at": "2026-03-18T11:59:47Z",
   "skills": {
     "databricks": {
       "version": "0.1.0",
-      "updated_at": "2026-03-11T17:08:20Z",
+      "updated_at": "2026-03-18T10:58:50Z",
       "files": [
         "SKILL.md",
-        "declarative-automation-bundles.md",
         "data-exploration.md",
         "databricks-cli-auth.md",
-        "databricks-cli-install.md"
+        "databricks-cli-install.md",
+        "declarative-automation-bundles.md"
       ]
     },
     "databricks-apps": {
       "version": "0.1.1",
-      "updated_at": "2026-03-12T13:32:37Z",
+      "updated_at": "2026-03-18T10:58:38Z",
       "files": [
         "SKILL.md",
         "references/appkit/appkit-sdk.md",
@@ -31,21 +31,21 @@
     },
     "databricks-jobs": {
       "version": "0.1.0",
-      "updated_at": "2026-03-11T17:08:20Z",
+      "updated_at": "2026-03-18T10:58:24Z",
       "files": [
         "SKILL.md"
       ]
     },
     "databricks-lakebase": {
       "version": "0.1.0",
-      "updated_at": "2026-03-11T17:08:20Z",
+      "updated_at": "2026-03-18T10:01:56Z",
       "files": [
         "SKILL.md"
       ]
     },
     "databricks-pipelines": {
       "version": "0.1.0",
-      "updated_at": "2026-03-11T17:08:20Z",
+      "updated_at": "2026-03-18T10:58:21Z",
       "files": [
         "SKILL.md",
         "references/auto-cdc-python.md",

--- a/skills/databricks-apps/references/other-frameworks.md
+++ b/skills/databricks-apps/references/other-frameworks.md
@@ -88,7 +88,7 @@ env:
 ```
 
 ### databricks.yml — Bundle/Deployment Configuration
-- Defines the **app resource** for DABs (Databricks Asset Bundles)
+- Defines the **app resource** for DABs (Declarative Automation Bundles)
 - `config:` section only takes effect after `bundle run`, NOT just `bundle deploy`
 
 ```yaml

--- a/skills/databricks-apps/references/platform-guide.md
+++ b/skills/databricks-apps/references/platform-guide.md
@@ -168,5 +168,5 @@ For long-running agent interactions, use **WebSockets** instead of SSE.
 | App deploys but config doesn't change | Only ran `bundle deploy` | Also run `bundle run <app-name>` |
 | `File is larger than 10485760 bytes` | Bundled dependencies | Use requirements.txt / package.json |
 | OBO scopes missing after deploy | Destructive update wiped them | Re-apply scopes after each deploy |
-| `${var.xxx}` appears literally in env | Variables not resolved in config | Use literal values, not DABs variables |
+| `${var.xxx}` appears literally in env | Variables not resolved in config | Use literal values, not bundle variables |
 | 504 Gateway Timeout | Request exceeded 120s | Use WebSockets for long operations |

--- a/skills/databricks-jobs/SKILL.md
+++ b/skills/databricks-jobs/SKILL.md
@@ -26,9 +26,9 @@ databricks bundle init default-python --config-file <(echo '{"project_name": "my
 After scaffolding, create `CLAUDE.md` and `AGENTS.md` in the project directory. These files are essential to provide agents with guidance on how to work with the project. Use this content:
 
 ```
-# Databricks Asset Bundles Project
+# Declarative Automation Bundles Project
 
-This project uses Databricks Asset Bundles for deployment.
+This project uses Declarative Automation Bundles (formerly Databricks Asset Bundles) for deployment.
 
 ## Prerequisites
 
@@ -186,4 +186,4 @@ uv run pytest
 
 - Lakeflow Jobs: https://docs.databricks.com/jobs
 - Task types: https://docs.databricks.com/jobs/configure-task
-- Databricks Asset Bundles: https://docs.databricks.com/dev-tools/bundles/examples
+- Declarative Automation Bundles: https://docs.databricks.com/dev-tools/bundles/

--- a/skills/databricks-pipelines/SKILL.md
+++ b/skills/databricks-pipelines/SKILL.md
@@ -184,9 +184,9 @@ databricks bundle init lakeflow-pipelines --config-file <(echo '{"project_name":
 After scaffolding, create `CLAUDE.md` and `AGENTS.md` in the project directory. These files are essential to provide agents with guidance on how to work with the project. Use this content:
 
 ```
-# Databricks Asset Bundles Project
+# Declarative Automation Bundles Project
 
-This project uses Databricks Asset Bundles for deployment.
+This project uses Declarative Automation Bundles (formerly Databricks Asset Bundles) for deployment.
 
 ## Prerequisites
 

--- a/skills/databricks/SKILL.md
+++ b/skills/databricks/SKILL.md
@@ -131,11 +131,11 @@ databricks bundle run <RESOURCE> -t <TARGET> --profile <PROFILE>
 | First time setup | [CLI Installation](databricks-cli-install.md) |
 | Auth issues / new workspace | [CLI Authentication](databricks-cli-auth.md) |
 | Exploring tables/schemas | [Data Exploration](data-exploration.md) |
-| Deploying jobs/pipelines | [Asset Bundles](asset-bundles.md) |
+| Deploying jobs/pipelines | [Declarative Automation Bundles](declarative-automation-bundles.md) |
 
 ## Reference Guides
 
 - [CLI Installation](databricks-cli-install.md)
 - [CLI Authentication](databricks-cli-auth.md)
 - [Data Exploration](data-exploration.md)
-- [Asset Bundles](asset-bundles.md)
+- [Declarative Automation Bundles](declarative-automation-bundles.md)

--- a/skills/databricks/data-exploration.md
+++ b/skills/databricks/data-exploration.md
@@ -327,4 +327,4 @@ Both commands support:
 
 ## Related Commands
 
-- **[Asset Bundles](asset-bundles.md)** - Deploy SQL, pipeline, and app resources as code
+- **[Declarative Automation Bundles](declarative-automation-bundles.md)** - Deploy SQL, pipeline, and app resources as code

--- a/skills/databricks/declarative-automation-bundles.md
+++ b/skills/databricks/declarative-automation-bundles.md
@@ -1,10 +1,10 @@
-# Databricks Asset Bundles (DABs)
+# Declarative Automation Bundles (DABs)
 
-Databricks Asset Bundles provide Infrastructure-as-Code for Databricks resources, enabling version control, automated deployments, and environment management.
+Declarative Automation Bundles (formerly known as Databricks Asset Bundles) provide Infrastructure-as-Code for Databricks resources, enabling version control, automated deployments, and environment management.
 
-## What are Asset Bundles?
+## What are Declarative Automation Bundles?
 
-Asset Bundles let you define your Databricks projects as code, including:
+Declarative Automation Bundles let you define your Databricks projects as code, including:
 - Jobs
 - Pipelines (Lakeflow Declarative Pipelines)
 - Apps


### PR DESCRIPTION
Aligns with the official product rename. Updates all references across skill files, plugin manifests, and the manifest.json. CLI commands (`databricks bundle`) and the DABs acronym remain unchanged.