### PR TITLE
docs: track aitools rename to top-level command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Skills for AI coding assistants (Claude Code, Cursor, etc.) that provide Databri
 ## Installation
 
 ```bash
-databricks experimental aitools install
+databricks aitools install
 ```
 
 This auto-detects your coding agent(s) and installs the stable skills to the

--- a/manifest.json
+++ b/manifest.json
@@ -104,7 +104,7 @@
       ]
     },
     "databricks-pipelines": {
-      "version": "0.1.0",
+      "version": "0.1.1",
       "description": "Databricks Spark Declarative Pipelines (SDP) for ETL and streaming",
       "repo_dir": "skills",
       "files": [

--- a/skills/databricks-jobs/SKILL.md
+++ b/skills/databricks-jobs/SKILL.md
@@ -53,7 +53,7 @@ Verify: `databricks -v`
 Read the `databricks-core` skill for CLI basics, authentication, and deployment workflow.
 Read the `databricks-jobs` skill for job-specific guidance.
 
-If skills are not available, install them: `databricks experimental aitools install`
+If skills are not available, install them: `databricks aitools install`
 ```
 
 ## Project Structure

--- a/skills/databricks-jobs/SKILL.md
+++ b/skills/databricks-jobs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: databricks-jobs
 description: Develop and deploy Lakeflow Jobs on Databricks via DABs, Python SDK, or the CLI. Use when creating data engineering jobs with notebooks, Python wheels, SQL, dbt, or pipelines. Invoke BEFORE starting implementation.
-compatibility: Requires databricks CLI (>= v0.292.0)
+compatibility: Requires databricks CLI (>= v1.0.0)
 metadata:
   version: "0.2.0"
 parent: databricks-core

--- a/skills/databricks-pipelines/SKILL.md
+++ b/skills/databricks-pipelines/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: databricks-pipelines
 description: Develop Lakeflow Spark Declarative Pipelines (formerly Delta Live Tables) on Databricks. Use when building batch or streaming data pipelines with Python or SQL. Invoke BEFORE starting implementation.
-compatibility: Requires databricks CLI (>= v0.292.0)
+compatibility: Requires databricks CLI (>= v1.0.0)
 metadata:
-  version: "0.1.0"
+  version: "0.1.1"
 parent: databricks-core
 ---
 

--- a/skills/databricks-pipelines/SKILL.md
+++ b/skills/databricks-pipelines/SKILL.md
@@ -202,7 +202,7 @@ Verify: `databricks -v`
 Read the `databricks-core` skill for CLI basics, authentication, and deployment workflow.
 Read the `databricks-pipelines` skill for pipeline-specific guidance.
 
-If skills are not available, install them: `databricks experimental aitools install`
+If skills are not available, install them: `databricks aitools install`
 ```
 
 ## Pipeline Structure


### PR DESCRIPTION
## Summary

Mirrors databricks/cli#4917 which promotes the aitools skills-management surface from `databricks experimental aitools` to top-level `databricks aitools`. Updates 3 install-command references so user-facing copy points at the canonical path:

- `README.md`
- `skills/databricks-jobs/SKILL.md`
- `skills/databricks-pipelines/SKILL.md`

## Why now

Purely cosmetic — there is no deprecation warning to avoid. The CLI keeps `databricks experimental aitools install` working as a **silent backward-compat alias** (it forwards to the same code, prints nothing). This PR is just keeping the docs aligned with the canonical command path so users meet the right name on first read.

## Intentionally left alone

The 37 `databricks experimental aitools tools …` references in `skills/databricks-core/`, `skills/databricks-apps/`, and elsewhere are **not** updated. The `tools` subtree (query, discover-schema, get-default-warehouse, statement) keeps its "no stability guarantees" disclaimer in #4917 and stays under `experimental aitools tools`. The docs continue to point at the live, canonical path.

## Compatibility

Lands in any order relative to #4917 — the old paths work either way, with or without the CLI change.

## Test plan

- [ ] README setup steps point at the new command
- [ ] `databricks-jobs` and `databricks-pipelines` skill markdown points at the new command
- [ ] No accidental rewrites of `tools`-subtree references

This pull request was AI-assisted by Isaac.