### PR TITLE
chore(appkit): update AppKit tRPC skill

### DIFF
--- a/skills/databricks-apps/references/appkit/trpc.md
+++ b/skills/databricks-apps/references/appkit/trpc.md
@@ -2,6 +2,8 @@
 
 **CRITICAL**: Do NOT use tRPC for SQL queries or data retrieval. Use `config/queries/` + `useAnalyticsQuery` instead.
 
+**CRITICAL**: Do NOT use tRPC for accessing Unity Catalog and File operations. Use the Files plugin instead.
+
 Use tRPC ONLY for:
 
 - **Mutations**: Creating, updating, or deleting data (INSERT, UPDATE, DELETE)
@@ -10,34 +12,82 @@ Use tRPC ONLY for:
 - **File operations**: File uploads, processing, transformations
 - **Custom computations**: Operations requiring TypeScript/Node.js logic
 
+## Before Writing New Routes
+
+**ALWAYS complete these checks before adding tRPC routes:**
+
+### 1. Check AppKit Version
+
+Read `package.json` to identify the installed `@databricks/appkit` version. Available server APIs and plugins differ across versions.
+
+```bash
+# From the project root
+cat package.json | grep @databricks/appkit
+```
+
+### 2. Review Available Plugins
+
+Check what plugins are already enabled and what server-side functionality they provide — avoid reimplementing what a plugin already handles.
+
+```bash
+# See plugin docs for the installed version
+npx @databricks/appkit docs ./docs/plugins.md
+
+# See all plugins available for a specific version
+databricks apps manifest --version <VERSION> --profile <PROFILE>
+
+# See plugins available for the default template
+databricks apps manifest --profile <PROFILE>
+```
+
+**Key plugins to check for:**
+
+- **analytics** — provides SQL warehouse query execution (do NOT reimplement with tRPC)
+- **lakebase** — provides `createLakebasePool` for PostgreSQL CRUD (use pool in tRPC routes, don't create raw connections)
+- **genie** — provides Genie AI-powered data exploration (check before building custom natural-language-to-SQL routes)
+- **files** — provides file storage and retrieval helpers (check before writing custom file upload/download routes)
+
+If a plugin already covers your use case, use the plugin's API instead of writing a custom tRPC route.
+
+If there's a newer version of `@databricks/appkit` has a plugin that fits the use-case.
+Prompt the user for updating.
+
+### 3. Check Existing Routes
+
+Read `server/server.ts` (or `server/trpc.ts`) to see what routes already exist. Extend the existing router rather than creating a parallel one.
+
 ## Server-side Pattern
 
-```typescript
+```tsx
 // server/trpc.ts
-import { initTRPC } from '@trpc/server';
-import { getExecutionContext } from '@databricks/appkit';
-import { z } from 'zod';
-import superjson from 'superjson';
+import { initTRPC } from "@trpc/server";
+import { getExecutionContext } from "@databricks/appkit";
+import { z } from "zod";
+import superjson from "superjson";
 
 const t = initTRPC.create({ transformer: superjson });
 const publicProcedure = t.procedure;
 
 export const appRouter = t.router({
   // Example: Query a serving endpoint
-  queryModel: publicProcedure.input(z.object({ prompt: z.string() })).query(async ({ input: { prompt } }) => {
-    const { serviceDatabricksClient: client } = getExecutionContext();
-    const response = await client.servingEndpoints.query({
-      name: 'your-endpoint-name',
-      messages: [{ role: 'user', content: prompt }],
-    });
-    return response;
-  }),
+  queryModel: publicProcedure
+    .input(z.object({ prompt: z.string() }))
+    .query(async ({ input: { prompt } }) => {
+      const { serviceDatabricksClient: client } = getExecutionContext();
+      const response = await client.servingEndpoints.query({
+        name: "your-endpoint-name",
+        messages: [{ role: "user", content: prompt }],
+      });
+      return response;
+    }),
 
   // Example: Mutation
-  createRecord: publicProcedure.input(z.object({ name: z.string() })).mutation(async ({ input }) => {
-    // Custom logic here
-    return { success: true, id: 123 };
-  }),
+  createRecord: publicProcedure
+    .input(z.object({ name: z.string() }))
+    .mutation(async ({ input }) => {
+      // Custom logic here
+      return { success: true, id: 123 };
+    }),
 });
 ```
 
@@ -90,7 +140,9 @@ function MyComponent() {
    - Complex computations in TypeScript
 
 **Summary:**
+
 - ✅ SQL queries → Visualization components or `useAnalyticsQuery`
 - ✅ Databricks APIs → tRPC
 - ✅ Data mutations → tRPC
 - ❌ SQL queries → tRPC (NEVER do this)
+- ❌ Files operations → tRPC (NEVER do this)


### PR DESCRIPTION
## Summary

New **"Before Writing New Routes"** section — adds 3 pre-flight checks agents must complete before writing tRPC routes:
  1. Check AppKit version from `package.json`
  2. Review available plugins (analytics, lakebase, genie, files) via `npx @databricks/appkit` docs or `databricks apps manifest` — avoid reimplementing
  plugin functionality. Prompt user to upgrade if a newer version has a relevant plugin.
  3. Check existing routes in the server file to extend rather than duplicate

**New guardrail for Files plugin**
added a second CRITICAL warning: do NOT use tRPC for Unity Catalog/file operations, use the Files plugin instead. Also

**added**
```
 ❌ Files operations → tRPC (NEVER do this) to the decision tree summary.
```

## Documentation safety checklist

- [x] Examples use least-privilege permissions (no unnecessary `ALL PRIVILEGES`, admin tokens, or broad scopes)
- [x] Elevated permissions are explicitly called out where required
- [x] Sensitive values are obfuscated (placeholder workspace IDs, URLs, no real tokens)
- [x] No insecure patterns introduced (e.g. disabled TLS verification, hardcoded credentials)
