### PR TITLE
Add Genie skill for Databricks Apps

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,24 +1,28 @@
 {
-  "version": "2",
-  "updated_at": "2026-04-07T13:25:51Z",
+  "version": "1",
+  "updated_at": "2026-03-25T13:22:01Z",
   "skills": {
-    "databricks-apps": {
-      "version": "0.1.1",
-      "description": "Databricks Apps development and deployment",
-      "experimental": false,
-      "updated_at": "2026-04-07T13:17:59Z",
+    "databricks": {
+      "version": "0.1.0",
+      "updated_at": "2026-03-25T13:07:20Z",
       "files": [
         "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
+        "data-exploration.md",
+        "databricks-cli-auth.md",
+        "databricks-cli-install.md",
+        "declarative-automation-bundles.md"
+      ]
+    },
+    "databricks-apps": {
+      "version": "0.1.1",
+      "updated_at": "2026-03-25T13:21:50Z",
+      "files": [
+        "SKILL.md",
         "references/appkit/appkit-sdk.md",
         "references/appkit/frontend.md",
+        "references/appkit/genie.md",
         "references/appkit/lakebase.md",
-        "references/appkit/model-serving.md",
         "references/appkit/overview.md",
-        "references/appkit/proto-contracts.md",
-        "references/appkit/proto-first.md",
         "references/appkit/sql-queries.md",
         "references/appkit/trpc.md",
         "references/other-frameworks.md",
@@ -26,85 +30,25 @@
         "references/testing.md"
       ]
     },
-    "databricks-core": {
-      "version": "0.1.0",
-      "description": "Core Databricks skill for CLI, auth, and data exploration",
-      "experimental": false,
-      "updated_at": "2026-04-07T13:17:46Z",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "data-exploration.md",
-        "databricks-cli-auth.md",
-        "databricks-cli-install.md"
-      ]
-    },
-    "databricks-dabs": {
-      "version": "0.0.0",
-      "description": "Declarative Automation Bundles (DABs) for deploying and managing Databricks resources",
-      "experimental": false,
-      "updated_at": "2026-04-07T13:17:46Z",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/alerts.md",
-        "references/bundle-structure.md",
-        "references/deploy-and-run.md",
-        "references/resource-permissions.md",
-        "references/sdp-pipelines.md"
-      ],
-      "base_revision": "e742f36e8ab1"
-    },
     "databricks-jobs": {
       "version": "0.1.0",
-      "description": "Databricks Jobs orchestration and scheduling",
-      "experimental": false,
-      "updated_at": "2026-04-07T13:17:46Z",
+      "updated_at": "2026-03-25T13:07:20Z",
       "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg"
+        "SKILL.md"
       ]
     },
     "databricks-lakebase": {
       "version": "0.1.0",
-      "description": "Databricks Lakebase database development",
-      "experimental": false,
-      "updated_at": "2026-04-07T13:17:59Z",
+      "updated_at": "2026-03-25T13:07:20Z",
       "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg"
-      ]
-    },
-    "databricks-model-serving": {
-      "version": "0.1.0",
-      "description": "Databricks Model Serving endpoint management",
-      "experimental": true,
-      "updated_at": "2026-04-07T13:25:43Z",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg"
+        "SKILL.md"
       ]
     },
     "databricks-pipelines": {
       "version": "0.1.0",
-      "description": "Databricks Pipelines (DLT) for ETL and streaming",
-      "experimental": false,
-      "updated_at": "2026-04-07T13:17:46Z",
+      "updated_at": "2026-03-25T13:07:20Z",
       "files": [
         "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
         "references/auto-cdc-python.md",
         "references/auto-cdc-sql.md",
         "references/auto-cdc.md",

--- a/manifest.json
+++ b/manifest.json
@@ -1,28 +1,25 @@
 {
-  "version": "1",
-  "updated_at": "2026-03-25T13:22:01Z",
+  "version": "2",
+  "updated_at": "2026-04-07T13:25:51Z",
   "skills": {
-    "databricks": {
-      "version": "0.1.0",
-      "updated_at": "2026-03-25T13:07:20Z",
-      "files": [
-        "SKILL.md",
-        "data-exploration.md",
-        "databricks-cli-auth.md",
-        "databricks-cli-install.md",
-        "declarative-automation-bundles.md"
-      ]
-    },
     "databricks-apps": {
       "version": "0.1.1",
-      "updated_at": "2026-03-25T13:21:50Z",
+      "description": "Databricks Apps development and deployment",
+      "experimental": false,
+      "updated_at": "2026-04-07T13:17:59Z",
       "files": [
         "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
         "references/appkit/appkit-sdk.md",
         "references/appkit/frontend.md",
         "references/appkit/genie.md",
         "references/appkit/lakebase.md",
+        "references/appkit/model-serving.md",
         "references/appkit/overview.md",
+        "references/appkit/proto-contracts.md",
+        "references/appkit/proto-first.md",
         "references/appkit/sql-queries.md",
         "references/appkit/trpc.md",
         "references/other-frameworks.md",
@@ -30,25 +27,85 @@
         "references/testing.md"
       ]
     },
+    "databricks-core": {
+      "version": "0.1.0",
+      "description": "Core Databricks skill for CLI, auth, and data exploration",
+      "experimental": false,
+      "updated_at": "2026-04-07T13:17:46Z",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "data-exploration.md",
+        "databricks-cli-auth.md",
+        "databricks-cli-install.md"
+      ]
+    },
+    "databricks-dabs": {
+      "version": "0.0.0",
+      "description": "Declarative Automation Bundles (DABs) for deploying and managing Databricks resources",
+      "experimental": false,
+      "updated_at": "2026-04-07T13:17:46Z",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/alerts.md",
+        "references/bundle-structure.md",
+        "references/deploy-and-run.md",
+        "references/resource-permissions.md",
+        "references/sdp-pipelines.md"
+      ],
+      "base_revision": "e742f36e8ab1"
+    },
     "databricks-jobs": {
       "version": "0.1.0",
-      "updated_at": "2026-03-25T13:07:20Z",
+      "description": "Databricks Jobs orchestration and scheduling",
+      "experimental": false,
+      "updated_at": "2026-04-07T13:17:46Z",
       "files": [
-        "SKILL.md"
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg"
       ]
     },
     "databricks-lakebase": {
       "version": "0.1.0",
-      "updated_at": "2026-03-25T13:07:20Z",
+      "description": "Databricks Lakebase database development",
+      "experimental": false,
+      "updated_at": "2026-04-07T13:17:59Z",
       "files": [
-        "SKILL.md"
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg"
+      ]
+    },
+    "databricks-model-serving": {
+      "version": "0.1.0",
+      "description": "Databricks Model Serving endpoint management",
+      "experimental": true,
+      "updated_at": "2026-04-07T13:25:43Z",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg"
       ]
     },
     "databricks-pipelines": {
       "version": "0.1.0",
-      "updated_at": "2026-03-25T13:07:20Z",
+      "description": "Databricks Pipelines (DLT) for ETL and streaming",
+      "experimental": false,
+      "updated_at": "2026-04-07T13:17:46Z",
       "files": [
         "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
         "references/auto-cdc-python.md",
         "references/auto-cdc-sql.md",
         "references/auto-cdc.md",

--- a/skills/databricks-apps/SKILL.md
+++ b/skills/databricks-apps/SKILL.md
@@ -23,7 +23,7 @@ Build apps that deploy to Databricks Apps platform.
 | Using `useAnalyticsQuery` | [AppKit SDK](references/appkit/appkit-sdk.md) |
 | Adding API endpoints | [tRPC Guide](references/appkit/trpc.md) |
 | Using Lakebase (OLTP database) | [Lakebase Guide](references/appkit/lakebase.md) |
-| Adding Genie chat / Genie-powered apps | [Genie Guide](references/appkit/genie.md) — do not assume the user already has a Genie Space ID |
+| Adding Genie chat / Genie-powered apps | [Genie Guide](references/appkit/genie.md) — follow the Genie agent workflow below |
 | Using Model Serving (ML inference) | [Model Serving Guide](references/appkit/model-serving.md) |
 | Typed data contracts (proto-first design) | [Proto-First Guide](references/appkit/proto-first.md) and [Plugin Contracts](references/appkit/proto-contracts.md) |
 | Platform rules (permissions, deployment, limits) | [Platform Guide](references/platform-guide.md) — READ for ALL apps including AppKit |
@@ -133,7 +133,15 @@ npx @databricks/appkit docs ./docs/plugins/analytics.md  # example: specific doc
 
 **READ [AppKit Overview](references/appkit/overview.md)** for project structure, workflow, and pre-implementation checklist.
 
-For chat interfaces backed by Databricks Genie, read [Genie Guide](references/appkit/genie.md).
+**Genie Agent Workflow** — when the user wants a Genie-powered app, do **not** start by asking for a Genie Space ID. Instead:
+
+1. Ask which Unity Catalog tables the app should query (fully qualified: `catalog.schema.table`).
+2. Ask whether to reuse an existing Genie space or create a new one.
+3. If creating: discover the warehouse, then create the space with `databricks genie create-space` (see [Genie Guide](references/appkit/genie.md) for syntax and serialized space format).
+4. If reusing: discover existing spaces with `w.genie.list_spaces()` (Python SDK) and let the user pick.
+5. Scaffold or wire the space ID into the app — derive `--set` keys from `databricks apps manifest`.
+
+Read the [Genie Guide](references/appkit/genie.md) for configuration, SSE endpoints, and frontend integration.
 
 ### Common Scaffolding Mistakes
 

--- a/skills/databricks-apps/SKILL.md
+++ b/skills/databricks-apps/SKILL.md
@@ -74,6 +74,7 @@ Before writing any SQL, use the parent `databricks-core` skill for data explorat
 - **Read analytics data → custom display (KPIs, cards)**: Use `useAnalyticsQuery` hook
 - **Read analytics data → need computation before display**: Still use `useAnalyticsQuery`, transform client-side
 - **Read/write persistent data (users, orders, CRUD state)**: Use Lakebase pool via tRPC — see [Lakebase Guide](references/appkit/lakebase.md)
+- **Natural language query interface over tables (Genie)**: Use `genie()` plugin — see [Genie Guide](references/appkit/genie.md)
 - **Call ML model endpoint**: Use tRPC — see [Model Serving Guide](references/appkit/model-serving.md)
 - **⚠️ NEVER use tRPC to run SELECT queries against the warehouse** — always use SQL files in `config/queries/`
 - **⚠️ NEVER use `useAnalyticsQuery` for Lakebase data** — it queries the SQL warehouse only

--- a/skills/databricks-apps/SKILL.md
+++ b/skills/databricks-apps/SKILL.md
@@ -23,6 +23,7 @@ Build apps that deploy to Databricks Apps platform.
 | Using `useAnalyticsQuery` | [AppKit SDK](references/appkit/appkit-sdk.md) |
 | Adding API endpoints | [tRPC Guide](references/appkit/trpc.md) |
 | Using Lakebase (OLTP database) | [Lakebase Guide](references/appkit/lakebase.md) |
+| Adding Genie chat / Genie-powered apps | [Genie Guide](references/appkit/genie.md) — do not assume the user already has a Genie Space ID |
 | Using Model Serving (ML inference) | [Model Serving Guide](references/appkit/model-serving.md) |
 | Typed data contracts (proto-first design) | [Proto-First Guide](references/appkit/proto-first.md) and [Plugin Contracts](references/appkit/proto-contracts.md) |
 | Platform rules (permissions, deployment, limits) | [Platform Guide](references/platform-guide.md) — READ for ALL apps including AppKit |
@@ -130,6 +131,8 @@ npx @databricks/appkit docs ./docs/plugins/analytics.md  # example: specific doc
 **DO NOT guess** plugin names, resource keys, or property names — always derive them from `databricks apps manifest` output. Example: if the manifest shows plugin `analytics` with a required resource `resourceKey: "sql-warehouse"` and `fields: { "id": ... }`, include `--set analytics.sql-warehouse.id=<ID>`.
 
 **READ [AppKit Overview](references/appkit/overview.md)** for project structure, workflow, and pre-implementation checklist.
+
+For chat interfaces backed by Databricks Genie, read [Genie Guide](references/appkit/genie.md).
 
 ### Common Scaffolding Mistakes
 

--- a/skills/databricks-apps/SKILL.md
+++ b/skills/databricks-apps/SKILL.md
@@ -138,7 +138,7 @@ npx @databricks/appkit docs ./docs/plugins/analytics.md  # example: specific doc
 1. Ask which Unity Catalog tables the app should query (fully qualified: `catalog.schema.table`).
 2. Ask whether to reuse an existing Genie space or create a new one.
 3. If creating: discover the warehouse, then create the space with `databricks genie create-space` (see [Genie Guide](references/appkit/genie.md) for syntax and serialized space format).
-4. If reusing: discover existing spaces with `w.genie.list_spaces()` (Python SDK) and let the user pick.
+4. If reusing: discover existing spaces with `databricks genie list-spaces --profile <PROFILE>` and let the user pick.
 5. Scaffold or wire the space ID into the app — derive `--set` keys from `databricks apps manifest`.
 
 Read the [Genie Guide](references/appkit/genie.md) for configuration, SSE endpoints, and frontend integration.

--- a/skills/databricks-apps/references/appkit/genie.md
+++ b/skills/databricks-apps/references/appkit/genie.md
@@ -1,27 +1,16 @@
 # AppKit Genie Guide
 
-Use this guide when building a Genie-powered app from scratch or when adding Databricks Genie to an existing AppKit app.
+Use Genie when your app needs a **natural language query interface** over Unity Catalog tables. For analytics dashboards, use `config/queries/` instead. For persistent storage, use Lakebase.
 
-## When to Use This Guide
+## When to Use
 
-| Scenario | Start at |
-|----------|----------|
-| Build a NEW app powered by Genie | [Scaffolding a New Genie App](#scaffolding-a-new-genie-app) |
-| Add Genie chat to an EXISTING AppKit app | [Adding Genie to an Existing App](#adding-genie-to-an-existing-app) |
-| Create a Genie space from tables (no space ID yet) | [Create-or-Reuse Space Workflow](#create-or-reuse-space-workflow) |
-| Wire a known space ID into an app | [Configuration Reference](#configuration-reference) |
-
-## Space Setup UX Rule
-
-When the user wants a Genie-powered app, do **not** start by asking for a `Genie Space ID`.
-
-Instead, begin with a create-or-reuse workflow:
-
-1. Ask whether the user wants to reuse an existing Genie space or create a new one.
-2. If reusing, discover or confirm the existing space and only then ask for the ID if the agent cannot retrieve it directly.
-3. If creating, ask which Unity Catalog tables or views the space should include before asking for any Genie-specific identifiers.
-
-The goal is to keep the user in an app-building flow, not send them to the Databricks UI just to come back with a space ID.
+| Pattern | Use Case | Data Source |
+|---------|----------|-------------|
+| Analytics | Read-only dashboards, charts, KPIs | SQL Warehouse |
+| Lakebase | CRUD operations, persistent state, forms | PostgreSQL (Lakebase) |
+| Model Serving | Chat, AI features, model inference | Serving Endpoint |
+| Genie | Natural language queries over tables | Genie Space → SQL Warehouse |
+| Multiple | Combine plugins as needed | Mix of the above |
 
 ## Architecture
 
@@ -30,293 +19,99 @@ User (browser) -> AppKit genie plugin (/api/genie/...) -> Databricks Genie API -
                <- SSE stream (status, message_result, query_result) <-
 ```
 
-The built-in `genie()` plugin from `@databricks/appkit` proxies requests to the Databricks Genie API via SSE streaming. The browser talks only to the AppKit server. The server-side plugin holds the credentials and resolves the Genie space from the `DATABRICKS_GENIE_SPACE_ID` env var. Call `genie()` with no arguments — it picks up the space ID automatically.
+The built-in `genie()` plugin from `@databricks/appkit` proxies requests via SSE streaming. It reads the space ID from the `DATABRICKS_GENIE_SPACE_ID` env var. Call `genie()` with no arguments.
 
-## Scaffolding a New Genie App
+## Genie Space Creation
 
-Use this workflow when the user wants to build a new app from scratch that uses Genie as its primary interface (e.g. "I want a Genie app for my sales data").
-
-### Prerequisites
-
-1. Authenticated Databricks profile (use parent `databricks-core` skill).
-2. Unity Catalog table names the user wants to query — fully qualified: `catalog.schema.table`.
-3. A SQL warehouse ID. Discover with:
-   ```bash
-   databricks experimental aitools tools get-default-warehouse --profile <PROFILE>
-   # or
-   databricks warehouses list --profile <PROFILE>
-   ```
-
-### Step-by-Step Workflow
-
-1. **Gather tables**: Ask the user which Unity Catalog tables or views the app should query. Accept fully qualified names like `catalog.schema.orders`.
-2. **Discover the warehouse**: Run warehouse discovery (see Prerequisites above).
-3. **Create the Genie space**: Use the Databricks CLI to create a space from the tables and warehouse. See [Genie Space Management](#genie-space-management) for details.
-4. **Check the manifest**: Run `databricks apps manifest --profile <PROFILE>` to verify the `genie` plugin is available and to identify its resource keys and required `--set` fields.
-5. **Scaffold the app**: Build the `databricks apps init` command from the manifest output. Example:
-   ```bash
-   databricks apps init --name <APP_NAME> \
-     --features genie \
-     --set "genie.<resourceKey>.<field>=<value>" \
-     --run none --profile <PROFILE>
-   ```
-   Replace `<resourceKey>` and `<field>` with the actual keys from the manifest. **Do not guess** — always derive from `databricks apps manifest`.
-6. **Verify wiring**: Confirm `server/server.ts` registers `genie()` and `app.yaml` maps `DATABRICKS_GENIE_SPACE_ID`.
-7. **Set local env**: Add `DATABRICKS_GENIE_SPACE_ID=<space_id>` to `server/.env` for local development.
-8. **Develop and validate**:
-   ```bash
-   cd <APP_NAME> && npm install && npm run dev
-   # When ready:
-   databricks apps validate --profile <PROFILE>
-   ```
-
-### Example: End-to-End New App
-
-User says: *"I want a Genie app for my sales data in `main.sales.orders` and `main.sales.customers`."*
+The `databricks genie create-space` command takes two positional arguments: `WAREHOUSE_ID` and `SERIALIZED_SPACE` (a JSON string).
 
 ```bash
-# 1. Discover warehouse
-databricks experimental aitools tools get-default-warehouse --profile my-profile
-# → returns warehouse ID, e.g. "abc123def456"
-
-# 2. Create Genie space
-databricks genie create-space \
+databricks genie create-space <WAREHOUSE_ID> \
+  '{"version":2,"data_sources":{"tables":[{"identifier":"catalog.schema.orders"},{"identifier":"catalog.schema.customers"}]}}' \
   --title "Sales Assistant" \
   --description "Answers sales analytics questions" \
-  --warehouse-id abc123def456 \
-  --table main.sales.orders \
-  --table main.sales.customers \
-  --profile my-profile
-# → returns space ID, e.g. "01ABCDEF12345678"
-
-# 3. Check manifest for genie plugin keys
-databricks apps manifest --profile my-profile
-
-# 4. Scaffold (use keys from manifest output)
-databricks apps init --name sales-genie \
-  --features genie \
-  --set "genie.genie-space.space_id=01ABCDEF12345678" \
-  --set "genie.genie-space.name=Sales Assistant" \
-  --set "genie.sql-warehouse.id=abc123def456" \
-  --run none --profile my-profile
-
-# 5. Local env + develop
-cd sales-genie
-echo "DATABRICKS_GENIE_SPACE_ID=01ABCDEF12345678" >> server/.env
-npm install && npm run dev
-```
-
-**Do not hardcode** the `--set` flags from this example. Always derive them from `databricks apps manifest` output for the current template version.
-
-## Adding Genie to an Existing App
-
-For an existing AppKit app, use this order:
-
-1. Confirm the app is AppKit-based and does not already register `genie()` or expose `/api/genie`.
-2. Get the current plugin/resource shape from authoritative sources:
-   - `databricks apps manifest --profile <PROFILE>`
-   - `npx @databricks/appkit docs`
-3. Add a Genie space resource in `databricks.yml` with `permission: CAN_VIEW`.
-4. Inject `DATABRICKS_GENIE_SPACE_ID` through `app.yaml` and the local development env file.
-5. Register `genie()` in `server/server.ts`, preserving existing plugins.
-6. Add UI with `<GenieChat />` unless the user explicitly wants a custom chat experience.
-7. Update smoke tests if headings or routes changed, then run the normal `databricks-apps` validation flow.
-
-## Create-or-Reuse Space Workflow
-
-Use this interaction pattern whenever the app needs Genie:
-
-### Reuse Existing Space
-
-Choose this path when the user already has a curated Genie space or wants to keep using an existing one.
-
-1. List or discover existing Genie spaces.
-2. Let the user choose one by title if there are multiple candidates.
-3. Resolve the selected space ID and use it in the app wiring.
-
-### Create New Space
-
-Choose this path when the user does not already have a Genie space or does not want to manage one manually in the UI.
-
-Ask for:
-
-- a space title
-- the SQL warehouse to associate with the space
-- the Unity Catalog tables or views to include, using fully qualified names like `catalog.schema.table`
-- optionally, a short description and a few sample questions
-
-Start with a small table set. Genie can support larger spaces, but an initial scope of about five or fewer tables is usually easier to curate and debug.
-
-After the space is created, wire the resulting space ID into the app resource configuration.
-
-## Genie Space Management
-
-### How Agents Should Help
-
-Prefer helping the user create or discover the Genie space instead of requiring them to do it manually in the UI first.
-
-- **Use the Databricks CLI** for space creation: `databricks genie create-space` is the simplest path.
-- **Ask for tables first**: if the user wants a new space, gather the table list before asking for any Genie IDs.
-- **Fall back to the Python SDK** only if the CLI does not support a required option (e.g. setting sample questions or instructions). The SDK exposes `create_space()`, `list_spaces()`, `get_space()`, and `update_space()`.
-
-If the workspace blocks programmatic creation, explain the limitation clearly and fall back to a minimal UI creation flow.
-
-### Discovery
-
-Use these capabilities to avoid asking the user to manually hunt for IDs:
-
-- `databricks genie get-space <SPACE_ID>` for validating a known space
-- Genie management API `list spaces` or SDK `w.genie.list_spaces()` for enumerating available spaces
-
-### Creating a Space
-
-**Preferred: Databricks CLI**
-
-```bash
-databricks genie create-space \
-  --title "Sales Assistant" \
-  --description "Answers sales analytics questions" \
-  --warehouse-id <WAREHOUSE_ID> \
-  --table catalog.schema.orders \
-  --table catalog.schema.customers \
   --profile <PROFILE>
 ```
 
-Repeat `--table` for each Unity Catalog table or view. The command returns the space ID to use in the app configuration.
+The JSON must include `version` and `data_sources.tables` with each table as `{"identifier":"catalog.schema.table"}`. Optional flags: `--title`, `--description`, `--parent-path`.
 
-**Fallback: Python SDK**
-
-Use the SDK when you need options the CLI does not expose (e.g. sample questions or custom instructions):
-
-```python
-import json
-from databricks.sdk import WorkspaceClient
-
-w = WorkspaceClient()
-space = w.genie.create_space(
-    warehouse_id="<WAREHOUSE_ID>",
-    title="Sales Assistant",
-    description="Answers sales analytics questions",
-    serialized_space=json.dumps({
-        "table_identifiers": [
-            "catalog.schema.orders",
-            "catalog.schema.customers"
-        ],
-        "instructions": "Help users explore order and customer data.",
-        "sample_questions": [
-            "What were total sales last quarter?",
-            "Show top 10 customers by revenue"
-        ]
-    }),
-)
-print(f"Created space: {space.space_id}")
-```
-
-If the `serialized_space` format is unclear, export an existing space to see the current expected shape:
-
-```python
-existing = w.genie.get_space("<KNOWN_SPACE_ID>", include_serialized_space=True)
-print(existing.serialized_space)  # Use this JSON as a template
-```
-
-### Warehouse Discovery
-
-The agent needs a warehouse ID before creating a space. Use these commands:
+To discover the full serialized space format (including optional fields), export an existing space:
 
 ```bash
-# Preferred: get the workspace default
+databricks genie get-space <SPACE_ID> --include-serialized-space --profile <PROFILE>
+```
+
+Discover warehouse ID with:
+
+```bash
+databricks experimental aitools tools get-default-warehouse --profile <PROFILE>
+```
+
+## Scaffolding a New Genie App
+
+```bash
+# 1. Discover warehouse
 databricks experimental aitools tools get-default-warehouse --profile <PROFILE>
 
-# Alternative: list all warehouses and let the user pick
-databricks warehouses list --profile <PROFILE>
+# 2. Create Genie space (see syntax above)
+databricks genie create-space <WAREHOUSE_ID> '<SERIALIZED_SPACE_JSON>' \
+  --title "My Space" --profile <PROFILE>
+
+# 3. Check manifest for genie plugin keys
+databricks apps manifest --profile <PROFILE>
+
+# 4. Scaffold (derive --set keys from manifest output)
+databricks apps init --name <APP_NAME> --features genie \
+  --set "genie.<resourceKey>.<field>=<SPACE_ID>" \
+  --run none --profile <PROFILE>
+
+# 5. Set local env + develop
+cd <APP_NAME>
+echo "DATABRICKS_GENIE_SPACE_ID=<SPACE_ID>" >> server/.env
+npm install && npm run dev
 ```
 
-## Key Files
+**Do not guess** `--set` flags — always derive from `databricks apps manifest`.
 
-| File | Purpose |
-|------|---------|
-| `databricks.yml` | Declare Genie variables and the `genie-space` app resource |
-| `app.yaml` | Map `DATABRICKS_GENIE_SPACE_ID` from the `genie-space` resource |
-| `server/server.ts` | Import and register the built-in `genie()` plugin |
-| `server/.env` or equivalent local env file | Set `DATABRICKS_GENIE_SPACE_ID` for local development |
-| `client/src/...` | Render `GenieChat` or use `useGenieChat` for custom UI |
+## Adding Genie to an Existing App
 
-## Configuration Reference
-
-### Local Development Env
-
-Set `DATABRICKS_GENIE_SPACE_ID` in the env file used by the app template for local server development. In the standard AppKit layout, that is commonly `server/.env`.
-
-```dotenv
-DATABRICKS_GENIE_SPACE_ID=<YOUR_SPACE_ID>
-```
-
-For deployment, use app resources and `valueFrom` in `app.yaml` instead of checking IDs into source control.
-
-### `app.yaml`
-
-Add Genie env injection next to the existing warehouse mapping:
-
-```yaml
-env:
-  - name: DATABRICKS_WAREHOUSE_ID
-    valueFrom: sql-warehouse
-  - name: DATABRICKS_GENIE_SPACE_ID
-    valueFrom: genie-space
-```
-
-The `valueFrom` name must match the resource name declared in `databricks.yml`.
-
-### `databricks.yml`
-
-Add Genie variables and a Genie space resource. Keep names aligned with the rest of the repo: resource type `genie_space`, resource name `genie-space`, permission `CAN_VIEW`.
-
-**Variables section**
+**`databricks.yml`** — add Genie variables and resource:
 
 ```yaml
 variables:
-  sql_warehouse_id:
-    description: SQL Warehouse ID
   genie_space_id:
     description: Genie Space ID
   genie_space_name:
     description: Genie Space name
-```
 
-**App resource**
-
-```yaml
 resources:
   apps:
     app:
       resources:
-        - name: sql-warehouse
-          sql_warehouse:
-            id: ${var.sql_warehouse_id}
-            permission: CAN_USE
+        # ... existing resources ...
         - name: genie-space
           genie_space:
             name: ${var.genie_space_name}
             space_id: ${var.genie_space_id}
             permission: CAN_VIEW
-```
 
-**Target variables**
-
-```yaml
 targets:
   default:
     variables:
-      sql_warehouse_id: <warehouse_id>
       genie_space_id: <space_id>
       genie_space_name: <space_name>
 ```
 
-If the app already has a `resources.apps.app.resources` list, append the Genie resource instead of rewriting the list.
+**`app.yaml`** — add env injection:
 
-## `server/server.ts`
+```yaml
+env:
+  # ... existing env vars ...
+  - name: DATABRICKS_GENIE_SPACE_ID
+    valueFrom: genie-space
+```
 
-Register the built-in plugin:
+**`server/server.ts`** — register the plugin:
 
 ```typescript
 import { createApp, server, analytics, genie } from "@databricks/appkit";
@@ -326,75 +121,15 @@ createApp({
 }).catch(console.error);
 ```
 
-If the app does not use analytics, keep the existing plugins and add `genie()` to the array. If the app already uses other plugins, preserve them and add `genie()`. Do not create a local Genie proxy plugin file unless the user explicitly needs behavior that the built-in plugin cannot provide.
+Preserve existing plugins and add `genie()` to the array.
 
-## Server Config Patterns
+**`server/.env`** — for local development:
 
-Call `genie()` with no arguments. It reads `DATABRICKS_GENIE_SPACE_ID` from the environment and exposes it as the `default` space.
-
-```typescript
-import { createApp, server, genie } from "@databricks/appkit";
-
-createApp({
-  plugins: [server(), genie()],
-}).catch(console.error);
+```dotenv
+DATABRICKS_GENIE_SPACE_ID=<YOUR_SPACE_ID>
 ```
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `timeout` | `number` | `120000` | Polling timeout in ms. Use `0` for no timeout |
-
-## HTTP Endpoints
-
-The plugin mounts SSE endpoints under `/api/genie`:
-
-| Route | Method | Purpose |
-|-------|--------|---------|
-| `/api/genie/:alias/messages` | `POST` | Send a message and stream progress/results |
-| `/api/genie/:alias/conversations/:conversationId` | `GET` | Replay an existing conversation |
-
-### Send Message Request
-
-```http
-POST /api/genie/:alias/messages
-Content-Type: application/json
-
-{ "content": "What were total sales last quarter?", "conversationId": "optional-existing-id" }
-```
-
-### SSE Event Types
-
-| Event | Payload | Description |
-|-------|---------|-------------|
-| `message_start` | `{ conversationId, messageId, spaceId }` | Message and conversation IDs assigned |
-| `status` | `{ status: "ASKING_AI" \| "EXECUTING_QUERY" \| ... }` | Progress updates |
-| `message_result` | `{ content, attachments }` | Final assistant message |
-| `query_result` | `{ attachmentId, statementId, data }` | Tabular results for a query attachment |
-| `error` | `{ error }` | Error details |
-
-Message statuses commonly progress through:
-
-`SUBMITTED -> FILTERING_CONTEXT -> ASKING_AI -> EXECUTING_QUERY -> COMPLETED`
-
-Failure states also include `FAILED` and `CANCELLED`.
-
-### Attachment Types
-
-Completed responses can contain attachments. Identify them by key:
-
-| Key | Meaning |
-|-----|---------|
-| `query` | Generated SQL plus metadata |
-| `text` | Natural-language explanation |
-| `suggestedQuestions` | Follow-up prompts |
-
-## Frontend Patterns
-
-Import UI pieces from `@databricks/appkit-ui/react`.
-
-### `GenieChat` (Default)
-
-Use this unless the user asks for a custom layout or specialized rendering:
+**Frontend** — add the chat component:
 
 ```tsx
 import { GenieChat } from "@databricks/appkit-ui/react";
@@ -408,131 +143,56 @@ function GeniePage() {
 }
 ```
 
-| Prop | Type | Default | Notes |
-|------|------|---------|-------|
-| `basePath` | `string` | `"/api/genie"` | Override only if routes are customized |
-| `placeholder` | `string` | `"Ask a question..."` | Input placeholder |
-| `className` | `string` | none | Root container styling |
+Update smoke tests if headings or routes changed, then `databricks apps validate`.
 
-Full-page example:
+## Frontend
 
-```tsx
-import { GenieChat } from "@databricks/appkit-ui/react";
+**For full component API**: run `npx @databricks/appkit docs "GenieChat"`.
 
-function GeniePage() {
-  return (
-    <div className="min-h-screen bg-background flex flex-col items-center p-4 w-full">
-      <div className="w-full max-w-4xl flex flex-col h-[calc(100vh-2rem)]">
-        <h1 className="text-2xl font-bold mb-4">Genie Chat</h1>
-        <GenieChat className="flex-1" />
-      </div>
-    </div>
-  );
-}
-```
+The `GenieChat` component handles SSE streaming, conversation state, history replay, and query result rendering. For custom UI, use the `useGenieChat` hook — see `npx @databricks/appkit docs "useGenieChat"`.
 
-### `useGenieChat` (Custom UI)
+Common anti-patterns:
 
-Use the hook only when the built-in component is not enough:
+| Mistake | Why it's wrong | What to do |
+|---------|---------------|------------|
+| No explicit height on parent container | Chat collapses to zero height | Give the parent a fixed height (`style={{ height: 600 }}` or CSS class) |
+| Old local Genie proxy file | Duplicate routes, import confusion | Remove it — use `genie` from `@databricks/appkit` |
+| Manual SSE reimplementation | Extra complexity, bugs | Use `GenieChat` or `useGenieChat` |
+| Missing `whitespace-pre-wrap` in custom UI | Explanation text renders on one line | Add `whitespace-pre-wrap` to message content |
 
-```tsx
-import { useGenieChat } from "@databricks/appkit-ui/react";
+## HTTP Endpoints
 
-const { messages, status, conversationId, error, sendMessage, reset } = useGenieChat();
-```
+The plugin mounts SSE endpoints under `/api/genie`:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `messages` | `GenieMessageItem[]` | Conversation messages |
-| `status` | `"idle" \| "loading-history" \| "streaming" \| "error"` | Current chat state |
-| `conversationId` | `string \| null` | Active conversation ID |
-| `error` | `string \| null` | Current error, if any |
-| `sendMessage` | `(content: string) => void` | Sends a prompt |
-| `reset` | `() => void` | Starts a new conversation |
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/genie/:alias/messages` | `POST` | Send a message and stream results |
+| `/api/genie/:alias/conversations/:conversationId` | `GET` | Replay an existing conversation |
 
-Example custom chat:
+### SSE Event Types
 
-```tsx
-import { useGenieChat } from "@databricks/appkit-ui/react";
-import { useState } from "react";
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `message_start` | `{ conversationId, messageId, spaceId }` | IDs assigned |
+| `status` | `{ status: "ASKING_AI" \| "EXECUTING_QUERY" \| ... }` | Progress |
+| `message_result` | `{ content, attachments }` | Final message |
+| `query_result` | `{ attachmentId, statementId, data }` | Tabular results |
+| `error` | `{ error }` | Error details |
 
-function CustomChat() {
-  const { messages, status, sendMessage, reset } = useGenieChat();
-  const [input, setInput] = useState("");
+### Attachment Types
 
-  const handleSend = () => {
-    if (!input.trim()) return;
-    sendMessage(input.trim());
-    setInput("");
-  };
+| Key | Meaning |
+|-----|---------|
+| `query` | Generated SQL plus metadata |
+| `text` | Natural-language explanation |
+| `suggestedQuestions` | Follow-up prompts |
 
-  return (
-    <div className="flex flex-col h-full">
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="font-bold">Chat</h2>
-        <Button variant="outline" size="sm" onClick={reset}>New Chat</Button>
-      </div>
-      <ScrollArea className="flex-1 min-h-0">
-        {messages.map((message) => (
-          <div key={message.id} className={message.role === "user" ? "flex justify-end" : "flex justify-start"}>
-            <div
-              className={`max-w-[85%] rounded-lg px-4 py-3 ${
-                message.role === "user" ? "bg-primary text-primary-foreground" : "bg-muted"
-              }`}
-            >
-              <p className="text-sm whitespace-pre-wrap">{message.content}</p>
-            </div>
-          </div>
-        ))}
-      </ScrollArea>
-      <div className="flex gap-2 mt-4 pt-4 border-t">
-        <Input
-          value={input}
-          onChange={(event) => setInput(event.target.value)}
-          onKeyDown={(event) => {
-            if (event.key === "Enter" && !event.shiftKey) {
-              event.preventDefault();
-              handleSend();
-            }
-          }}
-          placeholder="Ask a question..."
-          disabled={status === "streaming"}
-        />
-        <Button onClick={handleSend} disabled={status === "streaming"}>Send</Button>
-      </div>
-    </div>
-  );
-}
-```
+## Troubleshooting
 
-### Lower-Level Components
-
-These are also available from `@databricks/appkit-ui/react`:
-
-| Component | Purpose |
-|-----------|---------|
-| `GenieChatInput` | Auto-expanding input with Enter-to-send |
-| `GenieChatMessage` | Single chat bubble with attachment rendering |
-| `GenieChatMessageList` | Scrollable list with auto-scroll and streaming state |
-
-## Behavioral Defaults
-
-- Prefer `GenieChat` for most apps. It already handles SSE streaming, conversation state, history replay, and query result rendering.
-- Give the parent container an explicit height. Without one, the chat UI may collapse.
-- Start a new conversation when query accuracy matters. Long-lived threads can reduce answer quality.
-- Prefer the built-in streaming UX. Do not bolt on custom polling unless there is a proven gap.
-- Expect query result limits. If a large result looks truncated, explain that in the UI.
-- Treat POST requests as rate-limited. Avoid designing retry loops that can spam the API.
-
-## Common Mistakes
-
-| Mistake | Symptom | Fix |
-|---------|---------|-----|
-| Missing `DATABRICKS_GENIE_SPACE_ID` | Server reports Genie is not configured | Set env var in `server/.env` (local) or wire via `app.yaml` (deployed) |
-| No explicit chat height | Chat collapses or renders poorly | Give the parent container a fixed height |
-| Old local Genie proxy file | Duplicate routes or import confusion | Remove it and use `genie` from `@databricks/appkit` |
-| Manual SSE reimplementation | Extra complexity and bugs | Use `GenieChat` or `useGenieChat` |
-| Missing `whitespace-pre-wrap` in custom messages | Explanation text renders on one line | Add `whitespace-pre-wrap` to custom message content |
-| Hardcoding scaffold command from memory | Wrong `--set` flags or missing resources | Always run `databricks apps manifest` first |
-| Empty or malformed `serialized_space` | SDK `create_space()` fails or creates unusable space | Use the CLI instead, or use the SDK payload template above |
-| Skipping warehouse discovery | No warehouse ID for space creation | Run `databricks warehouses list` or use the default warehouse command |
+| Error | Cause | Solution |
+|-------|-------|---------|
+| Server reports Genie not configured | Missing `DATABRICKS_GENIE_SPACE_ID` | Set env var in `server/.env` (local) or wire via `app.yaml` (deployed) |
+| `create-space` fails with "Cannot find field" | Wrong `serialized_space` JSON format | Use `{"version":2,"data_sources":{"tables":[{"identifier":"..."}]}}` — export an existing space to verify |
+| Chat collapses or renders poorly | No explicit height on container | Give the parent a fixed height |
+| Duplicate routes or import confusion | Old local Genie proxy file | Remove it — use `genie` from `@databricks/appkit` |
+| Wrong `--set` flags during scaffold | Guessed plugin resource keys | Always derive from `databricks apps manifest` |

--- a/skills/databricks-apps/references/appkit/genie.md
+++ b/skills/databricks-apps/references/appkit/genie.md
@@ -1,0 +1,374 @@
+# AppKit Genie Guide
+
+Use this guide when adding Databricks Genie to an AppKit app, especially when retrofitting an existing app that does not already use the built-in `genie()` plugin.
+
+## Architecture
+
+```text
+User (browser) -> AppKit genie plugin (/api/genie/:alias/...) -> Databricks Genie API -> SQL Warehouse
+               <- SSE stream (status, message_result, query_result) <-
+```
+
+The built-in `genie()` plugin from `@databricks/appkit` proxies requests to the Databricks Genie API via SSE streaming. The browser talks only to the AppKit server. The server-side plugin holds the credentials and resolves a Genie space from either:
+
+- the default `DATABRICKS_GENIE_SPACE_ID` env var
+- a named alias in `genie({ spaces: { ... } })`
+
+## Default Retrofit Workflow
+
+For an existing AppKit app, use this order:
+
+1. Confirm the app is AppKit-based and does not already register `genie()` or expose `/api/genie`.
+2. Get the current plugin/resource shape from authoritative sources:
+   - `databricks apps manifest --profile <PROFILE>`
+   - `npx @databricks/appkit docs`
+3. Add a Genie space resource in `databricks.yml` with `permission: CAN_VIEW`.
+4. Inject `DATABRICKS_GENIE_SPACE_ID` through `app.yaml` and the local development env file.
+5. Register `genie()` in `server/server.ts`, preserving existing plugins.
+6. Add UI with `<GenieChat alias="default" />` unless the user explicitly wants a custom chat experience.
+7. Update smoke tests if headings or routes changed, then run the normal `databricks-apps` validation flow.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `databricks.yml` | Declare Genie variables and the `genie-space` app resource |
+| `app.yaml` | Map `DATABRICKS_GENIE_SPACE_ID` from the `genie-space` resource |
+| `server/server.ts` | Import and register the built-in `genie()` plugin |
+| `server/.env` or equivalent local env file | Set `DATABRICKS_GENIE_SPACE_ID` for local development |
+| `client/src/...` | Render `GenieChat` or use `useGenieChat` for custom UI |
+
+## Local Development Env
+
+Set `DATABRICKS_GENIE_SPACE_ID` in the env file used by the app template for local server development. In the standard AppKit layout, that is commonly `server/.env`.
+
+```dotenv
+DATABRICKS_GENIE_SPACE_ID=<YOUR_SPACE_ID>
+```
+
+For deployment, use app resources and `valueFrom` in `app.yaml` instead of checking IDs into source control.
+
+## `app.yaml`
+
+Add Genie env injection next to the existing warehouse mapping:
+
+```yaml
+env:
+  - name: DATABRICKS_WAREHOUSE_ID
+    valueFrom: sql-warehouse
+  - name: DATABRICKS_GENIE_SPACE_ID
+    valueFrom: genie-space
+```
+
+The `valueFrom` name must match the resource name declared in `databricks.yml`.
+
+## `databricks.yml`
+
+Add Genie variables and a Genie space resource. Keep names aligned with the rest of the repo: resource type `genie_space`, resource name `genie-space`, permission `CAN_VIEW`.
+
+**Variables section**
+
+```yaml
+variables:
+  sql_warehouse_id:
+    description: SQL Warehouse ID
+  genie_space_id:
+    description: Genie Space ID
+  genie_space_name:
+    description: Genie Space name
+```
+
+**App resource**
+
+```yaml
+resources:
+  apps:
+    app:
+      resources:
+        - name: sql-warehouse
+          sql_warehouse:
+            id: ${var.sql_warehouse_id}
+            permission: CAN_USE
+        - name: genie-space
+          genie_space:
+            name: ${var.genie_space_name}
+            space_id: ${var.genie_space_id}
+            permission: CAN_VIEW
+```
+
+**Target variables**
+
+```yaml
+targets:
+  default:
+    variables:
+      sql_warehouse_id: <warehouse_id>
+      genie_space_id: <space_id>
+      genie_space_name: <space_name>
+```
+
+If the app already has a `resources.apps.app.resources` list, append the Genie resource instead of rewriting the list.
+
+## `server/server.ts`
+
+Register the built-in plugin:
+
+```typescript
+import { createApp, server, analytics, genie } from "@databricks/appkit";
+
+createApp({
+  plugins: [server(), analytics(), genie()],
+}).catch(console.error);
+```
+
+If the app does not use analytics, keep the existing plugins and add `genie()` to the array. If the app already uses other plugins, preserve them and add `genie()`. Do not create a local Genie proxy plugin file unless the user explicitly needs behavior that the built-in plugin cannot provide.
+
+## Server Config Patterns
+
+### Default Single Space
+
+```typescript
+import { createApp, server, genie } from "@databricks/appkit";
+
+createApp({
+  plugins: [server(), genie()],
+}).catch(console.error);
+```
+
+This reads `DATABRICKS_GENIE_SPACE_ID` and exposes it as the `default` alias.
+
+### Multiple Spaces
+
+```typescript
+genie({
+  spaces: {
+    sales: "01ABCDEF12345678",
+    support: "01GHIJKL87654321",
+  },
+  timeout: 60000,
+})
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `spaces` | `Record<string, string>` | `{ default: DATABRICKS_GENIE_SPACE_ID }` | Alias-to-space map |
+| `timeout` | `number` | `120000` | Polling timeout in ms. Use `0` for no timeout |
+
+Use named aliases only when the UI truly needs multiple Genie spaces. Otherwise keep the default single-space flow.
+
+### Programmatic Server Access
+
+```typescript
+const app = await createApp({
+  plugins: [server(), genie({ spaces: { demo: "space-id" } })],
+});
+
+for await (const event of app.genie.sendMessage("demo", "Show revenue by region")) {
+  console.log(event.type, event);
+}
+```
+
+## HTTP Endpoints
+
+The plugin mounts SSE endpoints under `/api/genie`:
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/genie/:alias/messages` | `POST` | Send a message and stream progress/results |
+| `/api/genie/:alias/conversations/:conversationId` | `GET` | Replay an existing conversation |
+
+### Send Message Request
+
+```http
+POST /api/genie/:alias/messages
+Content-Type: application/json
+
+{ "content": "What were total sales last quarter?", "conversationId": "optional-existing-id" }
+```
+
+### SSE Event Types
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `message_start` | `{ conversationId, messageId, spaceId }` | Message and conversation IDs assigned |
+| `status` | `{ status: "ASKING_AI" \| "EXECUTING_QUERY" \| ... }` | Progress updates |
+| `message_result` | `{ content, attachments }` | Final assistant message |
+| `query_result` | `{ attachmentId, statementId, data }` | Tabular results for a query attachment |
+| `error` | `{ error }` | Error details |
+
+Message statuses commonly progress through:
+
+`SUBMITTED -> FILTERING_CONTEXT -> ASKING_AI -> EXECUTING_QUERY -> COMPLETED`
+
+Failure states also include `FAILED` and `CANCELLED`.
+
+### Attachment Types
+
+Completed responses can contain attachments. Identify them by key:
+
+| Key | Meaning |
+|-----|---------|
+| `query` | Generated SQL plus metadata |
+| `text` | Natural-language explanation |
+| `suggestedQuestions` | Follow-up prompts |
+
+## Frontend Patterns
+
+Import UI pieces from `@databricks/appkit-ui/react`.
+
+### `GenieChat` (Default)
+
+Use this unless the user asks for a custom layout or specialized rendering:
+
+```tsx
+import { GenieChat } from "@databricks/appkit-ui/react";
+
+function GeniePage() {
+  return (
+    <div style={{ height: 600 }}>
+      <GenieChat alias="default" />
+    </div>
+  );
+}
+```
+
+| Prop | Type | Default | Notes |
+|------|------|---------|-------|
+| `alias` | `string` | none | Must match the server alias |
+| `basePath` | `string` | `"/api/genie"` | Override only if routes are customized |
+| `placeholder` | `string` | `"Ask a question..."` | Input placeholder |
+| `className` | `string` | none | Root container styling |
+
+Full-page example:
+
+```tsx
+import { GenieChat } from "@databricks/appkit-ui/react";
+
+function GeniePage() {
+  return (
+    <div className="min-h-screen bg-background flex flex-col items-center p-4 w-full">
+      <div className="w-full max-w-4xl flex flex-col h-[calc(100vh-2rem)]">
+        <h1 className="text-2xl font-bold mb-4">Genie Chat</h1>
+        <GenieChat alias="default" className="flex-1" />
+      </div>
+    </div>
+  );
+}
+```
+
+### `useGenieChat` (Custom UI)
+
+Use the hook only when the built-in component is not enough:
+
+```tsx
+import { useGenieChat } from "@databricks/appkit-ui/react";
+
+const { messages, status, conversationId, error, sendMessage, reset } = useGenieChat({
+  alias: "default",
+});
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `messages` | `GenieMessageItem[]` | Conversation messages |
+| `status` | `"idle" \| "loading-history" \| "streaming" \| "error"` | Current chat state |
+| `conversationId` | `string \| null` | Active conversation ID |
+| `error` | `string \| null` | Current error, if any |
+| `sendMessage` | `(content: string) => void` | Sends a prompt |
+| `reset` | `() => void` | Starts a new conversation |
+
+Example custom chat:
+
+```tsx
+import { useGenieChat } from "@databricks/appkit-ui/react";
+import { useState } from "react";
+
+function CustomChat() {
+  const { messages, status, sendMessage, reset } = useGenieChat({ alias: "default" });
+  const [input, setInput] = useState("");
+
+  const handleSend = () => {
+    if (!input.trim()) return;
+    sendMessage(input.trim());
+    setInput("");
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="font-bold">Chat</h2>
+        <Button variant="outline" size="sm" onClick={reset}>New Chat</Button>
+      </div>
+      <ScrollArea className="flex-1 min-h-0">
+        {messages.map((message) => (
+          <div key={message.id} className={message.role === "user" ? "flex justify-end" : "flex justify-start"}>
+            <div
+              className={`max-w-[85%] rounded-lg px-4 py-3 ${
+                message.role === "user" ? "bg-primary text-primary-foreground" : "bg-muted"
+              }`}
+            >
+              <p className="text-sm whitespace-pre-wrap">{message.content}</p>
+            </div>
+          </div>
+        ))}
+      </ScrollArea>
+      <div className="flex gap-2 mt-4 pt-4 border-t">
+        <Input
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+              handleSend();
+            }
+          }}
+          placeholder="Ask a question..."
+          disabled={status === "streaming"}
+        />
+        <Button onClick={handleSend} disabled={status === "streaming"}>Send</Button>
+      </div>
+    </div>
+  );
+}
+```
+
+### Lower-Level Components
+
+These are also available from `@databricks/appkit-ui/react`:
+
+| Component | Purpose |
+|-----------|---------|
+| `GenieChatInput` | Auto-expanding input with Enter-to-send |
+| `GenieChatMessage` | Single chat bubble with attachment rendering |
+| `GenieChatMessageList` | Scrollable list with auto-scroll and streaming state |
+
+## Behavioral Defaults
+
+- Prefer `GenieChat` for most apps. It already handles SSE streaming, conversation state, history replay, and query result rendering.
+- Give the parent container an explicit height. Without one, the chat UI may collapse.
+- Keep the alias as `"default"` unless the server config defines named spaces.
+- Start a new conversation when query accuracy matters. Long-lived threads can reduce answer quality.
+- Prefer the built-in streaming UX. Do not bolt on custom polling unless there is a proven gap.
+- Expect query result limits. If a large result looks truncated, explain that in the UI.
+- Treat POST requests as rate-limited. Avoid designing retry loops that can spam the API.
+
+## Common Mistakes
+
+| Mistake | Symptom | Fix |
+|---------|---------|-----|
+| Alias mismatch | `404` under `/api/genie/...` | Make the frontend alias match the server alias |
+| Missing `DATABRICKS_GENIE_SPACE_ID` | Server reports Genie is not configured | Set env var or pass `spaces` explicitly |
+| No explicit chat height | Chat collapses or renders poorly | Give the parent container a fixed height |
+| Old local Genie proxy file | Duplicate routes or import confusion | Remove it and use `genie` from `@databricks/appkit` |
+| Manual SSE reimplementation | Extra complexity and bugs | Use `GenieChat` or `useGenieChat` |
+| Missing `whitespace-pre-wrap` in custom messages | Explanation text renders on one line | Add `whitespace-pre-wrap` to custom message content |
+
+## Scaffolding New Apps
+
+When starting a new app, follow the normal `databricks-apps` scaffolding workflow:
+
+1. Run `databricks apps manifest --profile <PROFILE>`
+2. Confirm the current template exposes a Genie feature and what resource fields it requires
+3. Build the `databricks apps init` command from the manifest output
+
+Do not hardcode a scaffold command from a different template. The manifest is the source of truth for plugin IDs, resource keys, and required `--set` fields.

--- a/skills/databricks-apps/references/appkit/genie.md
+++ b/skills/databricks-apps/references/appkit/genie.md
@@ -1,20 +1,114 @@
 # AppKit Genie Guide
 
-Use this guide when adding Databricks Genie to an AppKit app, especially when retrofitting an existing app that does not already use the built-in `genie()` plugin.
+Use this guide when building a Genie-powered app from scratch or when adding Databricks Genie to an existing AppKit app.
+
+## When to Use This Guide
+
+| Scenario | Start at |
+|----------|----------|
+| Build a NEW app powered by Genie | [Scaffolding a New Genie App](#scaffolding-a-new-genie-app) |
+| Add Genie chat to an EXISTING AppKit app | [Adding Genie to an Existing App](#adding-genie-to-an-existing-app) |
+| Create a Genie space from tables (no space ID yet) | [Create-or-Reuse Space Workflow](#create-or-reuse-space-workflow) |
+| Wire a known space ID into an app | [Configuration Reference](#configuration-reference) |
+
+## Space Setup UX Rule
+
+When the user wants a Genie-powered app, do **not** start by asking for a `Genie Space ID`.
+
+Instead, begin with a create-or-reuse workflow:
+
+1. Ask whether the user wants to reuse an existing Genie space or create a new one.
+2. If reusing, discover or confirm the existing space and only then ask for the ID if the agent cannot retrieve it directly.
+3. If creating, ask which Unity Catalog tables or views the space should include before asking for any Genie-specific identifiers.
+
+The goal is to keep the user in an app-building flow, not send them to the Databricks UI just to come back with a space ID.
 
 ## Architecture
 
 ```text
-User (browser) -> AppKit genie plugin (/api/genie/:alias/...) -> Databricks Genie API -> SQL Warehouse
+User (browser) -> AppKit genie plugin (/api/genie/...) -> Databricks Genie API -> SQL Warehouse
                <- SSE stream (status, message_result, query_result) <-
 ```
 
-The built-in `genie()` plugin from `@databricks/appkit` proxies requests to the Databricks Genie API via SSE streaming. The browser talks only to the AppKit server. The server-side plugin holds the credentials and resolves a Genie space from either:
+The built-in `genie()` plugin from `@databricks/appkit` proxies requests to the Databricks Genie API via SSE streaming. The browser talks only to the AppKit server. The server-side plugin holds the credentials and resolves the Genie space from the `DATABRICKS_GENIE_SPACE_ID` env var. Call `genie()` with no arguments — it picks up the space ID automatically.
 
-- the default `DATABRICKS_GENIE_SPACE_ID` env var
-- a named alias in `genie({ spaces: { ... } })`
+## Scaffolding a New Genie App
 
-## Default Retrofit Workflow
+Use this workflow when the user wants to build a new app from scratch that uses Genie as its primary interface (e.g. "I want a Genie app for my sales data").
+
+### Prerequisites
+
+1. Authenticated Databricks profile (use parent `databricks-core` skill).
+2. Unity Catalog table names the user wants to query — fully qualified: `catalog.schema.table`.
+3. A SQL warehouse ID. Discover with:
+   ```bash
+   databricks experimental aitools tools get-default-warehouse --profile <PROFILE>
+   # or
+   databricks warehouses list --profile <PROFILE>
+   ```
+
+### Step-by-Step Workflow
+
+1. **Gather tables**: Ask the user which Unity Catalog tables or views the app should query. Accept fully qualified names like `catalog.schema.orders`.
+2. **Discover the warehouse**: Run warehouse discovery (see Prerequisites above).
+3. **Create the Genie space**: Use the Databricks CLI to create a space from the tables and warehouse. See [Genie Space Management](#genie-space-management) for details.
+4. **Check the manifest**: Run `databricks apps manifest --profile <PROFILE>` to verify the `genie` plugin is available and to identify its resource keys and required `--set` fields.
+5. **Scaffold the app**: Build the `databricks apps init` command from the manifest output. Example:
+   ```bash
+   databricks apps init --name <APP_NAME> \
+     --features genie \
+     --set "genie.<resourceKey>.<field>=<value>" \
+     --run none --profile <PROFILE>
+   ```
+   Replace `<resourceKey>` and `<field>` with the actual keys from the manifest. **Do not guess** — always derive from `databricks apps manifest`.
+6. **Verify wiring**: Confirm `server/server.ts` registers `genie()` and `app.yaml` maps `DATABRICKS_GENIE_SPACE_ID`.
+7. **Set local env**: Add `DATABRICKS_GENIE_SPACE_ID=<space_id>` to `server/.env` for local development.
+8. **Develop and validate**:
+   ```bash
+   cd <APP_NAME> && npm install && npm run dev
+   # When ready:
+   databricks apps validate --profile <PROFILE>
+   ```
+
+### Example: End-to-End New App
+
+User says: *"I want a Genie app for my sales data in `main.sales.orders` and `main.sales.customers`."*
+
+```bash
+# 1. Discover warehouse
+databricks experimental aitools tools get-default-warehouse --profile my-profile
+# → returns warehouse ID, e.g. "abc123def456"
+
+# 2. Create Genie space
+databricks genie create-space \
+  --title "Sales Assistant" \
+  --description "Answers sales analytics questions" \
+  --warehouse-id abc123def456 \
+  --table main.sales.orders \
+  --table main.sales.customers \
+  --profile my-profile
+# → returns space ID, e.g. "01ABCDEF12345678"
+
+# 3. Check manifest for genie plugin keys
+databricks apps manifest --profile my-profile
+
+# 4. Scaffold (use keys from manifest output)
+databricks apps init --name sales-genie \
+  --features genie \
+  --set "genie.genie-space.space_id=01ABCDEF12345678" \
+  --set "genie.genie-space.name=Sales Assistant" \
+  --set "genie.sql-warehouse.id=abc123def456" \
+  --run none --profile my-profile
+
+# 5. Local env + develop
+cd sales-genie
+echo "DATABRICKS_GENIE_SPACE_ID=01ABCDEF12345678" >> server/.env
+npm install && npm run dev
+```
+
+**Do not hardcode** the `--set` flags from this example. Always derive them from `databricks apps manifest` output for the current template version.
+
+## Adding Genie to an Existing App
 
 For an existing AppKit app, use this order:
 
@@ -25,8 +119,117 @@ For an existing AppKit app, use this order:
 3. Add a Genie space resource in `databricks.yml` with `permission: CAN_VIEW`.
 4. Inject `DATABRICKS_GENIE_SPACE_ID` through `app.yaml` and the local development env file.
 5. Register `genie()` in `server/server.ts`, preserving existing plugins.
-6. Add UI with `<GenieChat alias="default" />` unless the user explicitly wants a custom chat experience.
+6. Add UI with `<GenieChat />` unless the user explicitly wants a custom chat experience.
 7. Update smoke tests if headings or routes changed, then run the normal `databricks-apps` validation flow.
+
+## Create-or-Reuse Space Workflow
+
+Use this interaction pattern whenever the app needs Genie:
+
+### Reuse Existing Space
+
+Choose this path when the user already has a curated Genie space or wants to keep using an existing one.
+
+1. List or discover existing Genie spaces.
+2. Let the user choose one by title if there are multiple candidates.
+3. Resolve the selected space ID and use it in the app wiring.
+
+### Create New Space
+
+Choose this path when the user does not already have a Genie space or does not want to manage one manually in the UI.
+
+Ask for:
+
+- a space title
+- the SQL warehouse to associate with the space
+- the Unity Catalog tables or views to include, using fully qualified names like `catalog.schema.table`
+- optionally, a short description and a few sample questions
+
+Start with a small table set. Genie can support larger spaces, but an initial scope of about five or fewer tables is usually easier to curate and debug.
+
+After the space is created, wire the resulting space ID into the app resource configuration.
+
+## Genie Space Management
+
+### How Agents Should Help
+
+Prefer helping the user create or discover the Genie space instead of requiring them to do it manually in the UI first.
+
+- **Use the Databricks CLI** for space creation: `databricks genie create-space` is the simplest path.
+- **Ask for tables first**: if the user wants a new space, gather the table list before asking for any Genie IDs.
+- **Fall back to the Python SDK** only if the CLI does not support a required option (e.g. setting sample questions or instructions). The SDK exposes `create_space()`, `list_spaces()`, `get_space()`, and `update_space()`.
+
+If the workspace blocks programmatic creation, explain the limitation clearly and fall back to a minimal UI creation flow.
+
+### Discovery
+
+Use these capabilities to avoid asking the user to manually hunt for IDs:
+
+- `databricks genie get-space <SPACE_ID>` for validating a known space
+- Genie management API `list spaces` or SDK `w.genie.list_spaces()` for enumerating available spaces
+
+### Creating a Space
+
+**Preferred: Databricks CLI**
+
+```bash
+databricks genie create-space \
+  --title "Sales Assistant" \
+  --description "Answers sales analytics questions" \
+  --warehouse-id <WAREHOUSE_ID> \
+  --table catalog.schema.orders \
+  --table catalog.schema.customers \
+  --profile <PROFILE>
+```
+
+Repeat `--table` for each Unity Catalog table or view. The command returns the space ID to use in the app configuration.
+
+**Fallback: Python SDK**
+
+Use the SDK when you need options the CLI does not expose (e.g. sample questions or custom instructions):
+
+```python
+import json
+from databricks.sdk import WorkspaceClient
+
+w = WorkspaceClient()
+space = w.genie.create_space(
+    warehouse_id="<WAREHOUSE_ID>",
+    title="Sales Assistant",
+    description="Answers sales analytics questions",
+    serialized_space=json.dumps({
+        "table_identifiers": [
+            "catalog.schema.orders",
+            "catalog.schema.customers"
+        ],
+        "instructions": "Help users explore order and customer data.",
+        "sample_questions": [
+            "What were total sales last quarter?",
+            "Show top 10 customers by revenue"
+        ]
+    }),
+)
+print(f"Created space: {space.space_id}")
+```
+
+If the `serialized_space` format is unclear, export an existing space to see the current expected shape:
+
+```python
+existing = w.genie.get_space("<KNOWN_SPACE_ID>", include_serialized_space=True)
+print(existing.serialized_space)  # Use this JSON as a template
+```
+
+### Warehouse Discovery
+
+The agent needs a warehouse ID before creating a space. Use these commands:
+
+```bash
+# Preferred: get the workspace default
+databricks experimental aitools tools get-default-warehouse --profile <PROFILE>
+
+# Alternative: list all warehouses and let the user pick
+databricks warehouses list --profile <PROFILE>
+```
 
 ## Key Files
 
@@ -38,7 +241,9 @@ For an existing AppKit app, use this order:
 | `server/.env` or equivalent local env file | Set `DATABRICKS_GENIE_SPACE_ID` for local development |
 | `client/src/...` | Render `GenieChat` or use `useGenieChat` for custom UI |
 
-## Local Development Env
+## Configuration Reference
+
+### Local Development Env
 
 Set `DATABRICKS_GENIE_SPACE_ID` in the env file used by the app template for local server development. In the standard AppKit layout, that is commonly `server/.env`.
 
@@ -48,7 +253,7 @@ DATABRICKS_GENIE_SPACE_ID=<YOUR_SPACE_ID>
 
 For deployment, use app resources and `valueFrom` in `app.yaml` instead of checking IDs into source control.
 
-## `app.yaml`
+### `app.yaml`
 
 Add Genie env injection next to the existing warehouse mapping:
 
@@ -62,7 +267,7 @@ env:
 
 The `valueFrom` name must match the resource name declared in `databricks.yml`.
 
-## `databricks.yml`
+### `databricks.yml`
 
 Add Genie variables and a Genie space resource. Keep names aligned with the rest of the repo: resource type `genie_space`, resource name `genie-space`, permission `CAN_VIEW`.
 
@@ -125,7 +330,7 @@ If the app does not use analytics, keep the existing plugins and add `genie()` t
 
 ## Server Config Patterns
 
-### Default Single Space
+Call `genie()` with no arguments. It reads `DATABRICKS_GENIE_SPACE_ID` from the environment and exposes it as the `default` space.
 
 ```typescript
 import { createApp, server, genie } from "@databricks/appkit";
@@ -135,38 +340,9 @@ createApp({
 }).catch(console.error);
 ```
 
-This reads `DATABRICKS_GENIE_SPACE_ID` and exposes it as the `default` alias.
-
-### Multiple Spaces
-
-```typescript
-genie({
-  spaces: {
-    sales: "01ABCDEF12345678",
-    support: "01GHIJKL87654321",
-  },
-  timeout: 60000,
-})
-```
-
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `spaces` | `Record<string, string>` | `{ default: DATABRICKS_GENIE_SPACE_ID }` | Alias-to-space map |
 | `timeout` | `number` | `120000` | Polling timeout in ms. Use `0` for no timeout |
-
-Use named aliases only when the UI truly needs multiple Genie spaces. Otherwise keep the default single-space flow.
-
-### Programmatic Server Access
-
-```typescript
-const app = await createApp({
-  plugins: [server(), genie({ spaces: { demo: "space-id" } })],
-});
-
-for await (const event of app.genie.sendMessage("demo", "Show revenue by region")) {
-  console.log(event.type, event);
-}
-```
 
 ## HTTP Endpoints
 
@@ -226,7 +402,7 @@ import { GenieChat } from "@databricks/appkit-ui/react";
 function GeniePage() {
   return (
     <div style={{ height: 600 }}>
-      <GenieChat alias="default" />
+      <GenieChat />
     </div>
   );
 }
@@ -234,7 +410,6 @@ function GeniePage() {
 
 | Prop | Type | Default | Notes |
 |------|------|---------|-------|
-| `alias` | `string` | none | Must match the server alias |
 | `basePath` | `string` | `"/api/genie"` | Override only if routes are customized |
 | `placeholder` | `string` | `"Ask a question..."` | Input placeholder |
 | `className` | `string` | none | Root container styling |
@@ -249,7 +424,7 @@ function GeniePage() {
     <div className="min-h-screen bg-background flex flex-col items-center p-4 w-full">
       <div className="w-full max-w-4xl flex flex-col h-[calc(100vh-2rem)]">
         <h1 className="text-2xl font-bold mb-4">Genie Chat</h1>
-        <GenieChat alias="default" className="flex-1" />
+        <GenieChat className="flex-1" />
       </div>
     </div>
   );
@@ -263,9 +438,7 @@ Use the hook only when the built-in component is not enough:
 ```tsx
 import { useGenieChat } from "@databricks/appkit-ui/react";
 
-const { messages, status, conversationId, error, sendMessage, reset } = useGenieChat({
-  alias: "default",
-});
+const { messages, status, conversationId, error, sendMessage, reset } = useGenieChat();
 ```
 
 | Field | Type | Description |
@@ -284,7 +457,7 @@ import { useGenieChat } from "@databricks/appkit-ui/react";
 import { useState } from "react";
 
 function CustomChat() {
-  const { messages, status, sendMessage, reset } = useGenieChat({ alias: "default" });
+  const { messages, status, sendMessage, reset } = useGenieChat();
   const [input, setInput] = useState("");
 
   const handleSend = () => {
@@ -346,7 +519,6 @@ These are also available from `@databricks/appkit-ui/react`:
 
 - Prefer `GenieChat` for most apps. It already handles SSE streaming, conversation state, history replay, and query result rendering.
 - Give the parent container an explicit height. Without one, the chat UI may collapse.
-- Keep the alias as `"default"` unless the server config defines named spaces.
 - Start a new conversation when query accuracy matters. Long-lived threads can reduce answer quality.
 - Prefer the built-in streaming UX. Do not bolt on custom polling unless there is a proven gap.
 - Expect query result limits. If a large result looks truncated, explain that in the UI.
@@ -356,19 +528,11 @@ These are also available from `@databricks/appkit-ui/react`:
 
 | Mistake | Symptom | Fix |
 |---------|---------|-----|
-| Alias mismatch | `404` under `/api/genie/...` | Make the frontend alias match the server alias |
-| Missing `DATABRICKS_GENIE_SPACE_ID` | Server reports Genie is not configured | Set env var or pass `spaces` explicitly |
+| Missing `DATABRICKS_GENIE_SPACE_ID` | Server reports Genie is not configured | Set env var in `server/.env` (local) or wire via `app.yaml` (deployed) |
 | No explicit chat height | Chat collapses or renders poorly | Give the parent container a fixed height |
 | Old local Genie proxy file | Duplicate routes or import confusion | Remove it and use `genie` from `@databricks/appkit` |
 | Manual SSE reimplementation | Extra complexity and bugs | Use `GenieChat` or `useGenieChat` |
 | Missing `whitespace-pre-wrap` in custom messages | Explanation text renders on one line | Add `whitespace-pre-wrap` to custom message content |
-
-## Scaffolding New Apps
-
-When starting a new app, follow the normal `databricks-apps` scaffolding workflow:
-
-1. Run `databricks apps manifest --profile <PROFILE>`
-2. Confirm the current template exposes a Genie feature and what resource fields it requires
-3. Build the `databricks apps init` command from the manifest output
-
-Do not hardcode a scaffold command from a different template. The manifest is the source of truth for plugin IDs, resource keys, and required `--set` fields.
+| Hardcoding scaffold command from memory | Wrong `--set` flags or missing resources | Always run `databricks apps manifest` first |
+| Empty or malformed `serialized_space` | SDK `create_space()` fails or creates unusable space | Use the CLI instead, or use the SDK payload template above |
+| Skipping warehouse discovery | No warehouse ID for space creation | Run `databricks warehouses list` or use the default warehouse command |

--- a/skills/databricks-apps/references/appkit/genie.md
+++ b/skills/databricks-apps/references/appkit/genie.md
@@ -93,7 +93,7 @@ resources:
           genie_space:
             name: ${var.genie_space_name}
             space_id: ${var.genie_space_id}
-            permission: CAN_VIEW
+            permission: CAN_RUN
 
 targets:
   default:
@@ -191,8 +191,7 @@ The plugin mounts SSE endpoints under `/api/genie`:
 
 | Error | Cause | Solution |
 |-------|-------|---------|
-| Server reports Genie not configured | Missing `DATABRICKS_GENIE_SPACE_ID` | Set env var in `server/.env` (local) or wire via `app.yaml` (deployed) |
 | `create-space` fails with "Cannot find field" | Wrong `serialized_space` JSON format | Use `{"version":2,"data_sources":{"tables":[{"identifier":"..."}]}}` — export an existing space to verify |
+| `plugin "genie" has no resource with key "..."` | Wrong `--set` flags during scaffold | Always derive resource keys from `databricks apps manifest` |
 | Chat collapses or renders poorly | No explicit height on container | Give the parent a fixed height |
 | Duplicate routes or import confusion | Old local Genie proxy file | Remove it — use `genie` from `@databricks/appkit` |
-| Wrong `--set` flags during scaffold | Guessed plugin resource keys | Always derive from `databricks apps manifest` |

--- a/skills/databricks-apps/references/appkit/overview.md
+++ b/skills/databricks-apps/references/appkit/overview.md
@@ -10,10 +10,12 @@ Before scaffolding, decide which data pattern the app needs:
 |---------|-------------|-------------|
 | **Analytics** (read-only) | Dashboards, charts, KPIs from warehouse | `--features analytics --set analytics.sql-warehouse.id=<ID>` |
 | **Lakebase (OLTP)** (read/write) | CRUD forms, persistent state, user data | `--features lakebase --set lakebase.postgres.branch=<BRANCH> --set lakebase.postgres.database=<DB>` |
-| **Both** | Dashboard + user data or preferences | `--features analytics,lakebase` with all required `--set` flags |
+| **Genie** (NL queries) | Chat interface over Unity Catalog tables | `--features genie --set genie.<resourceKey>.<field>=<value>` (check manifest) |
 | **Model Serving** (ML inference) | Chat, AI features, model predictions | Add `serving_endpoint` resource to `databricks.yml` (or `--features serving` if available in manifest) |
+| **Multiple** | Combine plugins as needed (e.g. dashboard + CRUD, analytics + Genie) | `--features analytics,lakebase,genie,...` with all required `--set` flags per plugin |
 
 See [Lakebase Guide](lakebase.md) for full Lakebase scaffolding and app-code patterns.
+See [Genie Guide](genie.md) for space creation, plugin setup, and frontend components.
 
 ## Workflow
 
@@ -123,6 +125,7 @@ Do not guess paths — run without args first, then pick from the index.
 | Add chart/table components | [Frontend](frontend.md) — component quick reference, anti-patterns |
 | Add API mutation endpoints | [tRPC](trpc.md) — only if you need server-side logic |
 | Use Lakebase for CRUD / persistent state | [Lakebase](lakebase.md) — createLakebasePool, tRPC patterns, schema init |
+| Add Genie chat | [Genie](genie.md) — space creation, plugin setup, frontend components |
 | Call ML model serving endpoints | [Model Serving](model-serving.md) — resource declaration, tRPC query pattern |
 
 ## Critical Rules


### PR DESCRIPTION
## Summary
- Adds Genie integration guide (`references/appkit/genie.md`) covering two use cases: scaffolding a new Genie-powered app from scratch and retrofitting an existing AppKit app
- Supports programmatic Genie space creation from user-provided tables via `databricks genie create-space` CLI (with Python SDK as fallback)
- Updates SKILL.md phase table and overview.md pattern table with Genie entries

This pull request was AI-assisted by Isaac.