### PR TITLE
Update Lakebase schema ownership recovery guidance

### DIFF
--- a/skills/databricks-apps/references/appkit/lakebase.md
+++ b/skills/databricks-apps/references/appkit/lakebase.md
@@ -275,8 +275,8 @@ Load `server/.env` in your dev server (e.g. via `dotenv` or `node --env-file=ser
 | Error | Cause | Solution |
 |-------|-------|---------|
 | `permission denied for schema public` | SP cannot access `public` schema | Create custom schema: `CREATE SCHEMA IF NOT EXISTS app_data` and qualify all table names with `app_data.` |
-| `permission denied for schema <name>` | Schema was created by another role (e.g. you ran locally before deploying) | Schema owned by wrong role. To preserve data: export first via `pg_dump` or copy tables to a temp schema. **Ask the user before dropping.** Then drop (**deletes all data**) and redeploy: `databricks psql --project <PROJECT_ID> -- -c "DROP SCHEMA IF EXISTS app CASCADE;"` + `databricks apps deploy`. The SP recreates the schema. (PostgreSQL schema ownership is tied to the role that created it and cannot be reassigned by regular users.) |
-| Works locally but `permission denied` after deploy | Local credentials created the schema; the SP cannot access schemas it does not own | Same as above |
+| `permission denied for schema <name>` | Schema was created by another role (e.g. you ran locally before deploying) | Schema owned by wrong role. To preserve data: export first (`pg_dump` or temp schema copy). **Ask the user before dropping.** Then drop + redeploy. See **`databricks-lakebase`** skill's **Schema Permissions for Deployed Apps** for full steps. |
+| Works locally but `permission denied` after deploy | Local credentials created the schema; the SP cannot access schemas it does not own | Schema owned by wrong role — see row above for export + drop + redeploy steps |
 | `connection refused` | Pool not connected or wrong env vars | Check `PGHOST`, `PGPORT`, `LAKEBASE_ENDPOINT` are set |
 | `relation "X" does not exist` | Tables not initialized | Run `CREATE TABLE IF NOT EXISTS` at startup |
 | App builds but pool fails at runtime | Env vars not set locally | Set vars in `server/.env` — see Local Development above |

--- a/skills/databricks-apps/references/appkit/lakebase.md
+++ b/skills/databricks-apps/references/appkit/lakebase.md
@@ -246,6 +246,8 @@ Check the response for the `active_deployment` field. If it exists with `status.
 
 If you skip this step, the Service Principal won't own the database schema. You'll create schemas under your credentials that the SP **cannot access** after deployment. See **`databricks-lakebase`** skill's **Schema Permissions for Deployed Apps** for the full workflow and recovery steps.
 
+Lakebase project creators already have database access after the first deploy. Collaborators need `databricks_superuser` granted by the project creator via Branch Overview.
+
 The Lakebase env vars (`PGHOST`, `PGDATABASE`, etc.) are auto-set only when deployed. For local development, get the connection details from your endpoint and set them manually:
 
 ```bash
@@ -273,8 +275,8 @@ Load `server/.env` in your dev server (e.g. via `dotenv` or `node --env-file=ser
 | Error | Cause | Solution |
 |-------|-------|---------|
 | `permission denied for schema public` | SP cannot access `public` schema | Create custom schema: `CREATE SCHEMA IF NOT EXISTS app_data` and qualify all table names with `app_data.` |
-| `permission denied for schema <name>` | Schema was created by another role (e.g. you ran locally before deploying) | **Ask the user before dropping** — `DROP SCHEMA` deletes all data. See **`databricks-lakebase`** skill's **Schema Permissions for Deployed Apps** for options |
-| Works locally but `permission denied` after deploy | Local credentials created the schema; the SP can't access schemas it doesn't own | **Ask the user before dropping** — warn about data loss, then deploy first. See **`databricks-lakebase`** skill's **Schema Permissions for Deployed Apps** for options |
+| `permission denied for schema <name>` | Schema was created by another role (e.g. you ran locally before deploying) | Schema owned by wrong role. To preserve data: export first via `pg_dump` or copy tables to a temp schema. **Ask the user before dropping.** Then drop (**deletes all data**) and redeploy: `databricks psql --project <PROJECT_ID> -- -c "DROP SCHEMA IF EXISTS app CASCADE;"` + `databricks apps deploy`. The SP recreates the schema. (PostgreSQL schema ownership is tied to the role that created it and cannot be reassigned by regular users.) |
+| Works locally but `permission denied` after deploy | Local credentials created the schema; the SP cannot access schemas it does not own | Same as above |
 | `connection refused` | Pool not connected or wrong env vars | Check `PGHOST`, `PGPORT`, `LAKEBASE_ENDPOINT` are set |
 | `relation "X" does not exist` | Tables not initialized | Run `CREATE TABLE IF NOT EXISTS` at startup |
 | App builds but pool fails at runtime | Env vars not set locally | Set vars in `server/.env` — see Local Development above |

--- a/skills/databricks-lakebase/SKILL.md
+++ b/skills/databricks-lakebase/SKILL.md
@@ -197,8 +197,8 @@ The app's Service Principal has `CAN_CONNECT_AND_CREATE` -- it can create new ob
 **If you already ran locally first** and hit `permission denied`: the schema is owned by your credentials, not the SP. **Do NOT drop the schema without asking the user** -- dropping it deletes all data.
 
 Ask the user to choose:
-- **(A) Drop and redeploy:** `databricks psql --project <PROJECT_ID> -- -c "DROP SCHEMA IF EXISTS app CASCADE;"`, then `databricks apps deploy` from the app directory. The SP recreates the schema on startup.
-- **(B) Export first, then drop and redeploy:** export via `pg_dump` or copy tables to a temp schema, then do option A and restore.
+- **(A) Drop and redeploy:** `databricks psql --project <PROJECT_ID> -- -c "DROP SCHEMA IF EXISTS <SCHEMA_NAME> CASCADE;"`, then `databricks apps deploy` from the app directory. The SP recreates the schema on startup.
+- **(B) Export first, then drop and redeploy:** export via `pg_dump` (use connection details from `databricks postgres get-endpoint`; see **Other Workflows** below for HOST and TOKEN) or copy tables to a temp schema using `databricks psql --project <PROJECT_ID>`, then do option A. After the SP recreates the schema on redeploy, restore with `pg_restore` or re-INSERT from the temp schema.
 
 ### Other Workflows
 
@@ -260,7 +260,7 @@ Get SP client ID: `databricks apps get <APP_NAME> --profile <PROFILE>` → `serv
 |-------|----------|
 | `cannot configure default credentials` | Use `--profile` flag or authenticate first |
 | `PERMISSION_DENIED` | Check workspace permissions |
-| `permission denied for schema` | Schema owned by another role. If app not yet deployed: deploy first so the SP creates and owns the schema. If deployed but hitting this error (dev ran locally first): warn user about data loss, offer to export first (`pg_dump` or temp schema copy), then `DROP SCHEMA IF EXISTS app CASCADE` + redeploy. |
+| `permission denied for schema` | Schema owned by another role. If app not yet deployed: deploy first so the SP creates and owns the schema. If deployed but hitting this error (dev ran locally first): warn user about data loss, offer to export first (`pg_dump` with connection details from `databricks postgres get-endpoint`, or temp schema copy via `databricks psql`), then `DROP SCHEMA IF EXISTS <SCHEMA_NAME> CASCADE` + redeploy. |
 | Protected branch won't delete | `update-branch` to set `spec.is_protected` to `false` first |
 | Long-running operation timeout | Use `--no-wait` and poll with `get-operation` |
 | Token expired during long query | Tokens expire after 1 hour; implement refresh (see [connectivity.md](references/connectivity.md)) |

--- a/skills/databricks-lakebase/SKILL.md
+++ b/skills/databricks-lakebase/SKILL.md
@@ -194,7 +194,11 @@ The app's Service Principal has `CAN_CONNECT_AND_CREATE` -- it can create new ob
 2. **Grant local access** *(if needed)*: assign `databricks_superuser` via UI (project creators already have access)
 3. **Develop locally**: your credentials get DML access to SP-owned schemas
 
-**If you already ran locally first** and hit `permission denied`: the schema is owned by your credentials, not the SP. **Do NOT drop the schema without asking the user** -- dropping it deletes all data. Ask the user to choose: (A) drop and redeploy (destructive), or (B) manually reassign ownership (preserves data).
+**If you already ran locally first** and hit `permission denied`: the schema is owned by your credentials, not the SP. **Do NOT drop the schema without asking the user** -- dropping it deletes all data.
+
+Ask the user to choose:
+- **(A) Drop and redeploy:** `databricks psql --project <PROJECT_ID> -- -c "DROP SCHEMA IF EXISTS app CASCADE;"`, then `databricks apps deploy` from the app directory. The SP recreates the schema on startup.
+- **(B) Export first, then drop and redeploy:** export via `pg_dump` or copy tables to a temp schema, then do option A and restore.
 
 ### Other Workflows
 
@@ -256,7 +260,7 @@ Get SP client ID: `databricks apps get <APP_NAME> --profile <PROFILE>` → `serv
 |-------|----------|
 | `cannot configure default credentials` | Use `--profile` flag or authenticate first |
 | `PERMISSION_DENIED` | Check workspace permissions |
-| `permission denied for schema` | Schema owned by another role. Deploy app first so SP creates/owns it |
+| `permission denied for schema` | Schema owned by another role. If app not yet deployed: deploy first so the SP creates and owns the schema. If deployed but hitting this error (dev ran locally first): warn user about data loss, offer to export first (`pg_dump` or temp schema copy), then `DROP SCHEMA IF EXISTS app CASCADE` + redeploy. |
 | Protected branch won't delete | `update-branch` to set `spec.is_protected` to `false` first |
 | Long-running operation timeout | Use `--no-wait` and poll with `get-operation` |
 | Token expired during long query | Tokens expire after 1 hour; implement refresh (see [connectivity.md](references/connectivity.md)) |


### PR DESCRIPTION
## Summary

Replace "manually reassign ownership" with concrete pg_dump/temp schema copy options. Add project creator access note.