### PR TITLE
Drop experimental flag from the Model Serving skill

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,12 @@
 {
   "version": "2",
-  "updated_at": "2026-04-07T13:25:51Z",
+  "updated_at": "2026-04-14T11:39:36Z",
   "skills": {
     "databricks-apps": {
       "version": "0.1.1",
       "description": "Databricks Apps development and deployment",
       "experimental": false,
-      "updated_at": "2026-04-07T13:17:59Z",
+      "updated_at": "2026-04-14T11:07:19Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -30,7 +30,7 @@
       "version": "0.1.0",
       "description": "Core Databricks skill for CLI, auth, and data exploration",
       "experimental": false,
-      "updated_at": "2026-04-07T13:17:46Z",
+      "updated_at": "2026-04-14T11:07:19Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -45,7 +45,7 @@
       "version": "0.0.0",
       "description": "Declarative Automation Bundles (DABs) for deploying and managing Databricks resources",
       "experimental": false,
-      "updated_at": "2026-04-07T13:17:46Z",
+      "updated_at": "2026-04-14T11:07:19Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -63,7 +63,7 @@
       "version": "0.1.0",
       "description": "Databricks Jobs orchestration and scheduling",
       "experimental": false,
-      "updated_at": "2026-04-07T13:17:46Z",
+      "updated_at": "2026-04-14T11:07:19Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -75,7 +75,7 @@
       "version": "0.1.0",
       "description": "Databricks Lakebase database development",
       "experimental": false,
-      "updated_at": "2026-04-07T13:17:59Z",
+      "updated_at": "2026-04-14T11:07:19Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -86,8 +86,8 @@
     "databricks-model-serving": {
       "version": "0.1.0",
       "description": "Databricks Model Serving endpoint management",
-      "experimental": true,
-      "updated_at": "2026-04-07T13:25:43Z",
+      "experimental": false,
+      "updated_at": "2026-04-14T11:07:19Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -99,7 +99,7 @@
       "version": "0.1.0",
       "description": "Databricks Pipelines (DLT) for ETL and streaming",
       "experimental": false,
-      "updated_at": "2026-04-07T13:17:46Z",
+      "updated_at": "2026-04-14T11:07:19Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",

--- a/scripts/skills.py
+++ b/scripts/skills.py
@@ -38,7 +38,7 @@ SKILL_METADATA = {
     },
     "databricks-model-serving": {
         "description": "Databricks Model Serving endpoint management",
-        "experimental": True,
+        "experimental": False,
     },
     "databricks-pipelines": {
         "description": "Databricks Pipelines (DLT) for ETL and streaming",


### PR DESCRIPTION
## Summary
- Promote `databricks-model-serving` skill from experimental to stable by setting `experimental: false` in skill metadata and regenerating the manifest.

## Test plan
- [x] `python3 scripts/skills.py validate` passes

This pull request was AI-assisted by Isaac.