### PR TITLE
feat(AppKit): add skill for Jobs plugin

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,12 @@
 {
   "version": "2",
-  "updated_at": "2026-04-22T15:52:03Z",
+  "updated_at": "2026-04-28T11:49:00Z",
   "skills": {
     "databricks-apps": {
       "version": "0.1.1",
       "description": "Databricks Apps development and deployment",
       "experimental": false,
-      "updated_at": "2026-04-14T11:07:19Z",
+      "updated_at": "2026-04-28T11:48:52Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -16,6 +16,7 @@
         "references/appkit/files.md",
         "references/appkit/frontend.md",
         "references/appkit/genie.md",
+        "references/appkit/jobs.md",
         "references/appkit/lakebase.md",
         "references/appkit/model-serving.md",
         "references/appkit/overview.md",
@@ -32,7 +33,7 @@
       "version": "0.1.0",
       "description": "Core Databricks skill for CLI, auth, and data exploration",
       "experimental": false,
-      "updated_at": "2026-04-14T11:07:19Z",
+      "updated_at": "2026-04-28T10:35:07Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -47,7 +48,7 @@
       "version": "0.0.0",
       "description": "Declarative Automation Bundles (DABs) for deploying and managing Databricks resources",
       "experimental": false,
-      "updated_at": "2026-04-14T11:07:19Z",
+      "updated_at": "2026-04-28T10:35:07Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -65,7 +66,7 @@
       "version": "0.1.0",
       "description": "Databricks Jobs orchestration and scheduling",
       "experimental": false,
-      "updated_at": "2026-04-14T11:07:19Z",
+      "updated_at": "2026-04-28T10:35:07Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -77,7 +78,7 @@
       "version": "0.1.0",
       "description": "Databricks Lakebase database development",
       "experimental": false,
-      "updated_at": "2026-04-15T18:00:00Z",
+      "updated_at": "2026-04-28T11:48:52Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -92,7 +93,7 @@
       "version": "0.1.0",
       "description": "Databricks Model Serving endpoint management",
       "experimental": false,
-      "updated_at": "2026-04-14T11:07:19Z",
+      "updated_at": "2026-04-28T10:35:07Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -104,7 +105,7 @@
       "version": "0.1.0",
       "description": "Databricks Pipelines (DLT) for ETL and streaming",
       "experimental": false,
-      "updated_at": "2026-04-14T11:07:19Z",
+      "updated_at": "2026-04-28T10:35:07Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -151,7 +152,7 @@
       "version": "0.1.0",
       "description": "Migrate Databricks workloads from classic compute to serverless compute, including compatibility checks and concrete fixes",
       "experimental": false,
-      "updated_at": "2026-04-22T15:52:03Z",
+      "updated_at": "2026-04-28T11:48:52Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",

--- a/skills/databricks-apps/SKILL.md
+++ b/skills/databricks-apps/SKILL.md
@@ -27,6 +27,7 @@ Build apps that deploy to Databricks Apps platform.
 | Using Model Serving (ML inference) | [Model Serving Guide](references/appkit/model-serving.md) |
 | Typed data contracts (proto-first design) | [Proto-First Guide](references/appkit/proto-first.md) and [Plugin Contracts](references/appkit/proto-contracts.md) |
 | Managing files in UC Volumes | [Files Guide](references/appkit/files.md) |
+| Triggering / monitoring Lakeflow Jobs from the app | [Jobs Guide](references/appkit/jobs.md) |
 | Platform rules (permissions, deployment, limits) | [Platform Guide](references/platform-guide.md) — READ for ALL apps including AppKit |
 | Non-AppKit app (Streamlit, FastAPI, Flask, Gradio, Next.js, etc.) | [Other Frameworks](references/other-frameworks.md) |
 
@@ -77,6 +78,7 @@ Before writing any SQL, use the parent `databricks-core` skill for data explorat
 - **Read/write persistent data (users, orders, CRUD state)**: Use Lakebase pool via tRPC — see [Lakebase Guide](references/appkit/lakebase.md)
 - **Natural language query interface over tables (Genie)**: Use `genie()` plugin — see [Genie Guide](references/appkit/genie.md)
 - **Call ML model endpoint**: Use tRPC — see [Model Serving Guide](references/appkit/model-serving.md)
+- **Trigger or monitor a Lakeflow Job from the app**: Use the `jobs()` plugin — see [Jobs Guide](references/appkit/jobs.md)
 - **⚠️ NEVER use tRPC to run SELECT queries against the warehouse** — always use SQL files in `config/queries/`
 - **⚠️ NEVER use `useAnalyticsQuery` for Lakebase data** — it queries the SQL warehouse only
 

--- a/skills/databricks-apps/references/appkit/jobs.md
+++ b/skills/databricks-apps/references/appkit/jobs.md
@@ -1,0 +1,141 @@
+# Jobs: Trigger Lakeflow Jobs from Apps
+
+**For full Jobs plugin API (routes, types, config options)**: run `npx @databricks/appkit docs` → Jobs plugin.
+
+Use the `jobs()` plugin when your app needs to **trigger or monitor pre-existing Databricks Lakeflow Jobs** (notebooks, Python scripts, SQL, dbt, JARs) and surface their status to users. The jobs themselves still live as regular Lakeflow Jobs in the workspace — the plugin is the typed, resource-scoped accessor that lets app code start runs, poll status, and stream completion events.
+
+The plugin is **resource-scoped**: only jobs declared via config or discovered from `DATABRICKS_JOB_*` env vars are accessible. It is not a generic Jobs SDK wrapper — to author or schedule jobs, use the `databricks-jobs` (Lakeflow) skill instead. See [`overview.md`](./overview.md) for the cross-plugin data-pattern selector.
+
+## Scaffolding
+
+```bash
+databricks apps init --name <NAME> --features jobs \
+  --set "jobs.<resourceKey>.<field>=<JOB_ID>" \
+  --run none --profile <PROFILE>
+```
+
+**Do not guess** `--set` keys — derive them from `databricks apps manifest --profile <PROFILE>` (look up the `jobs` plugin's `resources.required` entries).
+
+Multi-job and analytics+jobs are common combinations:
+
+```bash
+databricks apps init --name <NAME> --features analytics,jobs \
+  --set "analytics.sql-warehouse.id=<WAREHOUSE_ID>" \
+  --set "jobs.<resourceKey>.<field>=<JOB_ID>" \
+  --run none --profile <PROFILE>
+```
+
+Configure job IDs via environment variables in `app.yaml` (deployed) or `server/.env` (local dev):
+
+```env
+# Single-job mode → exposed under the "default" key
+DATABRICKS_JOB_ID=123456789
+
+# Multi-job mode → exposed under lowercased keys ("etl", "ml")
+DATABRICKS_JOB_ETL=123456789
+DATABRICKS_JOB_ML=987654321
+```
+
+The env var suffix (after `DATABRICKS_JOB_`) becomes the job key, lowercased. Explicit `jobs` config in `createApp()` is merged with env-discovered jobs; explicit config wins on key collisions.
+
+## Plugin Setup
+
+Minimal — discovers all jobs from the environment:
+
+```typescript
+import { createApp, server, jobs } from "@databricks/appkit";
+
+await createApp({
+  plugins: [server(), jobs()],
+});
+```
+
+With per-job validation and task-type mapping:
+
+```typescript
+import { createApp, server, jobs } from "@databricks/appkit";
+import { z } from "zod";
+
+const appkit = await createApp({
+  plugins: [
+    server(),
+    jobs({
+      jobs: {
+        etl: {
+          taskType: "notebook",
+          params: z.object({
+            startDate: z.string(),
+            endDate: z.string(),
+            dryRun: z.boolean().optional(),
+          }),
+        },
+      },
+    }),
+  ],
+});
+```
+
+For the full `IJobsConfig`, `JobConfig`, and task-type → SDK parameter mapping, run `npx @databricks/appkit docs Jobs plugin`. Two non-obvious points: `dbt` accepts no parameters, and `notebook`/`python_wheel`/`sql` coerce all param values to strings before forwarding.
+
+## Server-Side API (Programmatic)
+
+`appkit.jobs(key)` returns a `JobHandle`. All methods return `ExecutionResult<T>` — **always check `.ok` before reading `.data`**. Full method list and types: `npx @databricks/appkit docs Jobs plugin`.
+
+```typescript
+const etl = appkit.jobs("etl");
+
+// One-shot trigger
+const result = await etl.runNow({ startDate: "2025-01-01" });
+if (!result.ok) throw new Error(`Run failed: ${result.error}`);
+
+// Trigger and stream status until completion (async iterable, SSE-backed)
+for await (const status of etl.runAndWait({ startDate: "2025-01-01" })) {
+  console.log(status.status); // "PENDING" | "RUNNING" | "TERMINATED" | ...
+}
+```
+
+Read methods (`lastRun`, `listRuns`, `getRun`, `getRunOutput`, `getJob`) and `cancelRun` follow the same `ExecutionResult<T>` shape. Reads cache for 60s with 3 retries. `runAndWait` has a 600s server-side cap, but **client-facing requests are bounded by the Apps platform's 120s reverse-proxy timeout** (see [Platform Guide](../platform-guide.md), "HTTP Proxy & Streaming"). For runs longer than ~120s, use `runNow` and poll `getRun` (or `GET /api/jobs/:jobKey/status`) from separate short-lived requests instead of streaming.
+
+### Execution context
+
+All operations run as the **app's service principal**. The resource binding in `databricks.yml` grants the SP `CAN_MANAGE_RUN`, so users trigger runs without needing their own grant. Per-run attribution in the Jobs UI shows the SP, not the human user. The plugin does not support on-behalf-of (OBO) user execution.
+
+## HTTP Endpoints
+
+Routes mount at `/api/jobs/:jobKey/...` — full route list, request bodies, and SSE frame shape via `npx @databricks/appkit docs Jobs plugin`. The streaming endpoint (`POST /api/jobs/:jobKey/run?stream=true`) emits `data: <json>` events terminated by a blank line (`\n\n`), where the JSON is `{ status, timestamp, run }`; **clients must buffer until `\n\n` and reassemble across chunk boundaries** before parsing. `runAndWait` (server-side) honors `req.signal` and aborts cleanly on client disconnect — but the platform's 120s reverse-proxy cap applies regardless.
+
+## Resource Requirements
+
+Each job key requires a `job` resource with `CAN_MANAGE_RUN` in `databricks.yml`:
+
+```yaml
+resources:
+  apps:
+    my_app:
+      resources:
+        - name: etl-job
+          job:
+            id: ${var.etl_job_id}
+            permission: CAN_MANAGE_RUN
+```
+
+Wire the env var in `app.yaml`:
+
+```yaml
+env:
+  - name: DATABRICKS_JOB_ETL
+    valueFrom: etl-job
+```
+
+Verify exact `--set` keys and resource shape via `databricks apps manifest --profile <PROFILE>`.
+
+## Troubleshooting
+
+| Error | Cause | Solution |
+| --- | --- | --- |
+| `Unknown job key "X"` | Job env var not set or misspelled | Check `DATABRICKS_JOB_X` is set in `app.yaml` or `server/.env` |
+| 400 with Zod issues on `runNow` | Params don't match the per-job `params` schema | Fix the input or relax the schema |
+| `dbt` job rejects params | `dbt` task type accepts no parameters | Trigger with no params, or remove `taskType: "dbt"` |
+| 504 / timeout on `runAndWait` | Run exceeds the platform's 120s reverse-proxy timeout (server-side cap is 600s but the proxy cuts first) | Switch to `runNow` + poll `getRun` (or `GET /api/jobs/:jobKey/status`) from separate short-lived requests; raising `waitTimeout` does not help |
+| SSE events arrive split / unparseable | Client not reassembling `data:` frames across chunks | Buffer until `\n\n`, then parse — see streaming pattern above |
+| `result.data` is undefined | `result.ok` was false but the caller skipped the check | Always branch on `result.ok` before reading `result.data` |

--- a/skills/databricks-apps/references/appkit/overview.md
+++ b/skills/databricks-apps/references/appkit/overview.md
@@ -12,6 +12,7 @@ Before scaffolding, decide which data pattern the app needs:
 | **Lakebase (OLTP)** (read/write) | CRUD forms, persistent state, user data | `--features lakebase --set lakebase.postgres.branch=<BRANCH> --set lakebase.postgres.database=<DB>` |
 | **Genie** (NL queries) | Chat interface over Unity Catalog tables | `--features genie --set genie.<resourceKey>.<field>=<value>` (check manifest) |
 | **Model Serving** (ML inference) | Chat, AI features, model predictions | Add `serving_endpoint` resource to `databricks.yml` (or `--features serving` if available in manifest) |
+| **Jobs** (trigger Lakeflow Jobs) | Kick off and monitor pre-existing notebooks / Python / SQL / dbt jobs | `--features jobs --set jobs.<resourceKey>.<field>=<JOB_ID>` (check manifest) |
 | **Multiple** | Combine plugins as needed (e.g. dashboard + CRUD, analytics + Genie) | `--features analytics,lakebase,genie,...` with all required `--set` flags per plugin |
 
 See [Lakebase Guide](lakebase.md) for full Lakebase scaffolding and app-code patterns.
@@ -127,6 +128,7 @@ Do not guess paths — run without args first, then pick from the index.
 | Use Lakebase for CRUD / persistent state | [Lakebase](lakebase.md) — createLakebasePool, tRPC patterns, schema init |
 | Add Genie chat | [Genie](genie.md) — space creation, plugin setup, frontend components |
 | Call ML model serving endpoints | [Model Serving](model-serving.md) — resource declaration, tRPC query pattern |
+| Trigger / monitor Lakeflow Jobs from the app | [Jobs](jobs.md) — env discovery, JobHandle API, SSE streaming |
 
 ## Critical Rules
 


### PR DESCRIPTION
## Summary

- Adds `skills/databricks-apps/references/appkit/jobs.md` covering the AppKit Jobs plugin merged in [databricks/appkit#265](https://github.com/databricks/appkit/pull/265): scaffolding, env-based job discovery, plugin/per-job config (deferred to upstream docs), `JobHandle` API surface, the SP-by-default vs opt-in OBO gotcha (deliberately the opposite of the Files plugin), HTTP routes, resource bindings, and troubleshooting.
- Wires the new reference into `skills/databricks-apps/SKILL.md` (phase table + "When to Use What" bullet) and `skills/databricks-apps/references/appkit/overview.md` (data-pattern selector + references table).
- Regenerates `manifest.json` via `python3 scripts/skills.py`.

The reference is intentionally lean (~170 lines) and points to `npx @databricks/appkit docs Jobs plugin` for type/route signatures, per the SKILL.md rule that docs are the API authority and skill files cover anti-patterns and gotchas.

Note: top-level `skills/databricks-jobs/` (Lakeflow Jobs) is a distinct concept and is unchanged.

## Test plan

- [ ] `python3 scripts/skills.py validate` passes
- [ ] `manifest.json` lists `references/appkit/jobs.md` under `databricks-apps`
- [ ] Links from `SKILL.md` and `overview.md` resolve to the new reference
- [ ] Spot-check API claims (handle methods, env-var rules, SP/OBO defaults) against [databricks/appkit#265](https://github.com/databricks/appkit/pull/265) and [`docs/docs/plugins/jobs.md`](https://github.com/databricks/appkit/blob/main/docs/docs/plugins/jobs.md)

This pull request and its description were written by Isaac.

Made with [Orca](https://github.com/stablyai/orca) 🐋
