### PR TITLE
apps+lakebase: declare-resource as primary path, SQL grant as fallback, psql wrapper

### DIFF
--- a/skills/databricks-apps/SKILL.md
+++ b/skills/databricks-apps/SKILL.md
@@ -156,6 +156,8 @@ npx @databricks/appkit docs ./docs/plugins/analytics.md  # example: specific doc
 
 **DO NOT guess** plugin names, resource keys, or property names — always derive them from `databricks apps manifest` output. Example: if the manifest shows plugin `analytics` with a required resource `resourceKey: "sql-warehouse"` and `fields: { "id": ... }`, include `--set analytics.sql-warehouse.id=<ID>`.
 
+3. **Verify resources after init.** Open `databricks.yml` and confirm `resources.apps.<app>.resources` contains a block for **every** required resource from every plugin you included (manifest's `resources.required`). For example, `--features analytics,genie,lakebase` must produce three blocks: `sql_warehouse`, `genie_space`, **and** `database`. A missing resource means the Apps platform won't grant the SP access to that resource at deploy time, and the app will fail at runtime — typically with `password authentication failed for user '<SP_UUID>'` (Lakebase), `403` from the SQL warehouse, or `CAN_RUN denied` (Genie). Fix by re-running `init` with the missing `--set` flag, not by hand-editing the YAML — the YAML is a generated artifact and your edit will be lost the next time someone re-scaffolds.
+
 **READ [AppKit Overview](references/appkit/overview.md)** for project structure, workflow, and pre-implementation checklist.
 
 **Genie Agent Workflow** — when the user wants a Genie-powered app, do **not** start by asking for a Genie Space ID. Instead:

--- a/skills/databricks-apps/references/appkit/lakebase.md
+++ b/skills/databricks-apps/references/appkit/lakebase.md
@@ -263,10 +263,17 @@ Then create `server/.env` with the values from the endpoint response:
 PGHOST=<host from endpoint>
 PGPORT=5432
 PGDATABASE=<your database name>
-PGUSER=<your service principal client ID>
+PGUSER=<see note below>
 PGSSLMODE=require
 LAKEBASE_ENDPOINT=projects/<PROJECT_ID>/branches/<BRANCH_ID>/endpoints/<ENDPOINT_ID>
 ```
+
+> **`PGUSER` must match the credentials the AppKit dev server uses.** The Postgres role in `PGUSER` has to correspond to the principal that produced `PGPASSWORD` (the OAuth token).
+>
+> - **Default (personal Databricks profile):** AppKit's local server authenticates as your Databricks user, so `PGUSER` is your Databricks username/email. Tables created locally will be owned by your user, not the SP — that's why the deploy-first workflow exists.
+> - **Testing the deployed flow locally:** export `DATABRICKS_CLIENT_ID=<SP_CLIENT_ID>` and `DATABRICKS_CLIENT_SECRET=...` so the dev server authenticates as the SP. Then `PGUSER=<SP_CLIENT_ID>` matches.
+>
+> If `PGUSER` and the OAuth token disagree, Postgres rejects the connection with `password authentication failed for user '<UUID>'`.
 
 Load `server/.env` in your dev server (e.g. via `dotenv` or `node --env-file=server/.env`). Never commit `.env` files — add `server/.env` to `.gitignore`.
 

--- a/skills/databricks-apps/references/appkit/lakebase.md
+++ b/skills/databricks-apps/references/appkit/lakebase.md
@@ -246,7 +246,7 @@ Check the response for the `active_deployment` field. If it exists with `status.
 
 If you skip this step, the Service Principal won't own the database schema. You'll create schemas under your credentials that the SP **cannot access** after deployment. See **`databricks-lakebase`** skill's **Schema Permissions for Deployed Apps** for the full workflow and recovery steps.
 
-> **First deploy with `lakebase`:** the SP also needs a Postgres role created via `databricks_create_role()` before it can connect at all — otherwise the deployed app fails with `password authentication failed for user '<UUID>'`. Run the **Grant app SP for AppKit / CRUD apps** SQL block from the **`databricks-lakebase`** skill once after the first deploy, then restart the app.
+> **First deploy with `lakebase`:** confirm `databricks.yml` declares a `database` resource on the app (alongside `sql_warehouse`, `genie_space`, etc.). Apps platform auto-creates the SP's Postgres role only when the database is attached as an app resource — without it, the deployed app fails with `password authentication failed for user '<UUID>'`. If the resource is missing, re-run `databricks apps init` with `--set lakebase.postgres.branch=...` and `--set lakebase.postgres.database=...`; if you can't (shared Lakebase, custom permissions), use the manual SQL fallback in the **`databricks-lakebase`** skill's **Grant app SP for AppKit / CRUD apps** section.
 
 The Lakebase env vars (`PGHOST`, `PGDATABASE`, etc.) are auto-set only when deployed. For local development, get the connection details from your endpoint and set them manually:
 
@@ -278,6 +278,6 @@ Load `server/.env` in your dev server (e.g. via `dotenv` or `node --env-file=ser
 | `permission denied for schema <name>` | Schema was created by another role (e.g. you ran locally before deploying) | **Ask the user before dropping** — `DROP SCHEMA` deletes all data. See **`databricks-lakebase`** skill's **Schema Permissions for Deployed Apps** for options |
 | Works locally but `permission denied` after deploy | Local credentials created the schema; the SP can't access schemas it doesn't own | **Ask the user before dropping** — warn about data loss, then deploy first. See **`databricks-lakebase`** skill's **Schema Permissions for Deployed Apps** for options |
 | `connection refused` | Pool not connected or wrong env vars | Check `PGHOST`, `PGPORT`, `LAKEBASE_ENDPOINT` are set |
-| `password authentication failed for user '<UUID>'` | SP has no Postgres role on the branch (first deploy with `lakebase` plugin) | Run the **Grant app SP for AppKit / CRUD apps** SQL block from the **`databricks-lakebase`** skill, then restart the app |
+| `password authentication failed for user '<UUID>'` | App's `databricks.yml` is missing a `database` resource — Apps platform never auto-created the SP's Postgres role on attach | Add the missing `database` resource (re-run `databricks apps init` with `--set lakebase.postgres.branch=...` and `--set lakebase.postgres.database=...`), redeploy. Manual SQL fallback: see **`databricks-lakebase`**'s **Grant app SP for AppKit / CRUD apps** |
 | `relation "X" does not exist` | Tables not initialized | Run `CREATE TABLE IF NOT EXISTS` at startup |
 | App builds but pool fails at runtime | Env vars not set locally | Set vars in `server/.env` — see Local Development above |

--- a/skills/databricks-apps/references/appkit/lakebase.md
+++ b/skills/databricks-apps/references/appkit/lakebase.md
@@ -246,6 +246,8 @@ Check the response for the `active_deployment` field. If it exists with `status.
 
 If you skip this step, the Service Principal won't own the database schema. You'll create schemas under your credentials that the SP **cannot access** after deployment. See **`databricks-lakebase`** skill's **Schema Permissions for Deployed Apps** for the full workflow and recovery steps.
 
+> **First deploy with `lakebase`:** the SP also needs a Postgres role created via `databricks_create_role()` before it can connect at all — otherwise the deployed app fails with `password authentication failed for user '<UUID>'`. Run the **Grant app SP for AppKit / CRUD apps** SQL block from the **`databricks-lakebase`** skill once after the first deploy, then restart the app.
+
 The Lakebase env vars (`PGHOST`, `PGDATABASE`, etc.) are auto-set only when deployed. For local development, get the connection details from your endpoint and set them manually:
 
 ```bash
@@ -276,5 +278,6 @@ Load `server/.env` in your dev server (e.g. via `dotenv` or `node --env-file=ser
 | `permission denied for schema <name>` | Schema was created by another role (e.g. you ran locally before deploying) | **Ask the user before dropping** — `DROP SCHEMA` deletes all data. See **`databricks-lakebase`** skill's **Schema Permissions for Deployed Apps** for options |
 | Works locally but `permission denied` after deploy | Local credentials created the schema; the SP can't access schemas it doesn't own | **Ask the user before dropping** — warn about data loss, then deploy first. See **`databricks-lakebase`** skill's **Schema Permissions for Deployed Apps** for options |
 | `connection refused` | Pool not connected or wrong env vars | Check `PGHOST`, `PGPORT`, `LAKEBASE_ENDPOINT` are set |
+| `password authentication failed for user '<UUID>'` | SP has no Postgres role on the branch (first deploy with `lakebase` plugin) | Run the **Grant app SP for AppKit / CRUD apps** SQL block from the **`databricks-lakebase`** skill, then restart the app |
 | `relation "X" does not exist` | Tables not initialized | Run `CREATE TABLE IF NOT EXISTS` at startup |
 | App builds but pool fails at runtime | Env vars not set locally | Set vars in `server/.env` — see Local Development above |

--- a/skills/databricks-lakebase/SKILL.md
+++ b/skills/databricks-lakebase/SKILL.md
@@ -211,22 +211,19 @@ databricks postgres create-endpoint projects/<PROJECT_ID>/branches/<BRANCH_ID> <
 ```
 
 **Run SQL against Lakebase** (GRANT, CREATE INDEX, etc.):
+
+Preferred — `databricks psql` wrapper handles auth, host discovery, and TLS in one call:
 ```bash
-# 1. Get endpoint host
-databricks postgres get-endpoint projects/<PROJECT_ID>/branches/<BRANCH_ID>/endpoints/<ENDPOINT_ID> --profile <PROFILE>
+databricks psql --project <PROJECT_ID> --branch <BRANCH_ID> --endpoint <ENDPOINT_ID> \
+  -- -d databricks_postgres -f path/to/script.sql --profile <PROFILE>
 
-# 2. Generate OAuth token
-databricks postgres generate-database-credential \
-  projects/<PROJECT_ID>/branches/<BRANCH_ID>/endpoints/<ENDPOINT_ID> \
-  --profile <PROFILE>
-
-# 3. Connect (use token from step 2 as password, host from step 1)
-PGPASSWORD='<TOKEN>' psql "host=<HOST> user=<USERNAME> dbname=databricks_postgres sslmode=require"
+# One-off statement
+databricks psql --project <PROJECT_ID> -- -d databricks_postgres -c "SELECT 1" --profile <PROFILE>
 ```
 
-> **Note:** `generate-database-credential` requires the **endpoint** resource path (`.../endpoints/<ENDPOINT_ID>`), not a database or branch path.
+Requires `psql` on `PATH` (the wrapper shells out to it). Branch/endpoint default to the only one when there is just one.
 
-**Scriptable version** (single copy-paste, useful for agents):
+Manual form (use when the wrapper isn't available):
 ```bash
 EP=projects/<PROJECT_ID>/branches/<BRANCH_ID>/endpoints/<ENDPOINT_ID>
 # get-endpoint JSON shape: {"status": {"hosts": {"host": "<HOSTNAME>"}, ...}, ...}
@@ -237,13 +234,35 @@ TOKEN=$(databricks postgres generate-database-credential $EP --profile <PROFILE>
 PGPASSWORD="$TOKEN" psql "host=$HOST user=<USERNAME> dbname=databricks_postgres sslmode=require"
 ```
 
-**Grant app SP access to synced tables** (run as project owner after sync is ONLINE and app is deployed):
+> **Note:** `generate-database-credential` requires the **endpoint** resource path (`.../endpoints/<ENDPOINT_ID>`), not a database or branch path.
+
+**Grant app SP access to synced tables** (read-only) — run as project owner after sync is ONLINE and app is deployed:
 ```sql
 GRANT USAGE ON SCHEMA public TO "<SP_CLIENT_ID>";
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO "<SP_CLIENT_ID>";
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO "<SP_CLIENT_ID>";
 ```
-For least-privilege, consider syncing into a dedicated schema instead of `public` so the grant is scoped to synced data only.
+
+**Grant app SP for AppKit / CRUD apps** (full DML) — run **once after the first deploy** of any app whose `lakebase` plugin owns its own schema. Without this the app fails to connect with `password authentication failed for user '<SP_CLIENT_ID>'` because the SP has no Postgres role yet:
+```sql
+CREATE EXTENSION IF NOT EXISTS databricks_auth;
+
+DO $$
+DECLARE
+  sp TEXT := '<SP_CLIENT_ID>';   -- from `databricks apps get <APP> -o json | jq -r .service_principal_client_id`
+BEGIN
+  PERFORM databricks_create_role(sp, 'SERVICE_PRINCIPAL');
+  EXECUTE format('GRANT CONNECT ON DATABASE "databricks_postgres" TO %I', sp);
+  EXECUTE format('GRANT ALL ON SCHEMA public TO %I', sp);
+  EXECUTE format('GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO %I', sp);
+  EXECUTE format('GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO %I', sp);
+  EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO %I', sp);
+  EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO %I', sp);
+END $$;
+```
+Pipe through `databricks psql` (above) — no UI step required. The grant is idempotent; re-running is safe.
+
+> **Footgun:** `databricks postgres create-role` (the CLI) cannot create the SP role — every payload shape returns `Field 'role' is required and must contain at least one subfield with a non-default value`. Use the `databricks_create_role()` SQL function above instead.
 
 Get SP client ID: `databricks apps get <APP_NAME> --profile <PROFILE>` → `service_principal_client_id` field.
 
@@ -257,6 +276,8 @@ Get SP client ID: `databricks apps get <APP_NAME> --profile <PROFILE>` → `serv
 | `cannot configure default credentials` | Use `--profile` flag or authenticate first |
 | `PERMISSION_DENIED` | Check workspace permissions |
 | `permission denied for schema` | Schema owned by another role. Deploy app first so SP creates/owns it |
+| `password authentication failed for user '<UUID>'` (deployed app) | SP has no Postgres role on the branch yet. Run the **Grant app SP for AppKit / CRUD apps** SQL block above, then restart the app |
+| `Field 'role' is required` from `databricks postgres create-role` | The CLI cannot create SP roles. Use the `databricks_create_role()` SQL function over `databricks psql` instead — see **Grant app SP for AppKit / CRUD apps** |
 | Protected branch won't delete | `update-branch` to set `spec.is_protected` to `false` first |
 | Long-running operation timeout | Use `--no-wait` and poll with `get-operation` |
 | Token expired during long query | Tokens expire after 1 hour; implement refresh (see [connectivity.md](references/connectivity.md)) |

--- a/skills/databricks-lakebase/SKILL.md
+++ b/skills/databricks-lakebase/SKILL.md
@@ -243,7 +243,19 @@ GRANT SELECT ON ALL TABLES IN SCHEMA public TO "<SP_CLIENT_ID>";
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO "<SP_CLIENT_ID>";
 ```
 
-**Grant app SP for AppKit / CRUD apps** (full DML) — run **once after the first deploy** of any app whose `lakebase` plugin owns its own schema. Without this the app fails to connect with `password authentication failed for user '<SP_CLIENT_ID>'` because the SP has no Postgres role yet:
+**Grant app SP for AppKit / CRUD apps** (full DML) — run **once after the first deploy** of any app whose `lakebase` plugin owns its own schema. Without this the app fails to connect with `password authentication failed for user '<SP_CLIENT_ID>'` because the SP has no Postgres role yet.
+
+Two steps: create the SP's Postgres role, then grant it DML.
+
+Step 1 — create the role. Either via CLI:
+```bash
+databricks postgres create-role projects/<PROJECT_ID>/branches/<BRANCH_ID> \
+  --role-id <SP_CLIENT_ID> \
+  --json '{"spec":{"identity_type":"SERVICE_PRINCIPAL","postgres_role":"<SP_CLIENT_ID>","auth_method":"LAKEBASE_OAUTH_V1","membership_roles":["DATABRICKS_SUPERUSER"]}}' \
+  --profile <PROFILE>
+```
+
+Or, equivalently, as the first statement in the SQL block below — `databricks_create_role()` does the same thing, lets you bundle role creation and grants into one `psql` round-trip, and is the form the AppKit Lakebase docs use:
 ```sql
 CREATE EXTENSION IF NOT EXISTS databricks_auth;
 
@@ -260,9 +272,9 @@ BEGIN
   EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO %I', sp);
 END $$;
 ```
-Pipe through `databricks psql` (above) — no UI step required. The grant is idempotent; re-running is safe.
+Pipe through `databricks psql` (above) — no UI step required. Both forms are idempotent; re-running is safe.
 
-> **Footgun:** `databricks postgres create-role` (the CLI) cannot create the SP role — every payload shape returns `Field 'role' is required and must contain at least one subfield with a non-default value`. Use the `databricks_create_role()` SQL function above instead.
+> **CLI body shape.** `databricks postgres create-role`'s `--json` flag binds to the inner `Role` object — fields go directly under `spec`, **not** wrapped in `{"role": ...}`. The error `Field 'role' is required and must contain at least one subfield with a non-default value` means the inner Role had no recognized fields (often because someone wrapped the body, which the CLI strips with `Warning: unknown field: role` and ships an empty body). The CLI also doesn't yet expose convenience flags like `--spec.identity-type` ([cmd/workspace/postgres/postgres.go](https://github.com/databricks/cli/blob/main/cmd/workspace/postgres/postgres.go) marks `spec` as TODO), so you must hand-craft the JSON.
 
 Get SP client ID: `databricks apps get <APP_NAME> --profile <PROFILE>` → `service_principal_client_id` field.
 
@@ -277,7 +289,7 @@ Get SP client ID: `databricks apps get <APP_NAME> --profile <PROFILE>` → `serv
 | `PERMISSION_DENIED` | Check workspace permissions |
 | `permission denied for schema` | Schema owned by another role. Deploy app first so SP creates/owns it |
 | `password authentication failed for user '<UUID>'` (deployed app) | SP has no Postgres role on the branch yet. Run the **Grant app SP for AppKit / CRUD apps** SQL block above, then restart the app |
-| `Field 'role' is required` from `databricks postgres create-role` | The CLI cannot create SP roles. Use the `databricks_create_role()` SQL function over `databricks psql` instead — see **Grant app SP for AppKit / CRUD apps** |
+| `Field 'role' is required` from `databricks postgres create-role` | `--json` binds to the inner `Role`. Pass fields directly under `spec` (no `{"role": ...}` wrapper). See the CLI body-shape note in **Grant app SP for AppKit / CRUD apps** |
 | Protected branch won't delete | `update-branch` to set `spec.is_protected` to `false` first |
 | Long-running operation timeout | Use `--no-wait` and poll with `get-operation` |
 | Token expired during long query | Tokens expire after 1 hour; implement refresh (see [connectivity.md](references/connectivity.md)) |

--- a/skills/databricks-lakebase/SKILL.md
+++ b/skills/databricks-lakebase/SKILL.md
@@ -214,12 +214,14 @@ databricks postgres create-endpoint projects/<PROJECT_ID>/branches/<BRANCH_ID> <
 
 Preferred — `databricks psql` wrapper handles auth, host discovery, and TLS in one call:
 ```bash
-databricks psql --project <PROJECT_ID> --branch <BRANCH_ID> --endpoint <ENDPOINT_ID> \
-  -- -d databricks_postgres -f path/to/script.sql --profile <PROFILE>
+databricks psql --profile <PROFILE> --project <PROJECT_ID> --branch <BRANCH_ID> --endpoint <ENDPOINT_ID> \
+  -- -d databricks_postgres -f path/to/script.sql
 
 # One-off statement
-databricks psql --project <PROJECT_ID> -- -d databricks_postgres -c "SELECT 1" --profile <PROFILE>
+databricks psql --profile <PROFILE> --project <PROJECT_ID> -- -d databricks_postgres -c "SELECT 1"
 ```
+
+> **`--profile` placement.** All `databricks` flags (including `--profile`) MUST come before the `--` separator. Anything after `--` is forwarded verbatim to `psql`, which doesn't understand `--profile` and will exit with `psql: error: unrecognized option`.
 
 Requires `psql` on `PATH` (the wrapper shells out to it). Branch/endpoint default to the only one when there is just one.
 
@@ -242,6 +244,8 @@ GRANT USAGE ON SCHEMA public TO "<SP_CLIENT_ID>";
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO "<SP_CLIENT_ID>";
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO "<SP_CLIENT_ID>";
 ```
+
+> **Default privileges caveat.** `ALTER DEFAULT PRIVILEGES` without `FOR ROLE` only applies to tables created by the role running this statement. If sync pipelines create new tables under a different role, re-run `GRANT SELECT ON ALL TABLES IN SCHEMA public TO "<SP_CLIENT_ID>"` after each new table appears, or add `FOR ROLE <pipeline_role>` once you know which role the sync runs as.
 
 **Grant app SP for AppKit / CRUD apps** (full DML).
 
@@ -272,9 +276,11 @@ The role-creation step alone has a CLI form too (useful when granting privileges
 ```bash
 databricks postgres create-role projects/<PROJECT_ID>/branches/<BRANCH_ID> \
   --role-id <SP_CLIENT_ID> \
-  --json '{"spec":{"identity_type":"SERVICE_PRINCIPAL","postgres_role":"<SP_CLIENT_ID>","auth_method":"LAKEBASE_OAUTH_V1","membership_roles":["DATABRICKS_SUPERUSER"]}}' \
+  --json '{"spec":{"identity_type":"SERVICE_PRINCIPAL","postgres_role":"<SP_CLIENT_ID>","auth_method":"LAKEBASE_OAUTH_V1"}}' \
   --profile <PROFILE>
 ```
+
+> **Least privilege.** The example creates the role with default privileges only — grant database/schema/table access via the explicit `GRANT` statements above. Don't add `membership_roles: ["DATABRICKS_SUPERUSER"]` for an app SP unless broad administrative access is intentional; superuser membership lets the app role read every Lakebase database, not just its own.
 
 > **CLI body shape.** `databricks postgres create-role`'s `--json` flag binds to the inner `Role` object — fields go directly under `spec`, **not** wrapped in `{"role": ...}`. The error `Field 'role' is required and must contain at least one subfield with a non-default value` means the inner Role had no recognized fields (often because someone wrapped the body, which the CLI strips with `Warning: unknown field: role` and ships an empty body). The CLI also doesn't yet expose convenience flags like `--spec.identity-type` ([cmd/workspace/postgres/postgres.go](https://github.com/databricks/cli/blob/main/cmd/workspace/postgres/postgres.go) marks `spec` as TODO), so you must hand-craft the JSON.
 

--- a/skills/databricks-lakebase/SKILL.md
+++ b/skills/databricks-lakebase/SKILL.md
@@ -243,19 +243,13 @@ GRANT SELECT ON ALL TABLES IN SCHEMA public TO "<SP_CLIENT_ID>";
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO "<SP_CLIENT_ID>";
 ```
 
-**Grant app SP for AppKit / CRUD apps** (full DML) — run **once after the first deploy** of any app whose `lakebase` plugin owns its own schema. Without this the app fails to connect with `password authentication failed for user '<SP_CLIENT_ID>'` because the SP has no Postgres role yet.
+**Grant app SP for AppKit / CRUD apps** (full DML).
 
-Two steps: create the SP's Postgres role, then grant it DML.
+> **First check: is the Lakebase declared as an app resource?** When the Apps platform attaches a `database` resource (declared in the app's `databricks.yml` under `resources.apps.<app>.resources`) to an app on deploy, it auto-creates the SP's Postgres role with `CAN_CONNECT_AND_CREATE`. If the SP is failing to connect with `password authentication failed for user '<SP_CLIENT_ID>'`, the most likely cause is a missing `database` resource — fix that first, redeploy, and the auto-grant fires. See the `databricks-apps` skill (Scaffolding) for verifying every required plugin resource is declared.
+>
+> The SQL block below is the **fallback** for cases the resource form doesn't cover: granting access to an existing Lakebase the app spec doesn't own (shared across apps, pre-existing schema with custom permissions, post-hoc grants for additional tables/sequences).
 
-Step 1 — create the role. Either via CLI:
-```bash
-databricks postgres create-role projects/<PROJECT_ID>/branches/<BRANCH_ID> \
-  --role-id <SP_CLIENT_ID> \
-  --json '{"spec":{"identity_type":"SERVICE_PRINCIPAL","postgres_role":"<SP_CLIENT_ID>","auth_method":"LAKEBASE_OAUTH_V1","membership_roles":["DATABRICKS_SUPERUSER"]}}' \
-  --profile <PROFILE>
-```
-
-Or, equivalently, as the first statement in the SQL block below — `databricks_create_role()` does the same thing, lets you bundle role creation and grants into one `psql` round-trip, and is the form the AppKit Lakebase docs use:
+Manual fallback — create the role and grant DML, in one psql round-trip:
 ```sql
 CREATE EXTENSION IF NOT EXISTS databricks_auth;
 
@@ -272,7 +266,15 @@ BEGIN
   EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO %I', sp);
 END $$;
 ```
-Pipe through `databricks psql` (above) — no UI step required. Both forms are idempotent; re-running is safe.
+Pipe through `databricks psql` (above). The block is idempotent; re-running is safe.
+
+The role-creation step alone has a CLI form too (useful when granting privileges separately):
+```bash
+databricks postgres create-role projects/<PROJECT_ID>/branches/<BRANCH_ID> \
+  --role-id <SP_CLIENT_ID> \
+  --json '{"spec":{"identity_type":"SERVICE_PRINCIPAL","postgres_role":"<SP_CLIENT_ID>","auth_method":"LAKEBASE_OAUTH_V1","membership_roles":["DATABRICKS_SUPERUSER"]}}' \
+  --profile <PROFILE>
+```
 
 > **CLI body shape.** `databricks postgres create-role`'s `--json` flag binds to the inner `Role` object — fields go directly under `spec`, **not** wrapped in `{"role": ...}`. The error `Field 'role' is required and must contain at least one subfield with a non-default value` means the inner Role had no recognized fields (often because someone wrapped the body, which the CLI strips with `Warning: unknown field: role` and ships an empty body). The CLI also doesn't yet expose convenience flags like `--spec.identity-type` ([cmd/workspace/postgres/postgres.go](https://github.com/databricks/cli/blob/main/cmd/workspace/postgres/postgres.go) marks `spec` as TODO), so you must hand-craft the JSON.
 

--- a/skills/databricks-lakebase/references/connectivity.md
+++ b/skills/databricks-lakebase/references/connectivity.md
@@ -140,6 +140,42 @@ For production apps, combine with Pattern 2's token refresh loop and SQLAlchemy 
 - **Handle scale-to-zero reconnection** — first connection after idle may take ~100ms; implement retry
 - **psycopg2 or psycopg3** — both work; psycopg3 recommended for new development (better async, pooling)
 
+## DNS Resolution (macOS)
+
+Python's `socket.getaddrinfo()` can fail with long Lakebase hostnames on macOS. Workaround: resolve via `dig`, then pass the IP through `hostaddr` while keeping `host` for TLS SNI.
+
+```bash
+# Resolve the Lakebase hostname to an IP
+dig +short <ENDPOINT_HOST>
+```
+
+```python
+import subprocess
+
+def resolve_host(hostname: str) -> str:
+    try:
+        result = subprocess.run(
+            ["dig", "+short", hostname], capture_output=True, text=True, check=False
+        )
+    except FileNotFoundError as e:
+        raise RuntimeError("'dig' is not installed; install it (e.g. `apt-get install dnsutils`) or use socket.getaddrinfo() instead") from e
+    lines = result.stdout.strip().splitlines()
+    if not lines:
+        raise RuntimeError(f"DNS resolution failed for {hostname}")
+    return lines[0]
+
+ip = resolve_host(endpoint_host)
+
+conn = psycopg.connect(
+    host=endpoint_host,      # kept for TLS SNI verification
+    hostaddr=ip,             # bypasses getaddrinfo()
+    dbname="databricks_postgres",
+    user=username,
+    password=token,
+    sslmode="require",
+)
+```
+
 ## Data API
 
 PostgREST-compatible HTTP API for CRUD operations on Postgres tables. **Autoscaling only.**


### PR DESCRIPTION
## Summary

Stacks on top of #56. Three related fixes for what an agent should do when an AppKit Lakebase app fails on first deploy with `password authentication failed for user '<SP_UUID>'`.

The original framing of this PR (manual `databricks_create_role()` SQL as the standard step) was wrong — it was reflecting a workaround for *my* setup gap, not the platform's intended path. Pawel pointed out that the Apps platform auto-creates the SP's Postgres role at attach time **when the app declares a `database` resource** (via `--set lakebase.postgres.branch=...` and `--set lakebase.postgres.database=...` at `apps init`, which materializes as a `database:` block in the app's `resources:` in `databricks.yml`). The auth-failed error happens when that resource is missing — the platform never knows the app needs Lakebase access. The fix is to add the resource and redeploy; manual SQL is only needed when the resource form isn't an option (shared Lakebase, custom permissions, post-hoc grants).

The PR has been reframed accordingly. Changes:

**`skills/databricks-apps/SKILL.md`** — generic rule, not lakebase-specific:
- New Step 3 in the scaffolding workflow: after `databricks apps init`, verify `databricks.yml` declares every required resource from every plugin in the manifest. Same shape of error appears for missing `sql_warehouse` (403) and missing `genie_space` (CAN_RUN denied), not just `database` — so this rule belongs in the apps skill, not the lakebase one.

**`skills/databricks-apps/references/appkit/lakebase.md`** — cross-reference:
- Prerequisites callout and troubleshooting row both flipped: declare the `database` resource (re-run `apps init` with the right `--set` flags) is the primary fix; manual SQL is the fallback for shared/pre-existing Lakebases.

**`skills/databricks-lakebase/SKILL.md`** — what's still useful here:
- `databricks psql --project … -- -d databricks_postgres -f script.sql` recipe (one command vs the existing 5-line `generate-database-credential` + `PGPASSWORD` form). Useful in its own right.
- "Grant app SP for AppKit / CRUD apps" SQL block, now clearly marked as fallback to the resource-declaration path.
- Working `databricks postgres create-role` CLI form, with body-shape note (`--json '{"spec": {...}}'`, no `{"role": ...}` wrapper). The CLI body-shape gap is being addressed separately at databricks/cli#5110.
- Two troubleshooting rows: `password authentication failed for user '<UUID>'` (now points at missing-resource as the primary cause) and the `Field 'role' is required` CLI error (explains the wrapping confusion).

## Test plan
- [x] `python3.12 scripts/skills.py validate` passes
- [x] Reproduced the original failure on `e2-dogfood`: AppKit app with no `database` resource → SP fails with `password authentication failed`. Adding the resource via `databricks apps init --set lakebase.postgres.branch=... --set lakebase.postgres.database=...` and redeploying produced an auto-created SP role and the app started clean. The fallback SQL path is also tested independently.
- [ ] Reviewer confirms the Apps platform auto-grant behavior is the intended path documented elsewhere (Pawel's claim, which matches my repro).

This pull request and its description were written by Isaac.