### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Validate tag format
         env:

--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -16,10 +16,10 @@ jobs:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to specific commit SHAs for supply chain security, preventing tag-based attacks
- Follows the same pattern as [databricks/appkit#202](https://github.com/databricks/appkit/pull/202)

## Pinned actions
- [`actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5`](https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5) (v4.3.1)
- [`actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065`](https://github.com/actions/setup-python/commit/a26af69be951a213d495a4c3e4e4022e16d87065) (v5.6.0)

This pull request was AI-assisted by Isaac.