### PR TITLE
chore: add CODEOWNERS for lakebase and model-serving skills

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,8 @@
 /skills/ @lennartkats-db # net-new skills must be approved by @lennartkats-db
 /skills/databricks/ @lennartkats-db @camielstee-db @databricks/eng-apps-devex
 /skills/databricks-apps/ @databricks/eng-apps-devex
+/skills/databricks-lakebase/ @databricks/eng-apps-devex
+/skills/databricks-model-serving/ @databricks/eng-apps-devex
 /skills/databricks-jobs/ @lennartkats-db @camielstee-db
 /skills/databricks-pipelines/ @lennartkats-db @camielstee-db
 /.github/CODEOWNERS @lennartkats-db @fjakobs


### PR DESCRIPTION
## Summary
- Adds `@databricks/eng-apps-devex` as code owners for `/skills/databricks-lakebase/` and `/skills/databricks-model-serving/`
- Prevents these skills from falling back to the generic `/skills/ @lennartkats-db` rule, so PRs no longer require unnecessary approvals

## Test plan
- [x] Verify CODEOWNERS syntax is valid
- [x] Confirm the new rules appear after `/skills/` so they take precedence

This pull request was AI-assisted by Isaac.