### PR TITLE
Add manifest v2 fields: experimental, description, min_cli_version

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,13 @@
 {
-  "version": "1",
-  "updated_at": "2026-03-18T11:59:47Z",
+  "version": "2",
+  "updated_at": "2026-03-22T09:27:16Z",
   "skills": {
     "databricks": {
       "version": "0.1.0",
-      "updated_at": "2026-03-18T10:58:50Z",
+      "description": "Core Databricks skill for CLI, auth, and data exploration",
+      "experimental": false,
+      "min_cli_version": "",
+      "updated_at": "2026-03-22T09:19:20Z",
       "files": [
         "SKILL.md",
         "data-exploration.md",
@@ -15,7 +18,10 @@
     },
     "databricks-apps": {
       "version": "0.1.1",
-      "updated_at": "2026-03-18T10:58:38Z",
+      "description": "Databricks Apps development with AppKit SDK",
+      "experimental": false,
+      "min_cli_version": "",
+      "updated_at": "2026-03-22T09:19:20Z",
       "files": [
         "SKILL.md",
         "references/appkit/appkit-sdk.md",
@@ -31,21 +37,30 @@
     },
     "databricks-jobs": {
       "version": "0.1.0",
-      "updated_at": "2026-03-18T10:58:24Z",
+      "description": "Databricks Jobs orchestration and scheduling",
+      "experimental": false,
+      "min_cli_version": "",
+      "updated_at": "2026-03-22T09:19:20Z",
       "files": [
         "SKILL.md"
       ]
     },
     "databricks-lakebase": {
       "version": "0.1.0",
-      "updated_at": "2026-03-18T10:01:56Z",
+      "description": "Databricks Lakebase database development",
+      "experimental": false,
+      "min_cli_version": "",
+      "updated_at": "2026-03-22T09:19:20Z",
       "files": [
         "SKILL.md"
       ]
     },
     "databricks-pipelines": {
       "version": "0.1.0",
-      "updated_at": "2026-03-18T10:58:21Z",
+      "description": "Databricks Pipelines (DLT) for ETL and streaming",
+      "experimental": false,
+      "min_cli_version": "",
+      "updated_at": "2026-03-22T09:19:20Z",
       "files": [
         "SKILL.md",
         "references/auto-cdc-python.md",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "2",
-  "updated_at": "2026-03-22T10:27:09Z",
+  "updated_at": "2026-03-25T23:11:20Z",
   "skills": {
     "databricks": {
       "version": "0.1.0",
@@ -17,7 +17,7 @@
     },
     "databricks-apps": {
       "version": "0.1.1",
-      "description": "Databricks Apps development with AppKit SDK",
+      "description": "Databricks Apps development and deployment",
       "experimental": false,
       "updated_at": "2026-03-22T09:19:20Z",
       "files": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,11 @@
 {
   "version": "2",
-  "updated_at": "2026-03-22T09:27:16Z",
+  "updated_at": "2026-03-22T10:27:09Z",
   "skills": {
     "databricks": {
       "version": "0.1.0",
       "description": "Core Databricks skill for CLI, auth, and data exploration",
       "experimental": false,
-      "min_cli_version": "",
       "updated_at": "2026-03-22T09:19:20Z",
       "files": [
         "SKILL.md",
@@ -20,7 +19,6 @@
       "version": "0.1.1",
       "description": "Databricks Apps development with AppKit SDK",
       "experimental": false,
-      "min_cli_version": "",
       "updated_at": "2026-03-22T09:19:20Z",
       "files": [
         "SKILL.md",
@@ -39,7 +37,6 @@
       "version": "0.1.0",
       "description": "Databricks Jobs orchestration and scheduling",
       "experimental": false,
-      "min_cli_version": "",
       "updated_at": "2026-03-22T09:19:20Z",
       "files": [
         "SKILL.md"
@@ -49,7 +46,6 @@
       "version": "0.1.0",
       "description": "Databricks Lakebase database development",
       "experimental": false,
-      "min_cli_version": "",
       "updated_at": "2026-03-22T09:19:20Z",
       "files": [
         "SKILL.md"
@@ -59,7 +55,6 @@
       "version": "0.1.0",
       "description": "Databricks Pipelines (DLT) for ETL and streaming",
       "experimental": false,
-      "min_cli_version": "",
       "updated_at": "2026-03-22T09:19:20Z",
       "files": [
         "SKILL.md",

--- a/scripts/generate_manifest.py
+++ b/scripts/generate_manifest.py
@@ -58,7 +58,7 @@ SKILL_METADATA = {
         "experimental": False,
     },
     "databricks-apps": {
-        "description": "Databricks Apps development with AppKit SDK",
+        "description": "Databricks Apps development and deployment",
         "experimental": False,
     },
     "databricks-jobs": {

--- a/scripts/generate_manifest.py
+++ b/scripts/generate_manifest.py
@@ -103,15 +103,20 @@ def generate_manifest(repo_root: Path) -> dict:
             if f.is_file()
         )
 
-        metadata = SKILL_METADATA.get(item.name, {})
+        if item.name not in SKILL_METADATA:
+            raise ValueError(f"Missing SKILL_METADATA entry for skill '{item.name}'. Add it to SKILL_METADATA dict.")
+
+        metadata = SKILL_METADATA[item.name]
         skill_entry = {
             "version": extract_version_from_skill(item),
             "description": metadata.get("description", ""),
             "experimental": metadata.get("experimental", False),
-            "min_cli_version": "",
             "updated_at": get_skill_updated_at(item),
             "files": files,
         }
+
+        if metadata.get("min_cli_version"):
+            skill_entry["min_cli_version"] = metadata["min_cli_version"]
 
         # Preserve base_revision from existing manifest
         existing = existing_skills.get(item.name, {})

--- a/scripts/generate_manifest.py
+++ b/scripts/generate_manifest.py
@@ -52,6 +52,30 @@ def get_skill_updated_at(skill_path: Path) -> str:
     )
 
 
+SKILL_METADATA = {
+    "databricks": {
+        "description": "Core Databricks skill for CLI, auth, and data exploration",
+        "experimental": False,
+    },
+    "databricks-apps": {
+        "description": "Databricks Apps development with AppKit SDK",
+        "experimental": False,
+    },
+    "databricks-jobs": {
+        "description": "Databricks Jobs orchestration and scheduling",
+        "experimental": False,
+    },
+    "databricks-lakebase": {
+        "description": "Databricks Lakebase database development",
+        "experimental": False,
+    },
+    "databricks-pipelines": {
+        "description": "Databricks Pipelines (DLT) for ETL and streaming",
+        "experimental": False,
+    },
+}
+
+
 def generate_manifest(repo_root: Path) -> dict:
     """Generate manifest from skill directories."""
     # Load existing manifest to preserve base_revision fields
@@ -79,8 +103,12 @@ def generate_manifest(repo_root: Path) -> dict:
             if f.is_file()
         )
 
+        metadata = SKILL_METADATA.get(item.name, {})
         skill_entry = {
             "version": extract_version_from_skill(item),
+            "description": metadata.get("description", ""),
+            "experimental": metadata.get("experimental", False),
+            "min_cli_version": "",
             "updated_at": get_skill_updated_at(item),
             "files": files,
         }
@@ -93,7 +121,7 @@ def generate_manifest(repo_root: Path) -> dict:
         skills[item.name] = skill_entry
 
     return {
-        "version": "1",
+        "version": "2",
         "updated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "skills": skills,
     }


### PR DESCRIPTION
## Why

The Databricks CLI is adding support for skill filtering by experimental status and CLI version compatibility. The manifest needs new fields to support this.

## Changes

Before: Manifest v1 with `version`, `updated_at`, and `files` per skill.

Now: Manifest v2 adds three new fields to each skill entry:
- `experimental` (bool): Whether the skill is experimental. All current skills are `false`.
- `description` (string): One-line description of the skill.
- `min_cli_version` (string): Minimum CLI version required. Empty string means no minimum.

The CLI handles both v1 and v2 manifests gracefully. Missing v2 fields use zero-value defaults (non-experimental, no description, no version requirement).

Also updated `scripts/generate_manifest.py` to emit v2 fields with a `SKILL_METADATA` dict for per-skill configuration.

## Test plan

- [x] `python3 scripts/generate_manifest.py validate` passes
- [x] Generated manifest matches expected v2 format
- [x] All existing skills present with correct file lists