### PR TITLE
docs(apps): forbid `as unknown as` double type assertions

### DIFF
--- a/skills/databricks-apps/SKILL.md
+++ b/skills/databricks-apps/SKILL.md
@@ -37,6 +37,7 @@ Build apps that deploy to Databricks Apps platform.
 - **Validation**: `databricks apps validate --profile <PROFILE>` before deploying.
 - **Smoke tests** (AppKit only): ALWAYS update `tests/smoke.spec.ts` selectors BEFORE running validation. Default template checks for "Minimal Databricks App" heading and "hello world" text — these WILL fail in your custom app. See [testing guide](references/testing.md).
 - **Authentication**: covered by parent `databricks-core` skill.
+- **TypeScript casts**: never use `as unknown as <T>` double-assertions — `appkit lint` (run by `databricks apps validate`) enforces `no-double-type-assertion` and validate fails on a single occurrence. Fix the source type, use a runtime type guard (`if (typeof x.foo === "string") { ... }`), or narrow with Zod (`z.infer<typeof schema>`). If a query result needs reshaping, type the row schema in the SQL queryKey types or use a small mapper function rather than casting.
 
 ## Project Structure (after `databricks apps init --features analytics`)
 - `client/src/App.tsx` — main React component (start here)


### PR DESCRIPTION
## Summary

`databricks apps validate` runs `appkit lint`, which enforces the `no-double-type-assertion` ast-grep rule (added in a recent `@databricks/appkit` version). Even one occurrence in a generated app fails the validate step, while build / typecheck / unit tests still pass — exactly the "validate flips Y→N, everything else stays Y" fingerprint observed in the apps-mcp-evals nightly's Mode-B regression (prod run `456555456546311`, 2026-05-05; **11 of 16 clean-regress apps** carried this pattern).

This adds an explicit guideline so the agent doesn't reach for `as unknown as <T>` when typing analytics-query results — that's the cast pattern the regressed apps were generating. Suggests proper alternatives (fix source type, runtime type guard, Zod narrowing, mapper function).

## Independent confirmation

PromptingCo's CAO pilot (Apr 30, 25 DevHub templates, [report draft](https://github.com/databricks/databricks-agent-skills/issues/0)) clusters the same family of failures as **Cluster A — token passthrough / `user_api_scopes`** — 5 of 9 documented Codex failures. Two independent benchmarks, same root cause.

## Tracks

- LKB-12428 (Mode B sub-task)
- LKB-12426 (CLI 0.299.0 + AppKit 0.11.0 regression umbrella)

## Verifying signal

Skill update only — verifying signal is "next apps-mcp-evals nightly's `cb_*` and analytics apps cleanly pass `apps_validate_pass`, with no `as unknown as` strings appearing in generated `server.ts`". The merged appkit_version capture in PR [#1893815](https://github.com/databricks-eng/universe/pull/1893815) means we can also slice the next nightly by AppKit version + skill version directly from MLflow.

## Documentation safety checklist

- [x] Examples use least-privilege permissions (no unnecessary \`ALL PRIVILEGES\`, admin tokens, or broad scopes)
- [x] Elevated permissions are explicitly called out where required
- [x] Sensitive values are obfuscated (placeholder workspace IDs, URLs, no real tokens)
- [x] No insecure patterns introduced (e.g. disabled TLS verification, hardcoded credentials)

This is a one-line documentation addition with no examples or credentials — checklist applies trivially.