### PR TITLE
fix: skills aitools install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Skills for AI coding assistants (Claude Code, Cursor, etc.) that provide Databri
 **For Claude Code:**
 
 ```bash
-databricks experimental aitools skills install
+databricks experimental aitools install
 ```
 
 This installs skills to `~/.claude/skills/` for use with Claude Code.

--- a/skills/databricks-jobs/SKILL.md
+++ b/skills/databricks-jobs/SKILL.md
@@ -44,7 +44,7 @@ Verify: `databricks -v`
 Read the `databricks-core` skill for CLI basics, authentication, and deployment workflow.
 Read the `databricks-jobs` skill for job-specific guidance.
 
-If skills are not available, install them: `databricks experimental aitools skills install`
+If skills are not available, install them: `databricks experimental aitools install`
 ```
 
 ## Project Structure

--- a/skills/databricks-pipelines/SKILL.md
+++ b/skills/databricks-pipelines/SKILL.md
@@ -202,7 +202,7 @@ Verify: `databricks -v`
 Read the `databricks-core` skill for CLI basics, authentication, and deployment workflow.
 Read the `databricks-pipelines` skill for pipeline-specific guidance.
 
-If skills are not available, install them: `databricks experimental aitools skills install`
+If skills are not available, install them: `databricks experimental aitools install`
 ```
 
 ## Pipeline Structure


### PR DESCRIPTION
## Summary

Updates `databricks experimental aitools skills install` to `databricks experimental aitools install` as per https://github.com/databricks/appkit/pull/260