### PR TITLE
serverless-migration v2: UC MLflow patterns + AutoML rewrite + failure reporting + Genie Code install

### DIFF
--- a/.github/ISSUE_TEMPLATE/migration-feedback.md
+++ b/.github/ISSUE_TEMPLATE/migration-feedback.md
@@ -1,0 +1,82 @@
+---
+name: Migration Skill Feedback
+about: Report a bug, suggest a pattern, or submit a failure report for the serverless migration skill
+title: "[migration-skill] "
+labels: migration-skill
+assignees: ''
+---
+
+<!--
+Before submitting, please review the PII guidelines in README.md:
+- Remove customer code — use minimal reproducible examples
+- Remove credentials, workspace URLs, catalog names, user emails
+- Remove customer-identifying information
+-->
+
+## Category
+
+<!-- Check one -->
+
+- [ ] Pattern not detected (the skill missed a classic-compute construct)
+- [ ] Wrong fix suggested (the fix didn't work or was incorrect)
+- [ ] Migration succeeded but output differs (code runs, data is different)
+- [ ] Documentation unclear
+- [ ] Failure report (attach JSON from `~/.databricks-migration-skill/reports/`)
+- [ ] New pattern suggestion
+
+## Pre-submission checklist
+
+- [ ] I have removed all customer code and replaced with a minimal reproducible example
+- [ ] I have removed all credentials, tokens, and secret scope names
+- [ ] I have removed all workspace URLs, catalog names, and user emails
+- [ ] I have removed any customer-identifying information
+
+## Environment
+
+- Skill version: <!-- e.g., v0.2.0 (check SKILL.md metadata.version) -->
+- Agent: <!-- e.g., Claude Code, Cursor, custom -->
+- Model: <!-- e.g., claude-sonnet-4-6 -->
+- Databricks Runtime of source workload: <!-- e.g., 14.3 LTS -->
+
+## Description
+
+<!--
+What happened? What did you expect to happen?
+Include a minimal reproducible example if relevant.
+-->
+
+## Minimal reproducible example
+
+<!-- Replace with a 5-10 line snippet that shows the pattern -->
+```python
+# Classic compute code (minimal example, no customer data)
+```
+
+## Expected migration
+
+<!-- What the skill should have done -->
+
+## Actual migration
+
+<!-- What the skill actually did, if anything -->
+
+## Failure report (optional)
+
+<!--
+If you're attaching a failure report JSON:
+1. Open it and confirm no PII is present
+2. Paste the contents below in a code block, OR upload as a file attachment
+-->
+
+<details>
+<summary>Failure report JSON</summary>
+
+```json
+<!-- paste report contents here after reviewing for PII -->
+```
+
+</details>
+
+## Additional context
+
+<!-- Any other context, screenshots, or information -->

--- a/README.md
+++ b/README.md
@@ -4,26 +4,90 @@ Skills for AI coding assistants (Claude Code, Cursor, etc.) that provide Databri
 
 ## Installation
 
-**For Claude Code:**
+Two install paths cover the **stable** skills. They install to different places
+but end up loaded by the same agents — pick whichever fits your workflow.
+
+- **Databricks CLI** writes SKILL.md files directly into each agent's skill
+  directory (`~/.claude/skills/`, `~/.cursor/extensions/<...>`, etc.).
+- **Plugin marketplaces** (Claude Code, Cursor) cache the plugin under the
+  agent's plugin directory (e.g. `~/.claude/plugins/cache/databricks-agent-skills/`);
+  the agent discovers skills from there.
+
+**Via the Databricks CLI (canonical; supports experimental skills):**
 
 ```bash
-databricks experimental aitools install
+databricks aitools install
 ```
 
-This installs skills to `~/.claude/skills/` for use with Claude Code.
+The CLI auto-detects your coding agent(s) and installs the stable skills to the
+right location:
 
-**For Cursor:**
+- **Claude Code** → `~/.claude/skills/`
+- **Cursor**, **Codex CLI**, **OpenCode**, **GitHub Copilot**, **Antigravity**
+  → their respective skill directories
 
-Run this command in chat:
+For finer control, use the `aitools skills install` subcommand directly — it
+accepts a positional skill name and an `--experimental` flag (see the
+[Experimental Skills](#experimental-skills) section).
+
+**Via the Claude Code plugin marketplace** (stable skills only — installs every
+skill under [`./skills/`](./skills/)):
+
+```text
+/plugin marketplace add databricks/databricks-agent-skills
+/plugin install databricks@databricks-agent-skills
+```
+
+**Via the Cursor plugin marketplace:**
 
 ```text
 /add-plugin databricks-skills
 ```
 
+### CLI vs plugin marketplace
+
+| | CLI | Plugin marketplace |
+|---|---|---|
+| Stable skills | ✅ (default) | ✅ |
+| Experimental skills | ✅ (with `--experimental` or by name) | ❌ |
+| Per-skill selection | ✅ (`databricks aitools install <name>`) | ❌ (all-or-nothing) |
+| Updates | `databricks aitools update` | Plugin marketplace update flow |
+| Required outside the agent | Databricks CLI v1.0.0+ | None |
+
+If in doubt, use the CLI — it's the canonical install path and the only one that
+exposes experimental skills.
+
 ## Available Skills
 
-- **databricks-apps** - Build full-stack TypeScript apps on Databricks using AppKit
-- **databricks-serverless-migration** - Migrate classic-compute workloads (notebooks, jobs, pipelines) to serverless compute. Detects compatibility blockers, provides concrete fixes, and produces an anonymized failure report you can file as a GitHub issue when migration cannot complete. Also installable inside a Databricks workspace via Genie Code Agent mode — see [the install reference](skills/databricks-serverless-migration/references/install-in-databricks-genie-code.md).
+Stable skills shipped from [`skills/`](./skills/):
+
+- **databricks-core** — CLI, authentication, profile selection, data exploration. Parent skill for all product skills.
+- **databricks-apps** — Build full-stack TypeScript apps on Databricks using AppKit.
+- **databricks-dabs** — Declarative Automation Bundles (formerly Asset Bundles) for deploying and managing Databricks resources.
+- **databricks-jobs** — Lakeflow Jobs orchestration: task types, triggers, schedules, notifications.
+- **databricks-lakebase** — Lakebase Postgres: projects, branching, autoscaling, synced tables, Data API.
+- **databricks-model-serving** — Model Serving endpoint management, AI Gateway, traffic config.
+- **databricks-pipelines** — Lakeflow Spark Declarative Pipelines (formerly DLT) for batch and streaming.
+- **databricks-serverless-migration** — Migrate classic-compute workloads to serverless compute.
+- **databricks-vector-search** — Vector Search endpoints + indexes for RAG and semantic search.
+
+## Experimental Skills
+
+The [`experimental/`](./experimental/) directory contains additional skills
+originally imported from
+[databricks-solutions/ai-dev-kit](https://github.com/databricks-solutions/ai-dev-kit)
+(now deprecated — this repo is the source of truth going forward) on a
+**best-effort basis**.
+
+- Experimental skills are **not officially supported** — they may be used, but
+  do not follow the same review / quality bar as the stable skills under
+  [`skills/`](./skills/).
+- They are **not installed by default** by `databricks aitools install`.
+  Pass `--experimental` to install all of them, or install a specific one
+  by name (with the `--experimental` flag — e.g. `databricks aitools install
+  databricks-iceberg --experimental`).
+- See [`experimental/README.md`](./experimental/README.md) for the full list
+  and caveats.
 
 ## Structure
 
@@ -39,21 +103,24 @@ skill-name/
 
 ### Adding New Skills
 
-When experimenting with new skill variations, create a "subskill" that references the main skill and adds specific guidance:
+For a narrower variation of an existing skill, create a subskill that declares
+its parent via frontmatter. This is how the stable skills are organized today
+— each product skill sets `parent: databricks-core`.
 
 ```markdown
 ---
-name: "ai-databricks-apps"
-description: "Databricks apps with AI features"
+name: "databricks-apps-chatbots"
+description: "Databricks apps with chatbot features"
+parent: databricks-apps
 ---
 
-# AI powered Databricks Apps
+# Chatbot Apps
 
-First, load the base databricks-apps skill for foundational guidance.
+**FIRST**: Use the parent `databricks-apps` skill for app development basics.
 
-Then apply these additional patterns:
-- Custom pattern 1
-- Custom pattern 2
+Then apply these patterns:
+- Pattern 1
+- Pattern 2
 ```
 
 This approach:
@@ -63,19 +130,21 @@ This approach:
 
 ### Manifest Management
 
-Sync assets and generate manifest after adding/updating skills:
+`manifest.json` is **generated** by `scripts/skills.py` from the skill directories and frontmatter. Do not edit it by hand. CI rejects manual changes via two checks: content drift (parsed dict doesn't match what `generate` would produce) and canonical form (on-disk bytes don't match `json.dumps(..., indent=2, sort_keys=True)`).
+
+Sync assets and regenerate the manifest after adding or updating skills:
 
 ```bash
 python3 scripts/skills.py
 ```
 
-Validate that assets and manifest are up to date (for CI):
+Validate that assets and manifest are up to date (used by CI):
 
 ```bash
 python3 scripts/skills.py validate
 ```
 
-The manifest is used by the CLI to discover available skills.
+The manifest is consumed by the CLI to discover available skills.
 
 ## Security
 
@@ -83,7 +152,8 @@ Please see [SECURITY](./SECURITY) for vulnerability reporting guidelines.
 
 ## Integrity
 
-All future release tags will be GPG-signed and verifiable via `git tag -v <tag>`.
+Release tags are created by the [Release workflow](./.github/workflows/release.yml)
+and map 1:1 to a published version.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -4,90 +4,26 @@ Skills for AI coding assistants (Claude Code, Cursor, etc.) that provide Databri
 
 ## Installation
 
-Two install paths cover the **stable** skills. They install to different places
-but end up loaded by the same agents — pick whichever fits your workflow.
-
-- **Databricks CLI** writes SKILL.md files directly into each agent's skill
-  directory (`~/.claude/skills/`, `~/.cursor/extensions/<...>`, etc.).
-- **Plugin marketplaces** (Claude Code, Cursor) cache the plugin under the
-  agent's plugin directory (e.g. `~/.claude/plugins/cache/databricks-agent-skills/`);
-  the agent discovers skills from there.
-
-**Via the Databricks CLI (canonical; supports experimental skills):**
+**For Claude Code:**
 
 ```bash
-databricks aitools install
+databricks experimental aitools install
 ```
 
-The CLI auto-detects your coding agent(s) and installs the stable skills to the
-right location:
+This installs skills to `~/.claude/skills/` for use with Claude Code.
 
-- **Claude Code** → `~/.claude/skills/`
-- **Cursor**, **Codex CLI**, **OpenCode**, **GitHub Copilot**, **Antigravity**
-  → their respective skill directories
+**For Cursor:**
 
-For finer control, use the `aitools skills install` subcommand directly — it
-accepts a positional skill name and an `--experimental` flag (see the
-[Experimental Skills](#experimental-skills) section).
-
-**Via the Claude Code plugin marketplace** (stable skills only — installs every
-skill under [`./skills/`](./skills/)):
-
-```text
-/plugin marketplace add databricks/databricks-agent-skills
-/plugin install databricks@databricks-agent-skills
-```
-
-**Via the Cursor plugin marketplace:**
+Run this command in chat:
 
 ```text
 /add-plugin databricks-skills
 ```
 
-### CLI vs plugin marketplace
-
-| | CLI | Plugin marketplace |
-|---|---|---|
-| Stable skills | ✅ (default) | ✅ |
-| Experimental skills | ✅ (with `--experimental` or by name) | ❌ |
-| Per-skill selection | ✅ (`databricks aitools install <name>`) | ❌ (all-or-nothing) |
-| Updates | `databricks aitools update` | Plugin marketplace update flow |
-| Required outside the agent | Databricks CLI v1.0.0+ | None |
-
-If in doubt, use the CLI — it's the canonical install path and the only one that
-exposes experimental skills.
-
 ## Available Skills
 
-Stable skills shipped from [`skills/`](./skills/):
-
-- **databricks-core** — CLI, authentication, profile selection, data exploration. Parent skill for all product skills.
-- **databricks-apps** — Build full-stack TypeScript apps on Databricks using AppKit.
-- **databricks-dabs** — Declarative Automation Bundles (formerly Asset Bundles) for deploying and managing Databricks resources.
-- **databricks-jobs** — Lakeflow Jobs orchestration: task types, triggers, schedules, notifications.
-- **databricks-lakebase** — Lakebase Postgres: projects, branching, autoscaling, synced tables, Data API.
-- **databricks-model-serving** — Model Serving endpoint management, AI Gateway, traffic config.
-- **databricks-pipelines** — Lakeflow Spark Declarative Pipelines (formerly DLT) for batch and streaming.
-- **databricks-serverless-migration** — Migrate classic-compute workloads to serverless compute.
-- **databricks-vector-search** — Vector Search endpoints + indexes for RAG and semantic search.
-
-## Experimental Skills
-
-The [`experimental/`](./experimental/) directory contains additional skills
-originally imported from
-[databricks-solutions/ai-dev-kit](https://github.com/databricks-solutions/ai-dev-kit)
-(now deprecated — this repo is the source of truth going forward) on a
-**best-effort basis**.
-
-- Experimental skills are **not officially supported** — they may be used, but
-  do not follow the same review / quality bar as the stable skills under
-  [`skills/`](./skills/).
-- They are **not installed by default** by `databricks aitools install`.
-  Pass `--experimental` to install all of them, or install a specific one
-  by name (with the `--experimental` flag — e.g. `databricks aitools install
-  databricks-iceberg --experimental`).
-- See [`experimental/README.md`](./experimental/README.md) for the full list
-  and caveats.
+- **databricks-apps** - Build full-stack TypeScript apps on Databricks using AppKit
+- **databricks-serverless-migration** - Migrate classic-compute workloads (notebooks, jobs, pipelines) to serverless compute. Detects compatibility blockers, provides concrete fixes, and produces an anonymized failure report you can file as a GitHub issue when migration cannot complete. Also installable inside a Databricks workspace via Genie Code Agent mode — see [the install reference](skills/databricks-serverless-migration/references/install-in-databricks-genie-code.md).
 
 ## Structure
 
@@ -103,24 +39,21 @@ skill-name/
 
 ### Adding New Skills
 
-For a narrower variation of an existing skill, create a subskill that declares
-its parent via frontmatter. This is how the stable skills are organized today
-— each product skill sets `parent: databricks-core`.
+When experimenting with new skill variations, create a "subskill" that references the main skill and adds specific guidance:
 
 ```markdown
 ---
-name: "databricks-apps-chatbots"
-description: "Databricks apps with chatbot features"
-parent: databricks-apps
+name: "ai-databricks-apps"
+description: "Databricks apps with AI features"
 ---
 
-# Chatbot Apps
+# AI powered Databricks Apps
 
-**FIRST**: Use the parent `databricks-apps` skill for app development basics.
+First, load the base databricks-apps skill for foundational guidance.
 
-Then apply these patterns:
-- Pattern 1
-- Pattern 2
+Then apply these additional patterns:
+- Custom pattern 1
+- Custom pattern 2
 ```
 
 This approach:
@@ -130,21 +63,19 @@ This approach:
 
 ### Manifest Management
 
-`manifest.json` is **generated** by `scripts/skills.py` from the skill directories and frontmatter. Do not edit it by hand. CI rejects manual changes via two checks: content drift (parsed dict doesn't match what `generate` would produce) and canonical form (on-disk bytes don't match `json.dumps(..., indent=2, sort_keys=True)`).
-
-Sync assets and regenerate the manifest after adding or updating skills:
+Sync assets and generate manifest after adding/updating skills:
 
 ```bash
 python3 scripts/skills.py
 ```
 
-Validate that assets and manifest are up to date (used by CI):
+Validate that assets and manifest are up to date (for CI):
 
 ```bash
 python3 scripts/skills.py validate
 ```
 
-The manifest is consumed by the CLI to discover available skills.
+The manifest is used by the CLI to discover available skills.
 
 ## Security
 
@@ -152,8 +83,7 @@ Please see [SECURITY](./SECURITY) for vulnerability reporting guidelines.
 
 ## Integrity
 
-Release tags are created by the [Release workflow](./.github/workflows/release.yml)
-and map 1:1 to a published version.
+All future release tags will be GPG-signed and verifiable via `git tag -v <tag>`.
 
 ## Contributing
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,52 @@
 {
-  "version": "2",
-  "updated_at": "2026-05-12T07:54:37Z",
+  "//": "GENERATED FILE: DO NOT EDIT. Run `python3 scripts/skills.py generate` to regenerate.",
   "skills": {
+    "databricks-agent-bricks": {
+      "description": "Create Agent Bricks: Knowledge Assistants (KA) for document Q&A and Supervisor Agents for multi-agent orchestration (MAS).",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/1-knowledge-assistants.md",
+        "references/2-supervisor-agents.md"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
+    },
+    "databricks-ai-functions": {
+      "description": "Use Databricks built-in AI Functions (ai_classify, ai_extract, ai_summarize, ai_mask, ai_translate, ai_fix_grammar, ai_gen, ai_analyze_sentiment, ai_similarity, ai_parse_document, ai_query, ai_forecast) to add AI capabilities directly to SQL and PySpark pipelines without managing model endpoints. Also covers document parsing and building custom RAG pipelines (parse \u2192 chunk \u2192 index \u2192 query).",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/1-task-functions.md",
+        "references/2-ai-query.md",
+        "references/3-ai-forecast.md",
+        "references/4-document-processing-pipeline.md"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
+    },
+    "databricks-aibi-dashboards": {
+      "description": "Create Databricks AI/BI dashboards. Must use when creating, updating, or deploying Lakeview dashboards as Databricks Dashboard have a unique json structure. CRITICAL: You MUST test ALL SQL queries via CLI BEFORE deploying. Follow guidelines strictly.",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/1-widget-specifications.md",
+        "references/2-advanced-widget-specifications.md",
+        "references/3-filters.md",
+        "references/4-examples.md",
+        "references/5-troubleshooting.md"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
+    },
     "databricks-apps": {
-      "version": "0.1.1",
-      "description": "Databricks Apps development and deployment (evaluates analytics vs synced tables data access)",
-      "experimental": false,
-      "updated_at": "2026-04-30T11:00:26Z",
+      "description": "Build apps on Databricks Apps platform.",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -27,13 +67,33 @@
         "references/other-frameworks.md",
         "references/platform-guide.md",
         "references/testing.md"
-      ]
+      ],
+      "repo_dir": "skills",
+      "version": "0.1.2"
+    },
+    "databricks-apps-python": {
+      "description": "Builds Databricks applications. Prefers AppKit (TypeScript + React SDK) for new apps; falls back to Python frameworks (Dash, Streamlit, Gradio, Flask, FastAPI, Reflex) when Python is required. Handles OAuth authorization, app resources, SQL warehouse and Lakebase connectivity, model serving, foundation model APIs, and deployment. Use when building web apps, dashboards, ML demos, or REST APIs for Databricks, or when the user mentions AppKit, Streamlit, Dash, Gradio, Flask, FastAPI, Reflex, or Databricks app.",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "examples/fm-minimal-chat.py",
+        "examples/fm-parallel-calls.py",
+        "examples/fm-structured-outputs.py",
+        "examples/llm_config.py",
+        "references/1-authorization.md",
+        "references/2-app-resources.md",
+        "references/3-frameworks.md",
+        "references/4-deployment.md",
+        "references/5-lakebase.md",
+        "references/6-cli-approach.md"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
     },
     "databricks-core": {
-      "version": "0.1.0",
-      "description": "Core Databricks skill for CLI, auth, and data exploration",
-      "experimental": false,
-      "updated_at": "2026-04-23T13:47:44Z",
+      "description": "Databricks CLI operations: auth, profiles, data exploration, and bundles. Contains up-to-date guidelines for Databricks-related CLI tasks.",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -42,13 +102,12 @@
         "data-exploration.md",
         "databricks-cli-auth.md",
         "databricks-cli-install.md"
-      ]
+      ],
+      "repo_dir": "skills",
+      "version": "0.1.0"
     },
     "databricks-dabs": {
-      "version": "0.0.0",
-      "description": "Declarative Automation Bundles (DABs) for deploying and managing Databricks resources",
-      "experimental": false,
-      "updated_at": "2026-04-23T13:47:44Z",
+      "description": "Create, configure, validate, deploy, run, and manage Declarative Automation Bundles (DABs, formerly Databricks Asset Bundles).",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -60,25 +119,84 @@
         "references/resource-permissions.md",
         "references/sdp-pipelines.md"
       ],
-      "base_revision": "e742f36e8ab1"
+      "repo_dir": "skills",
+      "version": "0.0.1"
     },
-    "databricks-jobs": {
-      "version": "0.1.0",
-      "description": "Databricks Jobs orchestration and scheduling",
-      "experimental": false,
-      "updated_at": "2026-04-23T13:47:44Z",
+    "databricks-dbsql": {
+      "description": "Databricks SQL (DBSQL) advanced features and SQL warehouse capabilities. This skill MUST be invoked when the user mentions: \"DBSQL\", \"Databricks SQL\", \"SQL warehouse\", \"SQL scripting\", \"stored procedure\", \"CALL procedure\", \"materialized view\", \"CREATE MATERIALIZED VIEW\", \"pipe syntax\", \"|>\", \"geospatial\", \"H3\", \"ST_\", \"spatial SQL\", \"collation\", \"COLLATE\", \"ai_query\", \"ai_classify\", \"ai_extract\", \"ai_gen\", \"AI function\", \"http_request\", \"remote_query\", \"read_files\", \"Lakehouse Federation\", \"recursive CTE\", \"WITH RECURSIVE\", \"multi-statement transaction\", \"temp table\", \"temporary view\", \"pipe operator\". SHOULD also invoke when the user asks about SQL best practices, data modeling patterns, or advanced SQL features on Databricks.",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/ai-functions.md",
+        "references/best-practices.md",
+        "references/geospatial-collations.md",
+        "references/materialized-views-pipes.md",
+        "references/sql-scripting.md"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
+    },
+    "databricks-docs": {
+      "description": "Databricks documentation reference via llms.txt index. Use when other skills do not cover a topic, looking up unfamiliar Databricks features, or needing authoritative docs on APIs, configurations, or platform capabilities.",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
         "assets/databricks.png",
         "assets/databricks.svg"
-      ]
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
+    },
+    "databricks-execution-compute": {
+      "description": "Execute code and manage compute on Databricks: run Python/Scala/SQL/R via serverless, classic, or interactive clusters, and create/resize/delete clusters and SQL warehouses.",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/1-databricks-connect.md",
+        "references/2-serverless-job.md",
+        "references/3-interactive-cluster.md",
+        "scripts/compute.py"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
+    },
+    "databricks-iceberg": {
+      "description": "Apache Iceberg tables on Databricks \u2014 Managed Iceberg tables, External Iceberg Reads (fka Uniform), Compatibility Mode, Iceberg REST Catalog (IRC), Iceberg v3, Snowflake interop, PyIceberg, OSS Spark, external engine access and credential vending. Use when creating Iceberg tables, enabling External Iceberg Reads (uniform) on Delta tables (including Streaming Tables and Materialized Views via compatibility mode), configuring external engines to read Databricks tables via Unity Catalog IRC, integrating with Snowflake catalog to read Foreign Iceberg tables",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/1-managed-iceberg-tables.md",
+        "references/2-uniform-and-compatibility.md",
+        "references/3-iceberg-rest-catalog.md",
+        "references/4-snowflake-interop.md",
+        "references/5-external-engine-interop.md"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
+    },
+    "databricks-jobs": {
+      "description": "Develop and deploy Lakeflow Jobs on Databricks via DABs, Python SDK, or the CLI.",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/examples.md",
+        "references/notifications-monitoring.md",
+        "references/task-types.md",
+        "references/triggers-schedules.md"
+      ],
+      "repo_dir": "skills",
+      "version": "0.2.0"
     },
     "databricks-lakebase": {
-      "version": "0.1.0",
-      "description": "Databricks Lakebase Postgres: projects, scaling, connectivity, synced tables, and Data API",
-      "experimental": false,
-      "updated_at": "2026-04-30T11:02:37Z",
+      "description": "Databricks Lakebase Postgres: projects, scaling, connectivity, Lakebase synced tables, and Data API.",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -86,26 +204,64 @@
         "assets/databricks.svg",
         "references/computes-and-scaling.md",
         "references/connectivity.md",
+        "references/lakehouse-sync.md",
+        "references/medallion-from-cdc.md",
+        "references/off-platform.md",
+        "references/pgvector.md",
         "references/synced-tables.md"
-      ]
+      ],
+      "repo_dir": "skills",
+      "version": "0.1.0"
     },
-    "databricks-model-serving": {
-      "version": "0.1.0",
-      "description": "Databricks Model Serving endpoint management",
-      "experimental": false,
-      "updated_at": "2026-04-23T13:47:44Z",
+    "databricks-metric-views": {
+      "description": "Unity Catalog metric views: define, create, query, and manage governed business metrics in YAML. Use when building standardized KPIs, revenue metrics, order analytics, or any reusable business metrics that need consistent definitions across teams and tools.",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
         "assets/databricks.png",
-        "assets/databricks.svg"
-      ]
+        "assets/databricks.svg",
+        "references/patterns.md",
+        "references/yaml-reference.md"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
+    },
+    "databricks-mlflow-evaluation": {
+      "description": "MLflow 3 GenAI agent evaluation. Use when writing mlflow.genai.evaluate() code, creating @scorer functions, using built-in scorers (Guidelines, Correctness, Safety, RetrievalGroundedness), building eval datasets from traces, setting up trace ingestion and production monitoring, aligning judges with MemAlign from domain expert feedback, or running optimize_prompts() with GEPA for automated prompt improvement.",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/CRITICAL-interfaces.md",
+        "references/GOTCHAS.md",
+        "references/patterns-context-optimization.md",
+        "references/patterns-datasets.md",
+        "references/patterns-evaluation.md",
+        "references/patterns-judge-alignment.md",
+        "references/patterns-prompt-optimization.md",
+        "references/patterns-scorers.md",
+        "references/patterns-trace-analysis.md",
+        "references/patterns-trace-ingestion.md",
+        "references/user-journeys.md"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
+    },
+    "databricks-model-serving": {
+      "description": "Manage Databricks Model Serving endpoints via CLI.",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/off-platform-streaming.md"
+      ],
+      "repo_dir": "skills",
+      "version": "0.1.0"
     },
     "databricks-pipelines": {
-      "version": "0.1.0",
-      "description": "Databricks Pipelines (DLT) for ETL and streaming",
-      "experimental": false,
-      "updated_at": "2026-04-23T13:47:44Z",
+      "description": "Develop Lakeflow Spark Declarative Pipelines (formerly Delta Live Tables) on Databricks.",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -117,11 +273,13 @@
         "references/auto-loader-python.md",
         "references/auto-loader-sql.md",
         "references/auto-loader.md",
+        "references/dlt-migration.md",
         "references/expectations-python.md",
         "references/expectations-sql.md",
         "references/expectations.md",
         "references/foreach-batch-sink-python.md",
         "references/foreach-batch-sink.md",
+        "references/kafka.md",
         "references/materialized-view-python.md",
         "references/materialized-view-sql.md",
         "references/materialized-view.md",
@@ -132,10 +290,14 @@
         "references/options-parquet.md",
         "references/options-text.md",
         "references/options-xml.md",
+        "references/performance.md",
+        "references/pipeline-configuration.md",
         "references/python-basics.md",
+        "references/scd-2-querying.md",
         "references/sink-python.md",
         "references/sink.md",
         "references/sql-basics.md",
+        "references/streaming-patterns.md",
         "references/streaming-table-python.md",
         "references/streaming-table-sql.md",
         "references/streaming-table.md",
@@ -144,15 +306,31 @@
         "references/temporary-view.md",
         "references/view-sql.md",
         "references/view.md",
+        "references/workflows.md",
         "references/write-spark-declarative-pipelines.md"
       ],
-      "base_revision": "5c4b4fb0a82a"
+      "repo_dir": "skills",
+      "version": "0.3.0"
+    },
+    "databricks-python-sdk": {
+      "description": "Databricks development guidance including Python SDK, Databricks Connect, CLI, and REST API. Use when working with databricks-sdk, databricks-connect, or Databricks APIs.",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "examples/1-authentication.py",
+        "examples/2-clusters-and-jobs.py",
+        "examples/3-sql-and-warehouses.py",
+        "examples/4-unity-catalog.py",
+        "examples/5-serving-and-vector-search.py",
+        "references/doc-index.md"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
     },
     "databricks-serverless-migration": {
-      "version": "0.1.0",
-      "description": "Migrate Databricks workloads from classic compute to serverless compute, including compatibility checks and concrete fixes",
-      "experimental": false,
-      "updated_at": "2026-05-12T07:54:37Z",
+      "description": "Migrate Databricks workloads from classic compute to serverless compute.",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -163,9 +341,124 @@
         "references/configuration-guide.md",
         "references/failure-reporting.md",
         "references/install-in-databricks-genie-code.md",
+        "references/mlflow-uc-patterns.md",
+        "references/multi-source-enumeration.md",
         "references/networking-and-security.md",
         "references/streaming-migration.md"
-      ]
+      ],
+      "repo_dir": "skills",
+      "version": "0.1.0"
+    },
+    "databricks-spark-structured-streaming": {
+      "description": "Comprehensive guide to Spark Structured Streaming for production workloads. Use when building streaming pipelines, working with Kafka ingestion, implementing Real-Time Mode (RTM), configuring triggers (processingTime, availableNow), handling stateful operations with watermarks, optimizing checkpoints, performing stream-stream or stream-static joins, writing to multiple sinks, or tuning streaming cost and performance.",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/checkpoint-best-practices.md",
+        "references/kafka-streaming.md",
+        "references/merge-operations.md",
+        "references/multi-sink-writes.md",
+        "references/stateful-operations.md",
+        "references/stream-static-joins.md",
+        "references/stream-stream-joins.md",
+        "references/streaming-best-practices.md",
+        "references/trigger-and-cost-optimization.md"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
+    },
+    "databricks-synthetic-data-gen": {
+      "description": "Generate realistic synthetic data using Spark + Faker (strongly recommended). Supports serverless execution, multiple output formats (Parquet/JSON/CSV/Delta), and scales from thousands to millions of rows. For small datasets (<10K rows), can optionally generate locally and upload to volumes. Use when user mentions 'synthetic data', 'test data', 'generate data', 'demo dataset', 'Faker', or 'sample data'.",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/1-data-patterns.md",
+        "references/2-troubleshooting.md",
+        "scripts/generate_synthetic_data.py"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
+    },
+    "databricks-unity-catalog": {
+      "description": "Unity Catalog system tables and volumes. Use when querying system tables (audit, lineage, billing) or working with volume file operations (upload, download, list files in /Volumes/).",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/5-system-tables.md",
+        "references/6-volumes.md",
+        "references/7-data-profiling.md"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
+    },
+    "databricks-unstructured-pdf-generation": {
+      "description": "Generate PDF documents from HTML and upload to Unity Catalog volumes. Use for creating test PDFs, demo documents, reports, or evaluation datasets.",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "scripts/pdf_generator.py"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
+    },
+    "databricks-vector-search": {
+      "description": "Patterns for Databricks Vector Search: create endpoints and indexes, query with filters, manage embeddings. Use when building RAG applications, semantic search, or similarity matching. Covers both storage-optimized and standard endpoints.",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/end-to-end-rag.md",
+        "references/index-types.md",
+        "references/search-modes.md",
+        "references/troubleshooting-and-operations.md"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
+    },
+    "databricks-zerobus-ingest": {
+      "description": "Build Zerobus Ingest clients for near real-time data ingestion into Databricks Delta tables via gRPC. Use when creating producers that write directly to Unity Catalog tables without a message bus, working with the Zerobus Ingest SDK in Python/Java/Go/TypeScript/Rust, generating Protobuf schemas from UC tables, or implementing stream-based ingestion with ACK handling and retry logic.",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/1-setup-and-authentication.md",
+        "references/2-python-client.md",
+        "references/3-multilanguage-clients.md",
+        "references/4-protobuf-schema.md",
+        "references/5-operations-and-limits.md"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
+    },
+    "spark-python-data-source": {
+      "description": "Build custom Python data sources for Apache Spark using the PySpark DataSource API \u2014 batch and streaming readers/writers for external systems. Use this skill whenever someone wants to connect Spark to an external system (database, API, message queue, custom protocol), build a Spark connector or plugin in Python, implement a DataSourceReader or DataSourceWriter, pull data from or push data to a system via Spark, or work with the PySpark DataSource API in any way. Even if they just say \"read from X in Spark\" or \"write DataFrame to Y\" and there's no native connector, this skill applies.",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/authentication-patterns.md",
+        "references/error-handling.md",
+        "references/implementation-template.md",
+        "references/partitioning-patterns.md",
+        "references/production-patterns.md",
+        "references/streaming-patterns.md",
+        "references/testing-patterns.md",
+        "references/type-conversion.md"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
     }
-  }
+  },
+  "version": "2"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -330,7 +330,7 @@
       "version": "0.1.0"
     },
     "databricks-serverless-migration": {
-      "description": "Migrate Databricks workloads from classic compute to serverless compute. Scans code for serverless compatibility issues, provides concrete fixes for the serverless Spark Connect architecture, and g...",
+      "description": "Migrate Databricks workloads from classic compute to serverless compute.",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",

--- a/manifest.json
+++ b/manifest.json
@@ -1,52 +1,12 @@
 {
-  "//": "GENERATED FILE: DO NOT EDIT. Run `python3 scripts/skills.py generate` to regenerate.",
+  "version": "2",
+  "updated_at": "2026-05-12T07:54:37Z",
   "skills": {
-    "databricks-agent-bricks": {
-      "description": "Create Agent Bricks: Knowledge Assistants (KA) for document Q&A and Supervisor Agents for multi-agent orchestration (MAS).",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/1-knowledge-assistants.md",
-        "references/2-supervisor-agents.md"
-      ],
-      "repo_dir": "experimental",
-      "version": "0.1.0"
-    },
-    "databricks-ai-functions": {
-      "description": "Use Databricks built-in AI Functions (ai_classify, ai_extract, ai_summarize, ai_mask, ai_translate, ai_fix_grammar, ai_gen, ai_analyze_sentiment, ai_similarity, ai_parse_document, ai_query, ai_forecast) to add AI capabilities directly to SQL and PySpark pipelines without managing model endpoints. Also covers document parsing and building custom RAG pipelines (parse \u2192 chunk \u2192 index \u2192 query).",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/1-task-functions.md",
-        "references/2-ai-query.md",
-        "references/3-ai-forecast.md",
-        "references/4-document-processing-pipeline.md"
-      ],
-      "repo_dir": "experimental",
-      "version": "0.1.0"
-    },
-    "databricks-aibi-dashboards": {
-      "description": "Create Databricks AI/BI dashboards. Must use when creating, updating, or deploying Lakeview dashboards as Databricks Dashboard have a unique json structure. CRITICAL: You MUST test ALL SQL queries via CLI BEFORE deploying. Follow guidelines strictly.",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/1-widget-specifications.md",
-        "references/2-advanced-widget-specifications.md",
-        "references/3-filters.md",
-        "references/4-examples.md",
-        "references/5-troubleshooting.md"
-      ],
-      "repo_dir": "experimental",
-      "version": "0.1.0"
-    },
     "databricks-apps": {
-      "description": "Build apps on Databricks Apps platform.",
+      "version": "0.1.1",
+      "description": "Databricks Apps development and deployment (evaluates analytics vs synced tables data access)",
+      "experimental": false,
+      "updated_at": "2026-04-30T11:00:26Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -67,33 +27,13 @@
         "references/other-frameworks.md",
         "references/platform-guide.md",
         "references/testing.md"
-      ],
-      "repo_dir": "skills",
-      "version": "0.1.2"
-    },
-    "databricks-apps-python": {
-      "description": "Builds Databricks applications. Prefers AppKit (TypeScript + React SDK) for new apps; falls back to Python frameworks (Dash, Streamlit, Gradio, Flask, FastAPI, Reflex) when Python is required. Handles OAuth authorization, app resources, SQL warehouse and Lakebase connectivity, model serving, foundation model APIs, and deployment. Use when building web apps, dashboards, ML demos, or REST APIs for Databricks, or when the user mentions AppKit, Streamlit, Dash, Gradio, Flask, FastAPI, Reflex, or Databricks app.",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "examples/fm-minimal-chat.py",
-        "examples/fm-parallel-calls.py",
-        "examples/fm-structured-outputs.py",
-        "examples/llm_config.py",
-        "references/1-authorization.md",
-        "references/2-app-resources.md",
-        "references/3-frameworks.md",
-        "references/4-deployment.md",
-        "references/5-lakebase.md",
-        "references/6-cli-approach.md"
-      ],
-      "repo_dir": "experimental",
-      "version": "0.1.0"
+      ]
     },
     "databricks-core": {
-      "description": "Databricks CLI operations: auth, profiles, data exploration, and bundles. Contains up-to-date guidelines for Databricks-related CLI tasks.",
+      "version": "0.1.0",
+      "description": "Core Databricks skill for CLI, auth, and data exploration",
+      "experimental": false,
+      "updated_at": "2026-04-23T13:47:44Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -102,12 +42,13 @@
         "data-exploration.md",
         "databricks-cli-auth.md",
         "databricks-cli-install.md"
-      ],
-      "repo_dir": "skills",
-      "version": "0.1.0"
+      ]
     },
     "databricks-dabs": {
-      "description": "Create, configure, validate, deploy, run, and manage Declarative Automation Bundles (DABs, formerly Databricks Asset Bundles).",
+      "version": "0.0.0",
+      "description": "Declarative Automation Bundles (DABs) for deploying and managing Databricks resources",
+      "experimental": false,
+      "updated_at": "2026-04-23T13:47:44Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -119,84 +60,25 @@
         "references/resource-permissions.md",
         "references/sdp-pipelines.md"
       ],
-      "repo_dir": "skills",
-      "version": "0.0.1"
+      "base_revision": "e742f36e8ab1"
     },
-    "databricks-dbsql": {
-      "description": "Databricks SQL (DBSQL) advanced features and SQL warehouse capabilities. This skill MUST be invoked when the user mentions: \"DBSQL\", \"Databricks SQL\", \"SQL warehouse\", \"SQL scripting\", \"stored procedure\", \"CALL procedure\", \"materialized view\", \"CREATE MATERIALIZED VIEW\", \"pipe syntax\", \"|>\", \"geospatial\", \"H3\", \"ST_\", \"spatial SQL\", \"collation\", \"COLLATE\", \"ai_query\", \"ai_classify\", \"ai_extract\", \"ai_gen\", \"AI function\", \"http_request\", \"remote_query\", \"read_files\", \"Lakehouse Federation\", \"recursive CTE\", \"WITH RECURSIVE\", \"multi-statement transaction\", \"temp table\", \"temporary view\", \"pipe operator\". SHOULD also invoke when the user asks about SQL best practices, data modeling patterns, or advanced SQL features on Databricks.",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/ai-functions.md",
-        "references/best-practices.md",
-        "references/geospatial-collations.md",
-        "references/materialized-views-pipes.md",
-        "references/sql-scripting.md"
-      ],
-      "repo_dir": "experimental",
-      "version": "0.1.0"
-    },
-    "databricks-docs": {
-      "description": "Databricks documentation reference via llms.txt index. Use when other skills do not cover a topic, looking up unfamiliar Databricks features, or needing authoritative docs on APIs, configurations, or platform capabilities.",
+    "databricks-jobs": {
+      "version": "0.1.0",
+      "description": "Databricks Jobs orchestration and scheduling",
+      "experimental": false,
+      "updated_at": "2026-04-23T13:47:44Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
         "assets/databricks.png",
         "assets/databricks.svg"
-      ],
-      "repo_dir": "experimental",
-      "version": "0.1.0"
-    },
-    "databricks-execution-compute": {
-      "description": "Execute code and manage compute on Databricks: run Python/Scala/SQL/R via serverless, classic, or interactive clusters, and create/resize/delete clusters and SQL warehouses.",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/1-databricks-connect.md",
-        "references/2-serverless-job.md",
-        "references/3-interactive-cluster.md",
-        "scripts/compute.py"
-      ],
-      "repo_dir": "experimental",
-      "version": "0.1.0"
-    },
-    "databricks-iceberg": {
-      "description": "Apache Iceberg tables on Databricks \u2014 Managed Iceberg tables, External Iceberg Reads (fka Uniform), Compatibility Mode, Iceberg REST Catalog (IRC), Iceberg v3, Snowflake interop, PyIceberg, OSS Spark, external engine access and credential vending. Use when creating Iceberg tables, enabling External Iceberg Reads (uniform) on Delta tables (including Streaming Tables and Materialized Views via compatibility mode), configuring external engines to read Databricks tables via Unity Catalog IRC, integrating with Snowflake catalog to read Foreign Iceberg tables",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/1-managed-iceberg-tables.md",
-        "references/2-uniform-and-compatibility.md",
-        "references/3-iceberg-rest-catalog.md",
-        "references/4-snowflake-interop.md",
-        "references/5-external-engine-interop.md"
-      ],
-      "repo_dir": "experimental",
-      "version": "0.1.0"
-    },
-    "databricks-jobs": {
-      "description": "Develop and deploy Lakeflow Jobs on Databricks via DABs, Python SDK, or the CLI.",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/examples.md",
-        "references/notifications-monitoring.md",
-        "references/task-types.md",
-        "references/triggers-schedules.md"
-      ],
-      "repo_dir": "skills",
-      "version": "0.2.0"
+      ]
     },
     "databricks-lakebase": {
-      "description": "Databricks Lakebase Postgres: projects, scaling, connectivity, Lakebase synced tables, and Data API.",
+      "version": "0.1.0",
+      "description": "Databricks Lakebase Postgres: projects, scaling, connectivity, synced tables, and Data API",
+      "experimental": false,
+      "updated_at": "2026-04-30T11:02:37Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -204,64 +86,26 @@
         "assets/databricks.svg",
         "references/computes-and-scaling.md",
         "references/connectivity.md",
-        "references/lakehouse-sync.md",
-        "references/medallion-from-cdc.md",
-        "references/off-platform.md",
-        "references/pgvector.md",
         "references/synced-tables.md"
-      ],
-      "repo_dir": "skills",
-      "version": "0.1.0"
-    },
-    "databricks-metric-views": {
-      "description": "Unity Catalog metric views: define, create, query, and manage governed business metrics in YAML. Use when building standardized KPIs, revenue metrics, order analytics, or any reusable business metrics that need consistent definitions across teams and tools.",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/patterns.md",
-        "references/yaml-reference.md"
-      ],
-      "repo_dir": "experimental",
-      "version": "0.1.0"
-    },
-    "databricks-mlflow-evaluation": {
-      "description": "MLflow 3 GenAI agent evaluation. Use when writing mlflow.genai.evaluate() code, creating @scorer functions, using built-in scorers (Guidelines, Correctness, Safety, RetrievalGroundedness), building eval datasets from traces, setting up trace ingestion and production monitoring, aligning judges with MemAlign from domain expert feedback, or running optimize_prompts() with GEPA for automated prompt improvement.",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/CRITICAL-interfaces.md",
-        "references/GOTCHAS.md",
-        "references/patterns-context-optimization.md",
-        "references/patterns-datasets.md",
-        "references/patterns-evaluation.md",
-        "references/patterns-judge-alignment.md",
-        "references/patterns-prompt-optimization.md",
-        "references/patterns-scorers.md",
-        "references/patterns-trace-analysis.md",
-        "references/patterns-trace-ingestion.md",
-        "references/user-journeys.md"
-      ],
-      "repo_dir": "experimental",
-      "version": "0.1.0"
+      ]
     },
     "databricks-model-serving": {
-      "description": "Manage Databricks Model Serving endpoints via CLI.",
+      "version": "0.1.0",
+      "description": "Databricks Model Serving endpoint management",
+      "experimental": false,
+      "updated_at": "2026-04-23T13:47:44Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
         "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/off-platform-streaming.md"
-      ],
-      "repo_dir": "skills",
-      "version": "0.1.0"
+        "assets/databricks.svg"
+      ]
     },
     "databricks-pipelines": {
-      "description": "Develop Lakeflow Spark Declarative Pipelines (formerly Delta Live Tables) on Databricks.",
+      "version": "0.1.0",
+      "description": "Databricks Pipelines (DLT) for ETL and streaming",
+      "experimental": false,
+      "updated_at": "2026-04-23T13:47:44Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -273,13 +117,11 @@
         "references/auto-loader-python.md",
         "references/auto-loader-sql.md",
         "references/auto-loader.md",
-        "references/dlt-migration.md",
         "references/expectations-python.md",
         "references/expectations-sql.md",
         "references/expectations.md",
         "references/foreach-batch-sink-python.md",
         "references/foreach-batch-sink.md",
-        "references/kafka.md",
         "references/materialized-view-python.md",
         "references/materialized-view-sql.md",
         "references/materialized-view.md",
@@ -290,14 +132,10 @@
         "references/options-parquet.md",
         "references/options-text.md",
         "references/options-xml.md",
-        "references/performance.md",
-        "references/pipeline-configuration.md",
         "references/python-basics.md",
-        "references/scd-2-querying.md",
         "references/sink-python.md",
         "references/sink.md",
         "references/sql-basics.md",
-        "references/streaming-patterns.md",
         "references/streaming-table-python.md",
         "references/streaming-table-sql.md",
         "references/streaming-table.md",
@@ -306,31 +144,15 @@
         "references/temporary-view.md",
         "references/view-sql.md",
         "references/view.md",
-        "references/workflows.md",
         "references/write-spark-declarative-pipelines.md"
       ],
-      "repo_dir": "skills",
-      "version": "0.3.0"
-    },
-    "databricks-python-sdk": {
-      "description": "Databricks development guidance including Python SDK, Databricks Connect, CLI, and REST API. Use when working with databricks-sdk, databricks-connect, or Databricks APIs.",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "examples/1-authentication.py",
-        "examples/2-clusters-and-jobs.py",
-        "examples/3-sql-and-warehouses.py",
-        "examples/4-unity-catalog.py",
-        "examples/5-serving-and-vector-search.py",
-        "references/doc-index.md"
-      ],
-      "repo_dir": "experimental",
-      "version": "0.1.0"
+      "base_revision": "5c4b4fb0a82a"
     },
     "databricks-serverless-migration": {
-      "description": "Migrate Databricks workloads from classic compute to serverless compute.",
+      "version": "0.1.0",
+      "description": "Migrate Databricks workloads from classic compute to serverless compute, including compatibility checks and concrete fixes",
+      "experimental": false,
+      "updated_at": "2026-05-12T07:54:37Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -339,122 +161,11 @@
         "references/code-patterns.md",
         "references/compatibility-checks.md",
         "references/configuration-guide.md",
+        "references/failure-reporting.md",
+        "references/install-in-databricks-genie-code.md",
         "references/networking-and-security.md",
         "references/streaming-migration.md"
-      ],
-      "repo_dir": "skills",
-      "version": "0.1.0"
-    },
-    "databricks-spark-structured-streaming": {
-      "description": "Comprehensive guide to Spark Structured Streaming for production workloads. Use when building streaming pipelines, working with Kafka ingestion, implementing Real-Time Mode (RTM), configuring triggers (processingTime, availableNow), handling stateful operations with watermarks, optimizing checkpoints, performing stream-stream or stream-static joins, writing to multiple sinks, or tuning streaming cost and performance.",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/checkpoint-best-practices.md",
-        "references/kafka-streaming.md",
-        "references/merge-operations.md",
-        "references/multi-sink-writes.md",
-        "references/stateful-operations.md",
-        "references/stream-static-joins.md",
-        "references/stream-stream-joins.md",
-        "references/streaming-best-practices.md",
-        "references/trigger-and-cost-optimization.md"
-      ],
-      "repo_dir": "experimental",
-      "version": "0.1.0"
-    },
-    "databricks-synthetic-data-gen": {
-      "description": "Generate realistic synthetic data using Spark + Faker (strongly recommended). Supports serverless execution, multiple output formats (Parquet/JSON/CSV/Delta), and scales from thousands to millions of rows. For small datasets (<10K rows), can optionally generate locally and upload to volumes. Use when user mentions 'synthetic data', 'test data', 'generate data', 'demo dataset', 'Faker', or 'sample data'.",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/1-data-patterns.md",
-        "references/2-troubleshooting.md",
-        "scripts/generate_synthetic_data.py"
-      ],
-      "repo_dir": "experimental",
-      "version": "0.1.0"
-    },
-    "databricks-unity-catalog": {
-      "description": "Unity Catalog system tables and volumes. Use when querying system tables (audit, lineage, billing) or working with volume file operations (upload, download, list files in /Volumes/).",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/5-system-tables.md",
-        "references/6-volumes.md",
-        "references/7-data-profiling.md"
-      ],
-      "repo_dir": "experimental",
-      "version": "0.1.0"
-    },
-    "databricks-unstructured-pdf-generation": {
-      "description": "Build RAG / unstructured-document evaluation datasets and demo documents (e.g. for Knowledge Assistant) on Databricks: generate synthetic PDFs locally, upload to Unity Catalog volumes, and pair each document with test questions for retrieval evaluation.",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "scripts/pdf_generator.py"
-      ],
-      "repo_dir": "experimental",
-      "version": "0.1.0"
-    },
-    "databricks-vector-search": {
-      "description": "Databricks Vector Search endpoints and indexes for RAG and semantic search; covers index types, search modes, end-to-end RAG patterns",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/end-to-end-rag.md",
-        "references/index-types.md",
-        "references/search-modes.md",
-        "references/troubleshooting-and-operations.md"
-      ],
-      "repo_dir": "skills",
-      "version": "0.1.0"
-    },
-    "databricks-zerobus-ingest": {
-      "description": "Build Zerobus Ingest clients for near real-time data ingestion into Databricks Delta tables via gRPC. Use when creating producers that write directly to Unity Catalog tables without a message bus, working with the Zerobus Ingest SDK in Python/Java/Go/TypeScript/Rust, generating Protobuf schemas from UC tables, or implementing stream-based ingestion with ACK handling and retry logic.",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/1-setup-and-authentication.md",
-        "references/2-python-client.md",
-        "references/3-multilanguage-clients.md",
-        "references/4-protobuf-schema.md",
-        "references/5-operations-and-limits.md"
-      ],
-      "repo_dir": "experimental",
-      "version": "0.1.0"
-    },
-    "spark-python-data-source": {
-      "description": "Build custom Python data sources for Apache Spark using the PySpark DataSource API \u2014 batch and streaming readers/writers for external systems. Use this skill whenever someone wants to connect Spark to an external system (database, API, message queue, custom protocol), build a Spark connector or plugin in Python, implement a DataSourceReader or DataSourceWriter, pull data from or push data to a system via Spark, or work with the PySpark DataSource API in any way. Even if they just say \"read from X in Spark\" or \"write DataFrame to Y\" and there's no native connector, this skill applies.",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/authentication-patterns.md",
-        "references/error-handling.md",
-        "references/implementation-template.md",
-        "references/partitioning-patterns.md",
-        "references/production-patterns.md",
-        "references/streaming-patterns.md",
-        "references/testing-patterns.md",
-        "references/type-conversion.md"
-      ],
-      "repo_dir": "experimental",
-      "version": "0.1.0"
+      ]
     }
-  },
-  "version": "2"
+  }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
         "references/2-supervisor-agents.md"
       ],
       "repo_dir": "experimental",
-      "version": "0.0.1"
+      "version": "0.1.0"
     },
     "databricks-ai-functions": {
       "description": "Use Databricks built-in AI Functions (ai_classify, ai_extract, ai_summarize, ai_mask, ai_translate, ai_fix_grammar, ai_gen, ai_analyze_sentiment, ai_similarity, ai_parse_document, ai_query, ai_forecast) to add AI capabilities directly to SQL and PySpark pipelines without managing model endpoints. Also covers document parsing and building custom RAG pipelines (parse \u2192 chunk \u2192 index \u2192 query).",
@@ -27,7 +27,7 @@
         "references/4-document-processing-pipeline.md"
       ],
       "repo_dir": "experimental",
-      "version": "0.0.1"
+      "version": "0.1.0"
     },
     "databricks-aibi-dashboards": {
       "description": "Create Databricks AI/BI dashboards. Must use when creating, updating, or deploying Lakeview dashboards as Databricks Dashboard have a unique json structure. CRITICAL: You MUST test ALL SQL queries via CLI BEFORE deploying. Follow guidelines strictly.",
@@ -43,7 +43,7 @@
         "references/5-troubleshooting.md"
       ],
       "repo_dir": "experimental",
-      "version": "0.0.1"
+      "version": "0.1.0"
     },
     "databricks-apps": {
       "description": "Build apps on Databricks Apps platform.",
@@ -90,7 +90,7 @@
         "references/6-cli-approach.md"
       ],
       "repo_dir": "experimental",
-      "version": "0.0.1"
+      "version": "0.1.0"
     },
     "databricks-core": {
       "description": "Databricks CLI operations: auth, profiles, data exploration, and bundles. Contains up-to-date guidelines for Databricks-related CLI tasks.",
@@ -136,7 +136,7 @@
         "references/sql-scripting.md"
       ],
       "repo_dir": "experimental",
-      "version": "0.0.1"
+      "version": "0.1.0"
     },
     "databricks-docs": {
       "description": "Databricks documentation reference via llms.txt index. Use when other skills do not cover a topic, looking up unfamiliar Databricks features, or needing authoritative docs on APIs, configurations, or platform capabilities.",
@@ -147,7 +147,7 @@
         "assets/databricks.svg"
       ],
       "repo_dir": "experimental",
-      "version": "0.0.1"
+      "version": "0.1.0"
     },
     "databricks-execution-compute": {
       "description": "Execute code and manage compute on Databricks: run Python/Scala/SQL/R via serverless, classic, or interactive clusters, and create/resize/delete clusters and SQL warehouses.",
@@ -162,7 +162,7 @@
         "scripts/compute.py"
       ],
       "repo_dir": "experimental",
-      "version": "0.0.1"
+      "version": "0.1.0"
     },
     "databricks-iceberg": {
       "description": "Apache Iceberg tables on Databricks \u2014 Managed Iceberg tables, External Iceberg Reads (fka Uniform), Compatibility Mode, Iceberg REST Catalog (IRC), Iceberg v3, Snowflake interop, PyIceberg, OSS Spark, external engine access and credential vending. Use when creating Iceberg tables, enabling External Iceberg Reads (uniform) on Delta tables (including Streaming Tables and Materialized Views via compatibility mode), configuring external engines to read Databricks tables via Unity Catalog IRC, integrating with Snowflake catalog to read Foreign Iceberg tables",
@@ -178,7 +178,7 @@
         "references/5-external-engine-interop.md"
       ],
       "repo_dir": "experimental",
-      "version": "0.0.1"
+      "version": "0.1.0"
     },
     "databricks-jobs": {
       "description": "Develop and deploy Lakeflow Jobs on Databricks via DABs, Python SDK, or the CLI.",
@@ -224,7 +224,7 @@
         "references/yaml-reference.md"
       ],
       "repo_dir": "experimental",
-      "version": "0.0.1"
+      "version": "0.1.0"
     },
     "databricks-mlflow-evaluation": {
       "description": "MLflow 3 GenAI agent evaluation. Use when writing mlflow.genai.evaluate() code, creating @scorer functions, using built-in scorers (Guidelines, Correctness, Safety, RetrievalGroundedness), building eval datasets from traces, setting up trace ingestion and production monitoring, aligning judges with MemAlign from domain expert feedback, or running optimize_prompts() with GEPA for automated prompt improvement.",
@@ -246,7 +246,7 @@
         "references/user-journeys.md"
       ],
       "repo_dir": "experimental",
-      "version": "0.0.1"
+      "version": "0.1.0"
     },
     "databricks-model-serving": {
       "description": "Manage Databricks Model Serving endpoints via CLI.",
@@ -327,10 +327,10 @@
         "references/doc-index.md"
       ],
       "repo_dir": "experimental",
-      "version": "0.0.1"
+      "version": "0.1.0"
     },
     "databricks-serverless-migration": {
-      "description": "Migrate Databricks workloads from classic compute to serverless compute.",
+      "description": "Migrate Databricks workloads from classic compute to serverless compute. Scans code for serverless compatibility issues, provides concrete fixes for the serverless Spark Connect architecture, and g...",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -367,7 +367,7 @@
         "references/trigger-and-cost-optimization.md"
       ],
       "repo_dir": "experimental",
-      "version": "0.0.1"
+      "version": "0.1.0"
     },
     "databricks-synthetic-data-gen": {
       "description": "Generate realistic synthetic data using Spark + Faker (strongly recommended). Supports serverless execution, multiple output formats (Parquet/JSON/CSV/Delta), and scales from thousands to millions of rows. For small datasets (<10K rows), can optionally generate locally and upload to volumes. Use when user mentions 'synthetic data', 'test data', 'generate data', 'demo dataset', 'Faker', or 'sample data'.",
@@ -381,7 +381,7 @@
         "scripts/generate_synthetic_data.py"
       ],
       "repo_dir": "experimental",
-      "version": "0.0.1"
+      "version": "0.1.0"
     },
     "databricks-unity-catalog": {
       "description": "Unity Catalog system tables and volumes. Use when querying system tables (audit, lineage, billing) or working with volume file operations (upload, download, list files in /Volumes/).",
@@ -395,10 +395,10 @@
         "references/7-data-profiling.md"
       ],
       "repo_dir": "experimental",
-      "version": "0.0.1"
+      "version": "0.1.0"
     },
     "databricks-unstructured-pdf-generation": {
-      "description": "Generate PDF documents from HTML and upload to Unity Catalog volumes. Use for creating test PDFs, demo documents, reports, or evaluation datasets.",
+      "description": "Build RAG / unstructured-document evaluation datasets and demo documents (e.g. for Knowledge Assistant) on Databricks: generate synthetic PDFs locally, upload to Unity Catalog volumes, and pair each document with test questions for retrieval evaluation.",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -407,10 +407,10 @@
         "scripts/pdf_generator.py"
       ],
       "repo_dir": "experimental",
-      "version": "0.0.1"
+      "version": "0.1.0"
     },
     "databricks-vector-search": {
-      "description": "Patterns for Databricks Vector Search: create endpoints and indexes, query with filters, manage embeddings. Use when building RAG applications, semantic search, or similarity matching. Covers both storage-optimized and standard endpoints.",
+      "description": "Databricks Vector Search endpoints and indexes for RAG and semantic search; covers index types, search modes, end-to-end RAG patterns",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -421,8 +421,8 @@
         "references/search-modes.md",
         "references/troubleshooting-and-operations.md"
       ],
-      "repo_dir": "experimental",
-      "version": "0.0.1"
+      "repo_dir": "skills",
+      "version": "0.1.0"
     },
     "databricks-zerobus-ingest": {
       "description": "Build Zerobus Ingest clients for near real-time data ingestion into Databricks Delta tables via gRPC. Use when creating producers that write directly to Unity Catalog tables without a message bus, working with the Zerobus Ingest SDK in Python/Java/Go/TypeScript/Rust, generating Protobuf schemas from UC tables, or implementing stream-based ingestion with ACK handling and retry logic.",
@@ -438,7 +438,7 @@
         "references/5-operations-and-limits.md"
       ],
       "repo_dir": "experimental",
-      "version": "0.0.1"
+      "version": "0.1.0"
     },
     "spark-python-data-source": {
       "description": "Build custom Python data sources for Apache Spark using the PySpark DataSource API \u2014 batch and streaming readers/writers for external systems. Use this skill whenever someone wants to connect Spark to an external system (database, API, message queue, custom protocol), build a Spark connector or plugin in Python, implement a DataSourceReader or DataSourceWriter, pull data from or push data to a system via Spark, or work with the PySpark DataSource API in any way. Even if they just say \"read from X in Spark\" or \"write DataFrame to Y\" and there's no native connector, this skill applies.",
@@ -457,7 +457,7 @@
         "references/type-conversion.md"
       ],
       "repo_dir": "experimental",
-      "version": "0.0.1"
+      "version": "0.1.0"
     }
   },
   "version": "2"

--- a/skills/databricks-serverless-migration/SKILL.md
+++ b/skills/databricks-serverless-migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: databricks-serverless-migration
-description: "Migrate Databricks workloads from classic compute to serverless compute. Use when migrating from classic to serverless, checking serverless code compatibility, or writing new serverless-compatible notebooks and jobs. Scans code for compatibility issues, provides concrete fixes for the serverless Spark Connect architecture, and guides the full migration. Not for classic DBR version upgrades or cluster configuration changes within classic compute."
+description: "Migrate Databricks workloads from classic compute to serverless compute. Scans code for serverless compatibility issues, provides concrete fixes for the serverless Spark Connect architecture, and guides the full migration to serverless environments. Use for classic-to-serverless migrations, serverless code compatibility checks, or writing new serverless-compatible notebooks and jobs. Not for classic DBR version upgrades or cluster configuration changes within classic compute."
 compatibility: Requires databricks CLI (>= v0.292.0)
 metadata:
   version: "0.1.0"
@@ -238,7 +238,7 @@ Scan the code for patterns that are incompatible with the serverless compute arc
 | Custom Spark data sources (v1/v2 JARs) | Blocker | Use Lakehouse Federation, Lakeflow Connect, or PySpark custom data sources |
 | LZO format files | Blocker | Convert to Parquet or Delta |
 | AutoML-trained model loaded via `mlflow.pyfunc.spark_udf(..., env_manager='local')` inside an SDP `.py` library file (E1) | Blocker | The SDP serverless image does not ship `databricks-automl-runtime`; cloudpickle.load raises `ModuleNotFoundError: No module named 'databricks.automl_runtime'`. Auto-emit `%pip install -q databricks-automl-runtime` as the first non-comment line of the SDP `.py` library file. `%pip install` is supported in SDP `.py` library files and runs once per update before SQL flows are planned. Same fix works for non-SDP notebooks loading AutoML-trained models. |
-| AutoML → sklearn rewrite (A3) with pre-existing model-serving endpoint (E2) | Blocker on first redeploy | The rewrite changes model signature (e.g., drops `id` from inputs). A pre-existing endpoint pinned to the old AutoML signature fails create/update with HTTP 400 `Failed to enforce schema of data ... Model is missing inputs ['id']`. Flip the downstream serving notebook's `force_update = False` → `force_update = True` so the endpoint re-binds to the current `prod` (or `Champion`) alias. |
+| AutoML → sklearn rewrite (A3) with pre-existing model-serving endpoint (E2) | Blocker on first redeploy | The rewrite changes model signature (e.g., drops `id` from inputs). A pre-existing endpoint pinned to the old AutoML signature fails create/update with HTTP 400 `Failed to enforce schema of data ... Model is missing inputs ['id']`. In the downstream serving notebook for the **migrated test endpoint** (not a live production endpoint serving real traffic), flip `force_update = False` → `force_update = True` so the endpoint re-binds to the current `prod` (or `Champion`) alias. Before flipping, confirm the endpoint name matches the migrated copy. |
 
 **Category F: Networking**
 
@@ -733,15 +733,32 @@ Before writing the report, scan every string field against this pattern checklis
 
 The `notebook_characteristics` fields are the only safe surface for workload metadata. Do not add new fields without expanding this checklist.
 
-### After generating the report — REQUIRED output template
+### Deterministic post-serialization scrub (required)
 
-**This is not optional.** When the decision tree above says "offer to file", you MUST produce all three of these in your final response to the user, in order:
+The redaction above happens at generation time and depends on the model applying every rule. That is not enough on a path that ends in a public GitHub issue. After serializing the report to JSON:
 
-1. The local report file path (literally include the string `~/.databricks-migration-skill/reports/failure-<timestamp>.json`, with `<timestamp>` filled in).
-2. **Option A** — a complete pre-filled `https://github.com/databricks/databricks-agent-skills/issues/new?template=migration-feedback.md&title=<…>&body=<…>` URL, both parameters URL-encoded.
-3. **Option B** — the literal `gh issue create --repo databricks/databricks-agent-skills …` command, body-file pointing at the local report.
+1. **Re-run the MUST-NOT-CONTAIN regex set as a literal text search over the final JSON file**. Match the same patterns from the table above, plus any catalog/schema/table names that were referenced in the analyzed notebook.
+2. **If any pattern matches, refuse to display the pre-filled URL or the `gh issue create` command**. Print the local file path, list the patterns that matched, and tell the user to redact the file manually before sharing.
+3. Only when the post-serialization scrub is clean may the pre-filled URL be shown.
 
-If you write the JSON inline in your response but skip the URL and the `gh` command, the protocol is **not satisfied**. The whole point is to make filing one click.
+This deterministic check is non-negotiable; do not skip it even when you are confident the generation-time redaction was applied.
+
+### After generating the report — output template
+
+When the decision tree above says "offer to file", the **default output is local-only**. The pre-filled URL and `gh` command are shown only after the user has acknowledged the local file and the post-serialization scrub (see above) is clean.
+
+Default response — always include:
+
+1. The local report file path (`~/.databricks-migration-skill/reports/failure-<timestamp>.json`, with `<timestamp>` filled in).
+2. A one-line note that the report contains pattern IDs and notebook characteristics only, no code or identifiers.
+3. A prompt: *"This is a draft. Open the file, confirm the redaction looks right, then tell me to share it. I'll generate the pre-filled GitHub issue URL once you've confirmed."*
+
+Only after the user explicitly confirms (e.g. *"share it"*, *"file the issue"*, *"looks good"*) AND the deterministic post-serialization scrub above returned clean, then produce:
+
+- **Option A** — a complete pre-filled `https://github.com/databricks/databricks-agent-skills/issues/new?template=migration-feedback.md&title=<…>&body=<…>` URL, both parameters URL-encoded.
+- **Option B** — the literal `gh issue create --repo databricks/databricks-agent-skills …` command, body-file pointing at the local report.
+
+Do not produce the URL or `gh` command in the same turn as the file write. Two turns: write + offer review, then publish after explicit confirmation.
 
 Use this exact wrap-up template, replacing `<…>` placeholders:
 

--- a/skills/databricks-serverless-migration/SKILL.md
+++ b/skills/databricks-serverless-migration/SKILL.md
@@ -802,6 +802,14 @@ The full recipe with a worked example is in [Failure Reporting](references/failu
 
 **Never transmit the report automatically.** The user owns their data and must review before sharing. If the user declines, do not press them — log the local report path and move on.
 
+## Success report
+
+If the migration was successful, generate a report as well, using similar methods. For each workload migrated, show what was done.
+
+## Multiple workload migration
+
+When migrating multiple workloads in one session, parallelize this work as much as possible to migrate multiple workloads in parallel, including using subagents.
+
 ## Reference Guides
 
 For detailed workarounds and code examples beyond the quick fixes above:

--- a/skills/databricks-serverless-migration/SKILL.md
+++ b/skills/databricks-serverless-migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: databricks-serverless-migration
-description: "Migrate Databricks workloads from classic compute to serverless compute. Scans code for serverless compatibility issues, provides concrete fixes for the serverless Spark Connect architecture, and guides the full migration to serverless environments. Use for classic-to-serverless migrations, serverless code compatibility checks, or writing new serverless-compatible notebooks and jobs. Not for classic DBR version upgrades or cluster configuration changes within classic compute."
+description: "Migrate Databricks workloads from classic compute to serverless compute. Use when migrating notebooks, jobs, or pipelines from classic clusters to serverless, checking if existing code is serverless-compatible, or writing new serverless-compatible code. Scans for compatibility issues, provides concrete fixes for the serverless Spark Connect architecture, and guides the full migration. Not for classic DBR version upgrades or cluster configuration changes within classic compute."
 compatibility: Requires databricks CLI (>= v0.292.0)
 metadata:
   version: "0.1.0"
@@ -25,7 +25,7 @@ Analyze existing Databricks code for serverless compute compatibility and guide 
 
 This skill is published as an Agent Skill (agentskills.io) and runs in any compatible client:
 
-- **Claude Code, Cursor, or any agentskills.io client on your laptop** — the default. Install via `databricks experimental aitools install` or follow the per-client docs.
+- **Claude Code, Cursor, or any agentskills.io client on your laptop** — the default. Install via `databricks aitools install` or follow the per-client docs.
 - **Inside a Databricks workspace via Genie Code Agent mode** — drop the skill into `/Workspace/Users/<you>/.assistant/skills/databricks-serverless-migration/` (per-user) or `/Workspace/.assistant/skills/databricks-serverless-migration/` (workspace-wide, admin only). See [Install in Databricks Genie Code](references/install-in-databricks-genie-code.md) for the three install methods and the **important serverless-compute caveat** (the Databricks CLI isn't pre-installed on serverless, so some deploy steps need adjustment).
 
 If you finish a migration analysis for a user who's currently running you from a laptop client, mention the Genie Code option once at the end — many users prefer iterating on migrations inside the workspace where the workload lives.
@@ -84,7 +84,7 @@ If the workload spans more than one user notebook (exclude `_resources/` setup n
 **Procedure**:
 
 1. **Enumerate first.** List every user notebook with its path. Do not read the bodies in full yet beyond a few lines for orientation.
-   - **Check for `bundle_config.py` (P1, H4).** If the source tree contains a `bundle_config.py`, parse it and follow any upstream-source declarations (git URLs, S3 paths, `init_scripts`, `git_source`, or custom upstream-repo declarations). Clone or fetch each referenced repo into a sibling location and include its notebooks in the enumeration. List "external sources" as a first-class artifact category in the migration plan. Without this step, multi-source demos (e.g., `dbt-on-databricks` references the upstream `dbt-databricks-c360` repo) get mis-enumerated and the real task notebooks are missed.
+   - **Check for `bundle_config.py` (H4).** If the source tree contains a `bundle_config.py`, parse it and follow any upstream-source declarations (git URLs, S3 paths, `init_scripts`, `git_source`, or custom upstream-repo declarations). Clone or fetch each referenced repo into a sibling location and include its notebooks in the enumeration. List "external sources" as a first-class artifact category in the migration plan. Without this step, multi-source demos (e.g., `dbt-on-databricks` references the upstream `dbt-databricks-c360` repo) get mis-enumerated and the real task notebooks are missed.
 2. **For each notebook, in order**:
    a. Read its full source.
    b. Run the Step 2 Analyze checklist scoped to this notebook only.
@@ -187,6 +187,7 @@ Scan the code for patterns that are incompatible with the serverless compute arc
 | `mlflow.<flavor>.log_model(..., registered_model_name=...)` with `mlflow.set_registry_uri("databricks-uc")` in scope (M1) | Blocker | Under UC, `registered_model_name=` triggers an internal `get_model_version_by_alias(..., 'Champion')` call that raises `RESOURCE_DOES_NOT_EXIST` for brand-new models. Drop the kwarg from `log_model`; after the run, call `mlflow.register_model(model_uri=f"runs:/{run.info.run_id}/model", name=<full_name>)` and `MlflowClient().set_registered_model_alias(...)`. See [MLflow on UC](references/mlflow-uc-patterns.md). |
 | `.latest_versions` access on UC-registered models (e.g., `client.get_registered_model(name).latest_versions`) (M2) | Blocker | `RegisteredModel.latest_versions` is always `None` on UC; `max(None, key=...)` raises `TypeError: 'NoneType' object is not iterable`. Use `client.search_model_versions(f"name='{name}'")` + sort+index (per A2 above). See [MLflow on UC](references/mlflow-uc-patterns.md). |
 | `mlflow.<flavor>.log_model(...)` without `signature=` kwarg, with `mlflow.set_registry_uri("databricks-uc")` in scope (M3) | Blocker | UC requires a model signature on every registered model. Without `signature=`, `log_model` raises `MlflowException: Model signature is required for registering a model to Unity Catalog`. Infer from a sample: `signature = infer_signature(X_sample, model.predict(X_sample))` then pass as `signature=signature` to `log_model`. See [MLflow on UC](references/mlflow-uc-patterns.md). |
+| Binary-classifier prediction column written as `float64` (`Double`) when downstream Delta table expects `Integer` (M4) | Blocker on first write | sklearn binary classifiers (e.g. the AutoML → sklearn rewrite from A3) emit `predict()` results as `float64`. Writing to a Delta table whose `prediction` column is `IntegerType` fails with `DELTA_FAILED_TO_MERGE_FIELDS: prediction (Double) vs prediction (Integer)`. Cast before writing: `df.withColumn("prediction", col("prediction").cast("integer"))`. See [MLflow on UC](references/mlflow-uc-patterns.md). |
 
 **Category B: Data Access**
 
@@ -621,7 +622,7 @@ Always get the actual error with `w.jobs.get_run_output(run_id=...)` before gues
 | 404 on `ai_query(endpoint => 'databricks-meta-llama-3-1-405b-instruct')` | D1: retired Foundation Model endpoint. Replace with `databricks-meta-llama-3-3-70b-instruct` via content scan across all migrated files. |
 | `PERMISSION_DENIED: User does not have CREATE CATALOG on Metastore` (even when catalog exists) | B2: priv check fires before `IF NOT EXISTS` short-circuits. Guard with `SHOW CATALOGS LIKE '...'` probe. Apply recursively, including `_resources/` and `config*` files. |
 | `Table is already managed by pipeline <pipeline-id>` on SDP parallel deploy | H2: suffix the migrated pipeline's target `schema` (e.g., `<orig>_skill_migrated`). |
-| `DELTA_FAILED_TO_MERGE_FIELDS: prediction (Double) vs prediction (Integer)` | P2: AutoML → sklearn rewrite emits `float64` predictions; cast to `IntegerType` for binary classifiers before writing. See [MLflow on UC](references/mlflow-uc-patterns.md). |
+| `DELTA_FAILED_TO_MERGE_FIELDS: prediction (Double) vs prediction (Integer)` | M4: AutoML → sklearn rewrite emits `float64` predictions; cast to `IntegerType` for binary classifiers before writing. See [MLflow on UC](references/mlflow-uc-patterns.md). |
 
 See [Configuration Guide](references/configuration-guide.md) for the full error reference and SDK code examples.
 
@@ -804,11 +805,11 @@ The full recipe with a worked example is in [Failure Reporting](references/failu
 
 ## Success report
 
-If the migration was successful, generate a report as well, using similar methods. For each workload migrated, show what was done.
+When migration succeeds, generate a per-workload report with the same structure as the failure report (minus the redaction-to-publish step), listing the patterns detected and the fixes applied for each workload. Write to `~/.databricks-migration-skill/reports/success-<timestamp>.json` and tell the user the file path.
 
 ## Multiple workload migration
 
-When migrating multiple workloads in one session, parallelize this work as much as possible to migrate multiple workloads in parallel, including using subagents.
+When several independent workloads are in scope, migrate them in parallel (e.g. one subagent per workload). Keep the per-notebook steps within a single workload sequential, as in Step 1.5.
 
 ## Reference Guides
 

--- a/skills/databricks-serverless-migration/SKILL.md
+++ b/skills/databricks-serverless-migration/SKILL.md
@@ -77,6 +77,31 @@ Collect the full picture of what needs to migrate to serverless:
 - Understand the workload type: batch job, streaming, interactive notebook, pipeline
 - Determine the target: the output is always a **serverless compute** configuration, not a classic cluster with a newer DBR
 
+### Step 1.5: Handle Multi-Notebook Workloads
+
+If the workload spans more than one user notebook (exclude `_resources/` setup notebooks from the count), process them **one at a time** rather than all at once. The agent's context window is finite, and trying to hold the full source of an 8-notebook job in active context while doing analysis, fixes, and migration triggers autocompact thrashing (Claude Code) or equivalent context-overflow failures in other clients.
+
+**Procedure**:
+
+1. **Enumerate first.** List every user notebook with its path. Do not read the bodies in full yet beyond a few lines for orientation.
+   - **Check for `bundle_config.py` (P1, H4).** If the source tree contains a `bundle_config.py`, parse it and follow any upstream-source declarations (git URLs, S3 paths, `init_scripts`, `git_source`, or custom upstream-repo declarations). Clone or fetch each referenced repo into a sibling location and include its notebooks in the enumeration. List "external sources" as a first-class artifact category in the migration plan. Without this step, multi-source demos (e.g., `dbt-on-databricks` references the upstream `dbt-databricks-c360` repo) get mis-enumerated and the real task notebooks are missed.
+2. **For each notebook, in order**:
+   a. Read its full source.
+   b. Run the Step 2 Analyze checklist scoped to this notebook only.
+   c. Record a structured summary in your response or to a scratch file, then drop the raw source from active working memory. The summary must include:
+      - `notebook_path` (relative)
+      - `detected_patterns[]` (pattern IDs from this skill's catalog)
+      - `blockers[]` (Category-3 patterns this notebook hits, if any)
+      - `migration_steps[]` (concrete fixes ordered)
+      - `unmigratable` (bool — true if any blocker has no workaround)
+   d. If you have a writable scratch directory (`~/.databricks-migration-skill/scratch/<run-id>/findings/`), persist the summary as `<notebook-basename>.json`. This frees the source from context safely. If not, keep the summary compact in conversation history.
+3. **Synthesize.** After all notebooks have a summary, produce the unified migration plan from the summaries alone. Apply fixes notebook-by-notebook, never re-reading the original source unless required to resolve an ambiguity in a summary.
+4. **Failure Reporting.** Trigger the Failure Reporting Protocol exactly once per workload, not once per notebook. The `detected_patterns` array in the report aggregates across all notebooks; `notebook_characteristics` uses summed line counts and the union of language/streaming/ML flags.
+
+**Threshold guidance**: apply this procedure when the user notebook count is ≥ 3, or when individual notebooks exceed ~5KB of source. For 1–2 small notebooks the single-pass workflow in Steps 2–4 is fine.
+
+**Anti-pattern**: do NOT attempt a "merge all notebooks into one big file" or "read all notebooks, then act in one mega-turn" strategy. Both defeat the purpose by reintroducing the original context-pressure problem.
+
 ### Step 2: Analyze — Scan for Serverless Readiness
 
 **Read notebooks before running them — do not rely on failed job runs to discover issues.** A pre-run scan surfaces incompatibilities faster than iterating on error traces, and many serverless failures (hardcoded catalog references, init scripts, missing dependencies) are easy to spot statically but expensive to debug after a failed run.
@@ -93,6 +118,40 @@ Scan the code for patterns that are incompatible with the serverless compute arc
 - **Severity**: Blocker (must fix for serverless) / Warning (should fix) / Info (awareness)
 - **Pattern**: What was detected and where
 - **Fix**: Specific remediation targeting serverless compute
+
+#### Post-rewrite lint: Cell-magic boundary check (A1)
+
+**HIGH IMPACT.** Before declaring a migrated notebook ready, run this lint pass on every output cell. Caused 3/7 demos to fail in the dbdemos E2E sweep (hls-readmission, fsi-fraud, retail-c360).
+
+**Detect**: any cell that contains a `# MAGIC %<word>` line (e.g., `# MAGIC %run`, `# MAGIC %sql`, `# MAGIC %md`, `# MAGIC %pip`, `# MAGIC %fs`). Within that cell, every non-blank line must either start with `# MAGIC ` or be a blank line. If a plain-Python comment (or any other Python code) precedes the `# MAGIC %...` directive in the same cell, the cell is corrupted: Databricks parses it as Python and `%run` falls back to IPython line magic, producing errors like `File './00-global-setup-v2' not found`.
+
+**Fix**: never prepend plain-Python comments above a `# MAGIC %...` line within the same cell. Two valid options:
+
+1. **Preferred**: put migration notes in a separate `# MAGIC %md` cell above (its own `# COMMAND ----------` block).
+2. **Acceptable**: drop the migration note entirely and rely on git/file history.
+
+**Example before** (corrupted; `%run` fails with `File not found`):
+
+```python
+# COMMAND ----------
+
+# Migration: relative '%run ../../../_resources/00-global-setup-v2' may not
+# resolve under serverless job tasks. Replaced with sibling reference.
+# MAGIC %run ./00-global-setup-v2
+```
+
+**Example after** (clean; `%run` fires as cell magic):
+
+```python
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC Migration: relative %run path replaced with sibling reference.
+
+# COMMAND ----------
+
+# MAGIC %run ./00-global-setup-v2
+```
 
 **Category A: Unsupported APIs**
 
@@ -121,6 +180,13 @@ Scan the code for patterns that are incompatible with the serverless compute arc
 | Hive variable syntax `${var}` | Warning | Use `DECLARE VARIABLE` / `SET VARIABLE` (SQL) or Python f-strings |
 | `CREATE GLOBAL TEMPORARY VIEW` | Blocker | Use `CREATE OR REPLACE TEMPORARY VIEW` — `global_temp` database doesn't exist on serverless |
 | `global_temp.` prefix in queries | Warning | Remove prefix — session-scoped temp views are accessible without qualifier |
+| Builtin `max(..., key=)` / `min(..., key=)` / `sorted(..., key=)` with `from pyspark.sql.functions import *` (A2) | Blocker | `pyspark.sql.functions.max` shadows the builtin and rejects `key=` (raises `TypeError: max() got an unexpected keyword argument 'key'`). Use sort+index: `xs.sort(key=...); top = xs[0]`. See [MLflow on UC](references/mlflow-uc-patterns.md). |
+| `from databricks import automl` / `automl.classify()` / `automl.regress()` / `automl.forecast()` (A3) | Blocker | AutoML not available on serverless and the `DBDemos.create_mockup_automl_run` fallback hits `PlanMetrics not JSON serializable` on Spark Connect. Rewrite as inline scikit-learn `Pipeline` with `mlflow.sklearn.log_model` + `mlflow.register_model` + UC alias. See [MLflow on UC](references/mlflow-uc-patterns.md). |
+| `mlflow.pyfunc.spark_udf(...)` followed by `df.withColumn("prediction", loaded_model(struct(*features)))` (A4) | Blocker on mlflow 2.19.0 | Closure bug on Spark Connect: `batch_predict_fn` captures `loaded_model` as a free variable; workers fail with `NameError: cannot access free variable 'loaded_model'`. **Root cause is Spark Connect serialization.** Preferred fix (portable, any mlflow), driver-side pandas inference: `mlflow.pyfunc.load_model(uri).predict(df.toPandas())` then `spark.createDataFrame(...)`. Fallback fix: pin `mlflow>=2.20.0` in the environment spec. |
+| `AutoCaptureConfigInput(enabled=...)` in model-serving endpoint creation (A5) | Warning | Deprecated arg, breaks first-time endpoint deploy. Remove the `auto_capture_config=AutoCaptureConfigInput(...)` parameter entirely from `EndpointCoreConfigInput(...)`. |
+| `mlflow.<flavor>.log_model(..., registered_model_name=...)` with `mlflow.set_registry_uri("databricks-uc")` in scope (M1) | Blocker | Under UC, `registered_model_name=` triggers an internal `get_model_version_by_alias(..., 'Champion')` call that raises `RESOURCE_DOES_NOT_EXIST` for brand-new models. Drop the kwarg from `log_model`; after the run, call `mlflow.register_model(model_uri=f"runs:/{run.info.run_id}/model", name=<full_name>)` and `MlflowClient().set_registered_model_alias(...)`. See [MLflow on UC](references/mlflow-uc-patterns.md). |
+| `.latest_versions` access on UC-registered models (e.g., `client.get_registered_model(name).latest_versions`) (M2) | Blocker | `RegisteredModel.latest_versions` is always `None` on UC; `max(None, key=...)` raises `TypeError: 'NoneType' object is not iterable`. Use `client.search_model_versions(f"name='{name}'")` + sort+index (per A2 above). See [MLflow on UC](references/mlflow-uc-patterns.md). |
+| `mlflow.<flavor>.log_model(...)` without `signature=` kwarg, with `mlflow.set_registry_uri("databricks-uc")` in scope (M3) | Blocker | UC requires a model signature on every registered model. Without `signature=`, `log_model` raises `MlflowException: Model signature is required for registering a model to Unity Catalog`. Infer from a sample: `signature = infer_signature(X_sample, model.predict(X_sample))` then pass as `signature=signature` to `log_model`. See [MLflow on UC](references/mlflow-uc-patterns.md). |
 
 **Category B: Data Access**
 
@@ -134,6 +200,8 @@ Scan the code for patterns that are incompatible with the serverless compute arc
 | `CREATE DATABASE`/`CREATE SCHEMA` without `USE CATALOG` or 3-level name | Blocker | Prepend `spark.sql("USE CATALOG <your_catalog>")` at notebook start before any CREATE statements. Detect target catalog from existing table references, or ask the user. |
 | IAM instance profile references | Warning | Use UC external locations + storage credentials |
 | Hive SerDe tables | Blocker | Migrate to Delta tables in UC |
+| Bare `catalog = "<value>"` / `schema = "<value>"` assignment in `config.py`, `config/__init__.py`, `_config*.py`, or any Python file referenced via `%run` (B1) | Blocker | Catalog rewrite must scan **all** config files, not just notebook bodies that contain `spark.table(...)`. Replace literals like `"main"`, `"main__build"`, `"hive_metastore"` with the user's target catalog (typically `home_<user>`). Post-rewrite, grep the entire migrated tree for residual literal catalog refs. |
+| `spark.sql("CREATE CATALOG IF NOT EXISTS ...")` (B2) | Blocker | Privilege check fires before `IF NOT EXISTS` short-circuits, so non-admin users hit `PERMISSION_DENIED: User does not have CREATE CATALOG on Metastore` even when the catalog already exists. Guard with `SHOW CATALOGS LIKE '...'` probe first; only emit `CREATE CATALOG` if the probe returns empty. **Apply recursively across the entire migrated tree, including `_resources/00-global-setup-v2.py` and `config*` files.** Same pattern applies to `CREATE SCHEMA IF NOT EXISTS` and `CREATE VOLUME IF NOT EXISTS` in catalogs the user doesn't own. |
 
 **Category C: Streaming**
 
@@ -158,6 +226,7 @@ Scan the code for patterns that are incompatible with the serverless compute arc
 | `SET hivevar:` / `${hivevar:...}` (Hive variable substitution) | Blocker | Use SQL session variables: `DECLARE OR REPLACE VARIABLE name = value` (DBR 14.1+) |
 | Environment variables (in init scripts) | Warning | Use `dbutils.widgets` or job parameters |
 | Explicit executor count/memory configs | Info | Remove — serverless auto-scales and auto-tunes |
+| Retired Foundation Model endpoint references, e.g., `databricks-meta-llama-3-1-405b-instruct` and similar (D1) | Blocker | Detect by **content scan across every migrated file** (not by filename pattern). Common refs in `ai_query(endpoint => '...')`, `ChatDatabricks(endpoint=...)`, model-serving config, and Genie/AI-Functions SQL. Replace with the current default `databricks-meta-llama-3-3-70b-instruct`. Verify the replacement endpoint exists in the target workspace before final deploy. |
 
 **Category E: Libraries**
 
@@ -168,6 +237,8 @@ Scan the code for patterns that are incompatible with the serverless compute arc
 | `%pip install` without version pins | Warning | Pin versions: `%pip install numpy==2.2.2 pandas==2.2.3` |
 | Custom Spark data sources (v1/v2 JARs) | Blocker | Use Lakehouse Federation, Lakeflow Connect, or PySpark custom data sources |
 | LZO format files | Blocker | Convert to Parquet or Delta |
+| AutoML-trained model loaded via `mlflow.pyfunc.spark_udf(..., env_manager='local')` inside an SDP `.py` library file (E1) | Blocker | The SDP serverless image does not ship `databricks-automl-runtime`; cloudpickle.load raises `ModuleNotFoundError: No module named 'databricks.automl_runtime'`. Auto-emit `%pip install -q databricks-automl-runtime` as the first non-comment line of the SDP `.py` library file. `%pip install` is supported in SDP `.py` library files and runs once per update before SQL flows are planned. Same fix works for non-SDP notebooks loading AutoML-trained models. |
+| AutoML → sklearn rewrite (A3) with pre-existing model-serving endpoint (E2) | Blocker on first redeploy | The rewrite changes model signature (e.g., drops `id` from inputs). A pre-existing endpoint pinned to the old AutoML signature fails create/update with HTTP 400 `Failed to enforce schema of data ... Model is missing inputs ['id']`. Flip the downstream serving notebook's `force_update = False` → `force_update = True` so the endpoint re-binds to the current `prod` (or `Champion`) alias. |
 
 **Category F: Networking**
 
@@ -182,6 +253,17 @@ Scan the code for patterns that are incompatible with the serverless compute arc
 |---------|----------|-----|
 | Large driver memory configs | Info | Serverless REPL default is 8GB (high-memory option for 16GB+ via Environments) |
 | Spark UI references | Info | Use Query Profile instead: click "See performance" under cell output |
+
+**Category H: Job-level config (dbt_task, SDP, multi-source, deploy preconditions)**
+
+These checks operate on the job/pipeline spec JSON and on deploy preconditions, not on notebook bodies. Apply them alongside the per-notebook checks in Categories A–G.
+
+| Pattern | Severity | Fix |
+|---------|----------|-----|
+| `dbt_task` block in job spec (H1) | Blocker for dbt workloads | Three sub-checks: (1) **`warehouse_id`**: swap known-busy or non-serverless warehouses to a Stable/dedicated DBSQL serverless warehouse. (2) **`project_directory`**: rewrite to the migrated workspace location (e.g., `/Workspace/Users/<me>/<demo>-skill-migrated/...`). (3) **`libraries[]`**: replace classic-only Python wheels with pinned serverless-compatible versions; flag `dbt-databricks` < 1.7.x. |
+| SDP pipeline spec deployed alongside the original demo with the same `schema` (H2) | Blocker | UC rejects parallel deploy with `Table is already managed by pipeline <orig-id>`. When the target path includes a migration suffix (e.g., `-skill-migrated/`), automatically suffix the pipeline's target `schema` (e.g., `dbdemos_retail_c360` → `dbdemos_retail_c360_skill_migrated`). Apply the same rewrite to any `LIVE` / `STREAMING TABLE` references in transformation files that hard-code the schema. Lint the pipeline spec before deploy: if any target table already exists and belongs to another pipeline, fail with a clear message. |
+| Workspace `import` 10 MB cap (H3) | Advisory (foreseeable) | Pre-deploy precondition: walk the migrated tree before `databricks workspace import` and flag any file > 10 MB. Reroute large files (sample CSVs, `dbt seed` data, sample datasets, etc.) to UC Volumes (`databricks fs cp`) instead of workspace import. Emit a UC Volumes upload command alongside the workspace import command, with a manifest of what went where. Not blocking in most workloads but blocks any demo using `dbt seed` or large sample CSVs. |
+| Multi-source workloads with `bundle_config.py` declaring upstream git URLs (H4) | Diagnostic | Without this, the skill mis-enumerates user notebooks. Parse `bundle_config.py` and follow any upstream-source declarations (git URLs, S3 paths). Clone or fetch the referenced repos before per-notebook enumeration. List "external sources" as a first-class artifact category in the migration plan. See [Multi-source enumeration](references/multi-source-enumeration.md). Concrete example: `dbt-on-databricks`'s `bundle_config.py` references the upstream `dbt-databricks-c360` repo; the real task notebooks live there, not in the local `dbdemos-notebooks/` tree. |
 
 ### Required Output: Serverless Environment Specification
 
@@ -527,6 +609,19 @@ Always get the actual error with `w.jobs.get_run_output(run_id=...)` before gues
 | `PERMISSION_DENIED: CREATE SCHEMA on Catalog 'main'` | Add `spark.sql("USE CATALOG <your_catalog>")` before CREATE statements |
 | `DATA_SOURCE_NOT_FOUND: Failed to find data source` | Category 3 blocker — custom JAR data source needs classic compute |
 | `SyntaxError` after migration | Ensure comments are inside MAGIC blocks, not straddling cell delimiters |
+| `File './<name>' not found` from `%run` (or `%run` fires as IPython line magic) | A1: a plain-Python comment is preceding `# MAGIC %run` in the same cell. Move the comment to its own `# MAGIC %md` cell above. |
+| `TypeError: max() got an unexpected keyword argument 'key'` | A2: `from pyspark.sql.functions import *` shadowed builtin `max`. Use sort+index instead of `max(..., key=)`. |
+| `TypeError: Object of type PlanMetrics is not JSON serializable` | A3: `automl.classify/regress/forecast` not supported; the `DBDemos.create_mockup_automl_run` fallback hits this on Spark Connect. Rewrite as inline sklearn Pipeline. |
+| `NameError: cannot access free variable 'loaded_model'` | A4: mlflow 2.19.0 `pyfunc.spark_udf` closure bug on Spark Connect. Use driver-side `pyfunc.load_model` + `toPandas()` + `spark.createDataFrame`, or pin `mlflow>=2.20.0`. |
+| `ModuleNotFoundError: No module named 'databricks.automl_runtime'` | E1: SDP image missing `databricks-automl-runtime`. Emit `%pip install -q databricks-automl-runtime` at top of the SDP `.py` library file. |
+| `HTTP 400: Failed to enforce schema of data ... Model is missing inputs ['id']` | E2: AutoML → sklearn rewrite changed model signature; flip downstream `force_update = False` → `True`. |
+| `RESOURCE_DOES_NOT_EXIST` from `get_model_version_by_alias(..., 'Champion')` during `log_model` | M1: drop `registered_model_name=` from `log_model` under UC; call `mlflow.register_model(...)` after the run. |
+| `TypeError: 'NoneType' object is not iterable` from `.latest_versions` | M2: `RegisteredModel.latest_versions` is always `None` on UC. Use `client.search_model_versions(...)` + sort+index. |
+| `MlflowException: Model signature is required for registering a model to Unity Catalog` | M3: UC requires `signature=` on `log_model`. Infer via `infer_signature(X_sample, model.predict(X_sample))` and pass to `log_model(..., signature=signature)`. See [MLflow on UC](references/mlflow-uc-patterns.md). |
+| 404 on `ai_query(endpoint => 'databricks-meta-llama-3-1-405b-instruct')` | D1: retired Foundation Model endpoint. Replace with `databricks-meta-llama-3-3-70b-instruct` via content scan across all migrated files. |
+| `PERMISSION_DENIED: User does not have CREATE CATALOG on Metastore` (even when catalog exists) | B2: priv check fires before `IF NOT EXISTS` short-circuits. Guard with `SHOW CATALOGS LIKE '...'` probe. Apply recursively, including `_resources/` and `config*` files. |
+| `Table is already managed by pipeline <pipeline-id>` on SDP parallel deploy | H2: suffix the migrated pipeline's target `schema` (e.g., `<orig>_skill_migrated`). |
+| `DELTA_FAILED_TO_MERGE_FIELDS: prediction (Double) vs prediction (Integer)` | P2: AutoML → sklearn rewrite emits `float64` predictions; cast to `IntegerType` for binary classifiers before writing. See [MLflow on UC](references/mlflow-uc-patterns.md). |
 
 See [Configuration Guide](references/configuration-guide.md) for the full error reference and SDK code examples.
 
@@ -699,6 +794,8 @@ For detailed workarounds and code examples beyond the quick fixes above:
 - [Networking and Security](references/networking-and-security.md) — VPC peering to NCCs, Private Link, firewall setup
 - [Code Patterns](references/code-patterns.md) — Complete before/after code examples for every migration pattern
 - [Configuration Guide](references/configuration-guide.md) — Supported Spark configs, Environments setup, budget policies
+- [MLflow on UC](references/mlflow-uc-patterns.md) — AutoML rewrite to sklearn, UC-aware registration, `latest_versions` replacement, `spark_udf` closure-bug fix, prediction-column dtype alignment
+- [Multi-source enumeration](references/multi-source-enumeration.md) — Parsing `bundle_config.py` and fetching upstream git sources before per-notebook analysis
 - [Failure Reporting](references/failure-reporting.md) — Redaction checklist + pre-filled GitHub issue URL recipe (for when migration cannot complete)
 - [Install in Databricks Genie Code](references/install-in-databricks-genie-code.md) — Run this skill inside a Databricks workspace
 

--- a/skills/databricks-serverless-migration/SKILL.md
+++ b/skills/databricks-serverless-migration/SKILL.md
@@ -21,6 +21,15 @@ Analyze existing Databricks code for serverless compute compatibility and guide 
 - Troubleshooting serverless-specific errors after migration
 - Choosing between Performance-Optimized and Standard mode
 
+## Where to Run This Skill
+
+This skill is published as an Agent Skill (agentskills.io) and runs in any compatible client:
+
+- **Claude Code, Cursor, or any agentskills.io client on your laptop** — the default. Install via `databricks experimental aitools install` or follow the per-client docs.
+- **Inside a Databricks workspace via Genie Code Agent mode** — drop the skill into `/Workspace/Users/<you>/.assistant/skills/databricks-serverless-migration/` (per-user) or `/Workspace/.assistant/skills/databricks-serverless-migration/` (workspace-wide, admin only). See [Install in Databricks Genie Code](references/install-in-databricks-genie-code.md) for the three install methods and the **important serverless-compute caveat** (the Databricks CLI isn't pre-installed on serverless, so some deploy steps need adjustment).
+
+If you finish a migration analysis for a user who's currently running you from a laptop client, mention the Genie Code option once at the end — many users prefer iterating on migrations inside the workspace where the workload lives.
+
 ## Understanding Migration Blockers
 
 Migration blockers fall into three categories. Focus your effort on category 2 — that's where this skill helps most.
@@ -545,21 +554,28 @@ See [Configuration Guide](references/configuration-guide.md) for the full error 
 
 ## Failure Reporting Protocol
 
-When migration fails irrecoverably, generate a structured failure report to help improve the skill. This applies when:
+When migration fails or hits an unmigratable pattern, generate a structured failure report and offer the user a one-step path to file it as a GitHub issue. This feedback loop is how the skill learns — without it, gaps go undiscovered.
 
-- All retry attempts are exhausted (typically 5)
-- An unknown pattern is encountered that isn't in the compatibility checks
-- A fix was applied but didn't resolve the underlying issue
-- The workload hits a Category 3 blocker the user wasn't aware of
+See [Failure Reporting](references/failure-reporting.md) for the full redaction checklist, URL-encoding recipe, and example pre-filled link.
 
-### When to generate a report
+### Decision tree: when to offer to file an issue
 
-Generate a report at the end of a migration attempt if **any** of:
-- `retry_count >= max_retries` and final status is FAILED
-- A pattern was detected but no fix is available in the skill
-- The user explicitly requests a failure report (`/migration-report`)
+**Offer to file a GitHub issue any time the workload cannot be fully migrated to serverless as-is.** Reports from "known" patterns (R, Scala, custom JAR data sources, JVM access, third-party connectors) are just as valuable as reports from unknown patterns — they tell maintainers which gaps users hit most often, which drives prioritization.
 
-### How to generate
+Concretely, ALWAYS offer if **any** of these is true:
+
+1. **Workload contains any Category 3 (classic-only) blocker** — R, Scala notebook cells, custom JAR data sources, JVM/Py4J access, third-party connectors without serverless equivalents, native binary dependencies, etc. The fact that the pattern is "documented as Cat 3" is not a reason to skip the offer.
+2. **Retries exhausted** — `retry_count >= max_retries` (typically 5) and final status is FAILED
+3. **Unknown pattern** — a classic-compute construct was detected that isn't in the skill's catalog
+4. **Fix didn't resolve** — a known fix was applied but the workload still fails on serverless
+5. **Explicit request** — the user invokes `/migration-report`
+
+**Do NOT offer to file** only when:
+
+- The migration succeeded fully (even after retries), or
+- The workload is already serverless-compatible and required no changes.
+
+### How to generate the report
 
 Write a JSON file to `~/.databricks-migration-skill/reports/failure-<ISO-timestamp>.json`. Create the directory if it doesn't exist.
 
@@ -567,7 +583,7 @@ Write a JSON file to `~/.databricks-migration-skill/reports/failure-<ISO-timesta
 
 ```json
 {
-  "report_version": "1.0",
+  "report_version": "1.1",
   "report_id": "<uuid-v4>",
   "skill_version": "<from SKILL.md frontmatter metadata.version>",
   "timestamp": "<ISO 8601 UTC>",
@@ -578,7 +594,7 @@ Write a JSON file to `~/.databricks-migration-skill/reports/failure-<ISO-timesta
   "attempted_fixes": [
     {"pattern_id": "rdd_parallelize", "fix_applied": "<fix_id>", "attempt_number": 1, "outcome": "failed"}
   ],
-  "final_error_category": "unknown_api | missing_library | data_access | permission | custom_data_source | other",
+  "final_error_category": "unknown_api | missing_library | data_access | permission | custom_data_source | jvm_access | unsupported_language | other",
   "final_error_signature": "<SHA256 of top 3 stack frames, NOT the frames themselves>",
   "retry_count": 5,
   "total_duration_seconds": 245,
@@ -594,34 +610,85 @@ Write a JSON file to `~/.databricks-migration-skill/reports/failure-<ISO-timesta
 
 ### What the report MUST NOT contain
 
-This is a hard requirement — the report must be safe to share publicly on GitHub Issues:
+Hard requirement — the report must be safe to share publicly on GitHub Issues:
 
-- **No code content** — only pattern IDs from this skill's catalog (e.g., `rdd_parallelize`), never actual code snippets
-- **No file paths** — no notebook names, directory paths, or workspace URLs
+- **No code content** — pattern IDs only (e.g., `rdd_parallelize`), never code snippets, function bodies, or even single-line examples
+- **No file paths** — no notebook names, directory paths, workspace URLs, or DBFS paths
 - **No error message text** — only the error category enum and a hashed signature
-- **No identifiers** — no table names, column names, catalog names, schema names, user emails, workspace IDs, or customer names
-- **No credentials** — no secret scope names, API keys, or connection strings
-- **No data descriptions** — no column value samples, row counts tied to specific tables, or data shape details beyond the `notebook_characteristics` fields
+- **No identifiers** — no table names, column names, catalog names, schema names, secret scope names, user emails, workspace IDs, or account IDs
+- **No internal Databricks references** — no Databricks employee names, internal codenames (e.g., product code names not in public docs), `go/` links, Confluence page IDs, Google Doc IDs, Slack user or channel IDs (`U…`, `C…`), PROD-* / SEV-* / SC-* ticket numbers
+- **No customer references** — no company names, product names of customer systems, or anything that would identify the workspace's owning organization
+- **No credentials** — no tokens, API keys, connection strings, JDBC URLs, or service principal IDs
+- **No data descriptions** — no column value samples, row counts tied to specific tables, or schema fingerprints beyond the `notebook_characteristics` fields
 
-### After generating the report
+### Anonymization safety pass
 
-Tell the user:
+Before writing the report, scan every string field against this pattern checklist. If any pattern matches, **drop the offending field** (do not redact partially — empty string is safer than risking leakage):
+
+| Pattern | What to scrub |
+|---------|---------------|
+| `[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}` | Email addresses |
+| `dbfs:/`, `/dbfs/`, `s3://`, `abfss://`, `gs://`, `wasbs://` | Cloud storage paths |
+| `https?://[a-z0-9-]+\.cloud\.databricks\.com`, `https?://adb-\d+\.\d+\.azuredatabricks\.net` | Workspace URLs |
+| `U[A-Z0-9]{8,}`, `C[A-Z0-9]{8,}` | Slack user / channel IDs |
+| `\bgo/[a-z0-9-]+\b` | go/ links |
+| `\b(PROD|SEV|SC|JIRA)-\d+\b` | Internal ticket IDs |
+| `[0-9a-f]{20,}` (heuristic) | Likely doc/file/workspace IDs |
+| Catalog/schema/table name literals from the analyzed notebook | Drop and replace with `"<redacted>"` |
+
+The `notebook_characteristics` fields are the only safe surface for workload metadata. Do not add new fields without expanding this checklist.
+
+### After generating the report — REQUIRED output template
+
+**This is not optional.** When the decision tree above says "offer to file", you MUST produce all three of these in your final response to the user, in order:
+
+1. The local report file path (literally include the string `~/.databricks-migration-skill/reports/failure-<timestamp>.json`, with `<timestamp>` filled in).
+2. **Option A** — a complete pre-filled `https://github.com/databricks/databricks-agent-skills/issues/new?template=migration-feedback.md&title=<…>&body=<…>` URL, both parameters URL-encoded.
+3. **Option B** — the literal `gh issue create --repo databricks/databricks-agent-skills …` command, body-file pointing at the local report.
+
+If you write the JSON inline in your response but skip the URL and the `gh` command, the protocol is **not satisfied**. The whole point is to make filing one click.
+
+Use this exact wrap-up template, replacing `<…>` placeholders:
 
 ```
-Migration failed after <N> attempts. A failure report has been generated at:
+Migration could not complete. A failure report has been generated at:
 
   ~/.databricks-migration-skill/reports/failure-<timestamp>.json
 
-This report contains anonymized diagnostic data (detected patterns, error categories, retry count) and no code content or PII. You can:
+The report contains anonymized diagnostic data (detected pattern IDs, error
+category, retry count, notebook characteristics) and no code content or PII.
+Submission is optional and opt-in.
 
-1. Review the JSON to confirm no sensitive information is present
-2. Share it via GitHub Issue to help improve the skill:
-   https://github.com/databricks/databricks-agent-skills/issues/new?template=migration-feedback.md
+To help improve this skill, file the report as a GitHub issue:
 
-Submission is optional and opt-in. We use reports to prioritize new patterns and fix detection gaps.
+  Option A — One-click in browser (pre-filled):
+    <PREFILLED_ISSUE_URL>
+
+  Option B — From the terminal (if you have the GitHub CLI installed):
+    gh issue create \
+      --repo databricks/databricks-agent-skills \
+      --title "<TITLE>" \
+      --body-file ~/.databricks-migration-skill/reports/failure-<timestamp>.json \
+      --label migration-skill
+
+Before submitting, please open the JSON and confirm nothing sensitive
+slipped through. We never transmit reports automatically.
 ```
 
-**Never transmit the report automatically.** The user owns their data and must review before sharing.
+Build `<PREFILLED_ISSUE_URL>` like this:
+
+1. **Title**: `[migration-skill] <final_error_category> in <failure_phase> phase`
+   Example: `[migration-skill] custom_data_source in migrate phase`
+2. **Body**: the issue template's markdown skeleton (Category, Environment, Description, Failure report JSON fenced in ` ```json `) with the report JSON inlined.
+3. **URL-encode** both title and body (`%20` for spaces, `%23` for `#`, `%0A` for newline, etc.).
+4. **Final URL**:
+   `https://github.com/databricks/databricks-agent-skills/issues/new?template=migration-feedback.md&title=<URL-encoded title>&body=<URL-encoded body>`
+
+If your runtime cannot actually write the file (sandboxed, no filesystem write), still show the path the file WOULD be at and produce Options A and B. The user can write the JSON to disk themselves.
+
+The full recipe with a worked example is in [Failure Reporting](references/failure-reporting.md).
+
+**Never transmit the report automatically.** The user owns their data and must review before sharing. If the user declines, do not press them — log the local report path and move on.
 
 ## Reference Guides
 
@@ -632,6 +699,8 @@ For detailed workarounds and code examples beyond the quick fixes above:
 - [Networking and Security](references/networking-and-security.md) — VPC peering to NCCs, Private Link, firewall setup
 - [Code Patterns](references/code-patterns.md) — Complete before/after code examples for every migration pattern
 - [Configuration Guide](references/configuration-guide.md) — Supported Spark configs, Environments setup, budget policies
+- [Failure Reporting](references/failure-reporting.md) — Redaction checklist + pre-filled GitHub issue URL recipe (for when migration cannot complete)
+- [Install in Databricks Genie Code](references/install-in-databricks-genie-code.md) — Run this skill inside a Databricks workspace
 
 ## Documentation
 

--- a/skills/databricks-serverless-migration/references/configuration-guide.md
+++ b/skills/databricks-serverless-migration/references/configuration-guide.md
@@ -343,9 +343,9 @@ In the Databricks UI:
 
 ### Key Changes
 
-- **Remove** `job_clusters` / `new_cluster` — serverless manages infrastructure
-- **Add** `environments` with serverless spec
-- **Replace** `job_cluster_key` with `environment_key` in each task
+- **Remove** `job_clusters` / `new_cluster` — serverless manages infrastructure. Removing the cluster reference is what makes a task run on serverless compute.
+- **Remove** `job_cluster_key` (and any `existing_cluster_id` / `new_cluster`) from each task. Tasks with no cluster reference and no `compute` block run on serverless compute by default.
+- **Add** an `environments` array at the job level if the task needs Python dependencies, and reference one via `environment_key` per task. `environment_key` declares *dependencies* (PyPI / workspace files / etc.), it does **not** replace `job_cluster_key` as a compute selector. A task can have `environment_key` set without specifying compute, and it will still run on serverless.
 - **Remove** `init_scripts` — move to environment `dependencies`
 - **Remove** `num_workers`, `node_type_id`, `spark_version` — all auto-managed
 

--- a/skills/databricks-serverless-migration/references/failure-reporting.md
+++ b/skills/databricks-serverless-migration/references/failure-reporting.md
@@ -1,0 +1,162 @@
+# Failure Reporting — Filing a Migration Skill Issue
+
+Reference for the [Failure Reporting Protocol](../SKILL.md#failure-reporting-protocol) in `SKILL.md`. Read this when migration could not complete and you need to file a GitHub issue with anonymized context.
+
+## Why this exists
+
+The skill detects ~40 patterns across 7 categories today. Every new pattern in the wild that the skill doesn't recognize, every fix that didn't work, every Cat 3 blocker surfaced late — these are the inputs that close detection gaps. Reports are opt-in and never auto-submitted; the user owns the data.
+
+## Redaction checklist (apply before writing the JSON)
+
+Walk every string-typed field in the report and confirm none of these appear. If anything matches, drop the field rather than partially redacting.
+
+- **Identifiers**: emails, employee names, Slack user/channel IDs (`U…`, `C…`), customer / company names, account IDs, workspace IDs.
+- **Paths and URLs**: `dbfs:/`, `/dbfs/`, `s3://`, `abfss://`, `gs://`, `wasbs://`, notebook paths, workspace URLs (`*.cloud.databricks.com`, `adb-*.azuredatabricks.net`), git remote URLs.
+- **Internal references**: `go/` links, internal codenames not in public docs, Confluence page IDs, Google Doc IDs (`1[A-Za-z0-9_-]{20,}`), Slack channel names, PROD-* / SEV-* / SC-* tickets.
+- **Catalog / schema / table / column names** from the analyzed notebook. Pattern IDs from this skill's catalog are fine; literals from the workload are not.
+- **Credentials**: tokens, API keys, connection strings, JDBC URLs, service principal IDs, secret scope names.
+- **Stack frame contents**: hash the top 3 frames with SHA-256, never include the frames themselves.
+- **Error messages**: store only the `final_error_category` enum, never the raw error text.
+
+If a field is ambiguous, drop it. `notebook_characteristics` is the safe surface for workload metadata — do not invent new fields here without first updating this checklist and the schema in `SKILL.md`.
+
+## Building the pre-filled GitHub issue URL
+
+GitHub's `issues/new` endpoint accepts URL-encoded `title=` and `body=` query parameters. Combined with the `template=migration-feedback.md` parameter, you can produce a one-click link that drops the user straight into a pre-filled issue.
+
+### Title format
+
+```
+[migration-skill] <final_error_category> in <failure_phase> phase
+```
+
+Examples:
+- `[migration-skill] custom_data_source in migrate phase`
+- `[migration-skill] unknown_api in analyze phase`
+- `[migration-skill] jvm_access in test phase`
+
+### Body skeleton
+
+Use this Markdown template. Replace the placeholders, then URL-encode the whole thing.
+
+```markdown
+## Category
+
+- [x] Failure report (see JSON below)
+
+## Pre-submission checklist
+
+- [x] I reviewed the JSON below and confirmed no PII slipped through
+
+## Environment
+
+- Skill version: <skill_version from report>
+- Agent: Claude Code / Cursor / other
+- Databricks Runtime of source workload: <databricks_runtime_source from report>
+
+## Description
+
+Migration failed in the `<failure_phase>` phase. Final error category:
+`<final_error_category>`. Retry count: <retry_count>.
+
+## Failure report JSON
+
+<details>
+<summary>failure-&lt;timestamp&gt;.json</summary>
+
+```json
+<paste the full report JSON here>
+```
+
+</details>
+```
+
+### URL-encoding
+
+Encode the title and body with standard `application/x-www-form-urlencoded` rules (space → `%20`, newline → `%0A`, `#` → `%23`, `<` → `%3C`, `>` → `%3E`, backtick → `%60`, `[` → `%5B`, `]` → `%5D`, etc.). In Python:
+
+```python
+import urllib.parse
+url = (
+    "https://github.com/databricks/databricks-agent-skills/issues/new"
+    "?template=migration-feedback.md"
+    f"&title={urllib.parse.quote(title)}"
+    f"&body={urllib.parse.quote(body)}"
+)
+```
+
+GitHub accepts URLs up to ~8 KB. The failure report JSON is well under 2 KB after redaction, so the encoded URL fits.
+
+### Worked example
+
+Title: `[migration-skill] custom_data_source in migrate phase`
+
+Body (abridged):
+
+```markdown
+## Category
+- [x] Failure report (see JSON below)
+## Environment
+- Skill version: 0.1.0
+- Agent: Claude Code
+- Databricks Runtime: 14.3.x-scala2.12
+## Description
+Migration failed in the `migrate` phase. Final error category: `custom_data_source`. Retry count: 5.
+## Failure report JSON
+<details><summary>failure-2026-05-12T08-00-00Z.json</summary>
+
+```json
+{
+  "report_version": "1.1",
+  "report_id": "5b7c8e8e-...",
+  "skill_version": "0.1.0",
+  "failure_phase": "migrate",
+  "detected_patterns": [{"category": "E", "pattern_id": "custom_jar_datasource", "count": 1}],
+  "attempted_fixes": [],
+  "final_error_category": "custom_data_source",
+  "final_error_signature": "a91b5e...",
+  "retry_count": 5,
+  "notebook_characteristics": {"lines_of_code": 73, "language": "python", "uses_streaming": false, "uses_ml_libraries": false, "databricks_runtime_source": "14.3.x-scala2.12"}
+}
+\`\`\`
+
+</details>
+```
+
+Encoded URL (truncated for readability):
+
+```
+https://github.com/databricks/databricks-agent-skills/issues/new?template=migration-feedback.md
+  &title=%5Bmigration-skill%5D%20custom_data_source%20in%20migrate%20phase
+  &body=%23%23%20Category%0A-%20%5Bx%5D%20Failure%20report...
+```
+
+## CLI alternative (`gh`)
+
+If the user has the GitHub CLI on their PATH (`which gh`), offer:
+
+```bash
+gh issue create \
+  --repo databricks/databricks-agent-skills \
+  --title "[migration-skill] <final_error_category> in <failure_phase> phase" \
+  --body-file ~/.databricks-migration-skill/reports/failure-<timestamp>.json \
+  --label migration-skill
+```
+
+This works but skips the issue template's checklist sections. Prefer the browser URL when the user is unfamiliar with the contribution flow.
+
+## What we do with reports
+
+Reports are triaged by the skill maintainers (`@lennartkats-db @simonfaltum` plus the migration-skill code owners) and used to:
+
+1. Prioritize new patterns to add to `references/compatibility-checks.md`
+2. Identify fixes that don't work in practice and need correction
+3. Spot Cat 3 blockers that need clearer up-front detection so users hit them in analyze rather than migrate
+
+Reports never leave the public GitHub issues thread. We do not aggregate them externally.
+
+## Troubleshooting
+
+- **The pre-filled URL is too long for the browser** — GitHub caps at ~8 KB. If the report is unusually large (many `attempted_fixes`), fall back to the `gh` CLI command, or open the issue manually and paste the JSON in.
+- **The browser opens an empty issue** — the `template=` parameter requires the template file to exist in the repo's `.github/ISSUE_TEMPLATE/`. If it's missing, file with the title and body only; the maintainers will update the template.
+- **The user wants to share more context** — that's fine, but ask them to add it as a follow-up comment, not in the initial report body. Initial body should be the anonymized JSON only.

--- a/skills/databricks-serverless-migration/references/failure-reporting.md
+++ b/skills/databricks-serverless-migration/references/failure-reporting.md
@@ -147,7 +147,7 @@ This works but skips the issue template's checklist sections. Prefer the browser
 
 ## What we do with reports
 
-Reports are triaged by the skill maintainers (`@lennartkats-db @simonfaltum` plus the migration-skill code owners) and used to:
+Reports are triaged by the skill maintainers listed in the repo's [CODEOWNERS](https://github.com/databricks/databricks-agent-skills/blob/main/CODEOWNERS) file, and used to:
 
 1. Prioritize new patterns to add to `references/compatibility-checks.md`
 2. Identify fixes that don't work in practice and need correction

--- a/skills/databricks-serverless-migration/references/failure-reporting.md
+++ b/skills/databricks-serverless-migration/references/failure-reporting.md
@@ -147,7 +147,7 @@ This works but skips the issue template's checklist sections. Prefer the browser
 
 ## What we do with reports
 
-Reports are triaged by the skill maintainers listed in the repo's [CODEOWNERS](https://github.com/databricks/databricks-agent-skills/blob/main/CODEOWNERS) file, and used to:
+Reports are triaged by the skill maintainers listed in the repo's [CODEOWNERS](https://github.com/databricks/databricks-agent-skills/blob/main/.github/CODEOWNERS) file, and used to:
 
 1. Prioritize new patterns to add to `references/compatibility-checks.md`
 2. Identify fixes that don't work in practice and need correction

--- a/skills/databricks-serverless-migration/references/install-in-databricks-genie-code.md
+++ b/skills/databricks-serverless-migration/references/install-in-databricks-genie-code.md
@@ -1,0 +1,87 @@
+# Install this skill in a Databricks workspace (Genie Code Agent mode)
+
+You can run this skill **inside Databricks** — not just from Claude Code or Cursor on your laptop. Databricks Genie Code Agent mode uses the same Agent Skills standard ([agentskills.io](https://agentskills.io/specification)) as Claude Code, so this skill is drop-in compatible. Once installed, the skill auto-loads in Genie Code Agent chats based on its `description` frontmatter, or you can invoke it explicitly.
+
+## Where skills live in a workspace
+
+Workspace files at one of two paths:
+
+| Scope | Path | Who can install |
+|-------|------|-----------------|
+| **Per-user** | `/Workspace/Users/<your-email>/.assistant/skills/<skill-name>/` | Any user |
+| **Workspace-wide** | `/Workspace/.assistant/skills/<skill-name>/` | Workspace admin only |
+
+Genie Code automatically picks up skills from these paths the next time the user starts an Agent-mode chat — no manifest registration, no separate UI step.
+
+## Three install methods
+
+### Option 1 — Notebook installer (easiest for one user)
+
+The `databricks-solutions/ai-dev-kit` repo ships a notebook that pulls skills from GitHub and writes them to your `/Workspace/Users/<you>/.assistant/skills/` path.
+
+1. Import [`install_genie_code_skills.py`](https://github.com/databricks-solutions/ai-dev-kit/blob/main/databricks-skills/install_genie_code_skills.py) into your workspace.
+2. Edit the constants at the top of the notebook:
+   - `REPO = "databricks/databricks-agent-skills"`
+   - `BRANCH = "main"`
+   - `SKILLS = ["databricks-serverless-migration"]` (plus any others you want)
+3. Attach the notebook to any running cluster (classic or serverless, any size).
+4. Run All. The installer uses `WorkspaceClient().workspace.import_()` to upload `SKILL.md` + every file listed in this skill's entry in `manifest.json`.
+5. Open a Genie Code Agent chat. The skill loads on demand based on its `description`.
+
+### Option 2 — Shell installer (for repeat installs)
+
+From a local clone of `databricks-solutions/ai-dev-kit`:
+
+```bash
+./databricks-skills/install_skills.sh --local --install-to-genie
+```
+
+Add `--profile <YOUR_PROFILE>` if your `databricks` CLI default isn't the target workspace. Requires the `databricks` CLI installed and authenticated locally.
+
+### Option 3 — Databricks App (workspace-wide)
+
+The `mcp-ai-dev-kit` app deploys once per workspace, pulls skills from a configured GitHub repo on every redeploy, and writes to the workspace-wide `/Workspace/.assistant/skills/` path so every user in the workspace sees them. Recommended if you're rolling this skill out to a team.
+
+This requires workspace admin. Ping `#india-gcc-fe-team` for the latest deploy instructions.
+
+## Format compatibility
+
+Zero conversion needed. Genie Code uses the same Agent Skills layout as Claude Code:
+
+```
+databricks-serverless-migration/
+├── SKILL.md          # frontmatter + instructions (this skill)
+├── agents/           # optional agent configs
+├── assets/           # static assets
+└── references/       # supplementary docs loaded on demand (you're reading one)
+```
+
+The installer copies the entire skill directory as listed in `manifest.json`.
+
+## Caveats specific to this skill
+
+⚠️ **Databricks CLI is not pre-installed on serverless compute.** This skill's frontmatter declares `compatibility: Requires databricks CLI (>= v0.292.0)` because several recommended commands shell out to `databricks bundle deploy`, `databricks jobs update`, and `databricks fs cp`.
+
+Inside Genie Code on serverless compute, those commands will fail with `databricks: command not found`. Three options to reconcile:
+
+1. **Run the Agent-mode chat against a classic cluster** that has the CLI installed (you can `%pip install databricks-cli` in a setup cell, or bake it into a cluster init script).
+2. **Use the Databricks SDK equivalents** the skill mentions where available — `WorkspaceClient().jobs.update(...)`, `WorkspaceClient().workspace.import_(...)`. The skill's recommendations are CLI-flavored today; SDK calls work equivalently in a notebook context.
+3. **Skip the deploy steps** entirely. The skill's value is the analyze + migrate phases — code transformation, blocker detection, and fix suggestions. Those work without the CLI. You can apply the migrated job/DABs changes by hand or from a separate environment.
+
+Other notes:
+
+- **Genie Code's underlying model is not publicly specified** and may not be Claude. The skill is authored against Claude Code defaults; behavior parity is not guaranteed. Smoke-test on a non-critical workload first.
+- **Skills are knowledge + scripts, not arbitrary tools.** Genie Code skills can't make network calls outside the workspace boundary. The skill's GitHub-issue-filing flow ([Failure Reporting](failure-reporting.md)) still works because it generates a URL the user clicks rather than auto-submitting.
+- **File-edit sandboxing**: Genie Code can write files in the workspace, so the migration outputs (migrated notebooks, updated job JSON, env spec YAML) land where you expect.
+
+## Pointers and follow-ups
+
+| Resource | Link |
+|----------|------|
+| Public docs: Extend Genie Code with agent skills | https://docs.databricks.com/aws/en/genie-code/skills |
+| Public docs: Agent skills overview | https://docs.databricks.com/aws/en/agent-skills/ |
+| Notebook + shell installer | https://github.com/databricks-solutions/ai-dev-kit |
+| This skill's source | https://github.com/databricks/databricks-agent-skills/tree/main/skills/databricks-serverless-migration |
+| Agent Skills spec | https://agentskills.io/specification |
+
+For Genie Code runtime questions, the internal Slack channel is `#eng-genie-code-team`. For the workspace-wide app deployment pattern, `#india-gcc-fe-team`.

--- a/skills/databricks-serverless-migration/references/install-in-databricks-genie-code.md
+++ b/skills/databricks-serverless-migration/references/install-in-databricks-genie-code.md
@@ -78,8 +78,8 @@ Other notes:
 
 | Resource | Link |
 |----------|------|
-| Public docs: Extend Genie Code with agent skills | https://docs.databricks.com/aws/en/genie-code/skills |
-| Public docs: Agent skills overview | https://docs.databricks.com/aws/en/agent-skills/ |
+| Public docs: Extend Genie Code with agent skills | https://docs.databricks.com/en/genie-code/skills |
+| Public docs: Agent skills overview | https://docs.databricks.com/en/agent-skills/ |
 | Notebook + shell installer | https://github.com/databricks-solutions/ai-dev-kit |
 | This skill's source | https://github.com/databricks/databricks-agent-skills/tree/main/skills/databricks-serverless-migration |
 | Agent Skills spec | https://agentskills.io/specification |

--- a/skills/databricks-serverless-migration/references/install-in-databricks-genie-code.md
+++ b/skills/databricks-serverless-migration/references/install-in-databricks-genie-code.md
@@ -42,7 +42,7 @@ Add `--profile <YOUR_PROFILE>` if your `databricks` CLI default isn't the target
 
 The `mcp-ai-dev-kit` app deploys once per workspace, pulls skills from a configured GitHub repo on every redeploy, and writes to the workspace-wide `/Workspace/.assistant/skills/` path so every user in the workspace sees them. Recommended if you're rolling this skill out to a team.
 
-This requires workspace admin. Ping `#india-gcc-fe-team` for the latest deploy instructions.
+This requires workspace admin. Ask the workspace admin who owns the Databricks Apps deployment for your workspace, or refer to the public Databricks Apps documentation.
 
 ## Format compatibility
 
@@ -84,4 +84,4 @@ Other notes:
 | This skill's source | https://github.com/databricks/databricks-agent-skills/tree/main/skills/databricks-serverless-migration |
 | Agent Skills spec | https://agentskills.io/specification |
 
-For Genie Code runtime questions, the internal Slack channel is `#eng-genie-code-team`. For the workspace-wide app deployment pattern, `#india-gcc-fe-team`.
+For runtime questions or to report skill issues, file an issue on the public skill repo: https://github.com/databricks/databricks-agent-skills/issues

--- a/skills/databricks-serverless-migration/references/mlflow-uc-patterns.md
+++ b/skills/databricks-serverless-migration/references/mlflow-uc-patterns.md
@@ -1,0 +1,315 @@
+# MLflow on Unity Catalog: Serverless Migration Patterns
+
+This reference covers the MLflow patterns that change when migrating to serverless compute with Unity Catalog as the model registry. Source: 7-demo dbdemos E2E sweep (lakehouse-fsi-credit, lakehouse-fsi-fraud, lakehouse-hls-readmission, lakehouse-retail-c360, dbt-on-databricks, mlops-end2end).
+
+Six related patterns:
+
+- **A3**: AutoML rewrite to inline scikit-learn `Pipeline`
+- **A4**: `mlflow.pyfunc.spark_udf` closure bug on Spark Connect (mlflow 2.19.0)
+- **M1**: Drop `registered_model_name=` from `log_model` under UC
+- **M2**: Replace `.latest_versions` access with `search_model_versions` + sort+index
+- **M3**: Pass `signature=` to `log_model` under UC (required, not optional)
+- **P2**: Sklearn prediction-column dtype alignment for binary classifiers
+
+---
+
+## A3: AutoML to inline scikit-learn Pipeline
+
+**Problem**: `from databricks import automl` raises `ImportError` on serverless. The dbdemos fallback `DBDemos.create_mockup_automl_run` hits `TypeError: Object of type PlanMetrics is not JSON serializable` on Spark Connect.
+
+**Detect**:
+- `from databricks import automl` import line
+- Calls to `automl.classify(...)`, `automl.regress(...)`, `automl.forecast(...)`
+- The try/except block falling back to `DBDemos.create_mockup_automl_run`
+
+**Rewrite procedure**:
+1. Materialize training data via `.sample(0.02).toPandas()` (driver-side, avoids Spark Connect autolog paths).
+2. Pick the model based on the AutoML call: `RandomForestClassifier` for `automl.classify`, `RandomForestRegressor` / `LogisticRegression` for `automl.regress`.
+3. Disable `mlflow.autolog()` to prevent re-triggering the `PlanMetrics` JSON serialization bug.
+4. Log via `mlflow.sklearn.log_model(...)` with **no** `registered_model_name=` kwarg (see M1 below).
+5. After the run, register via `mlflow.register_model(...)` and set the UC alias (typically `prod` or `Champion`, match the demo's convention).
+6. Insert an early-exit cell into any downstream `*-automl-generated-notebook-*` companion notebook that calls `dbutils.notebook.exit("skipped")` when the UC alias already exists.
+
+**Example before** (fails with `PlanMetrics not JSON serializable` on serverless):
+
+```python
+try:
+    from databricks import automl
+    automl_run = automl.classify(
+        dataset=features_df,
+        target_col="is_fraud",
+        timeout_minutes=5,
+    )
+except ImportError:
+    DBDemos.create_mockup_automl_run(...)
+```
+
+**Example after**:
+
+```python
+import mlflow
+from mlflow.tracking import MlflowClient
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.compose import ColumnTransformer
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+from sklearn.pipeline import Pipeline
+
+mlflow.autolog(disable=True)
+mlflow.sklearn.autolog(disable=True)
+mlflow.set_registry_uri("databricks-uc")
+
+pdf = features_df.sample(0.02).toPandas()
+numeric_cols = [...]      # detect from schema
+categorical_cols = [...]
+
+pre = ColumnTransformer([
+    ("num", StandardScaler(), numeric_cols),
+    ("cat", OneHotEncoder(handle_unknown="ignore"), categorical_cols),
+])
+pipe = Pipeline([
+    ("pre", pre),
+    ("clf", RandomForestClassifier(n_estimators=50, random_state=42)),
+])
+pipe.fit(pdf[numeric_cols + categorical_cols], pdf["is_fraud"])
+
+model_full_name = f"{catalog}.{db}.dbdemos_fsi_fraud"
+with mlflow.start_run(run_name="serverless_sklearn_rewrite") as run:
+    mlflow.sklearn.log_model(pipe, artifact_path="model")  # no registered_model_name= (see M1)
+
+r = mlflow.register_model(
+    model_uri=f"runs:/{run.info.run_id}/model",
+    name=model_full_name,
+)
+MlflowClient().set_registered_model_alias(
+    name=model_full_name,
+    alias="prod",
+    version=r.version,
+)
+```
+
+**Companion fixes** when A3 is applied:
+- **E2** (downstream serving): flip `force_update = False` → `force_update = True` so the existing endpoint re-binds to the rewritten signature.
+- **P2** (dtype alignment): cast `prediction` column to `IntegerType` for binary classifiers (see P2 section below).
+
+---
+
+## A4: mlflow 2.19.0 `pyfunc.spark_udf` closure bug on Spark Connect
+
+**Problem**: On Spark Connect, `mlflow.pyfunc.spark_udf` (mlflow 2.19.0) captures `loaded_model` as a free variable in its inner `batch_predict_fn`. Worker-side deserialization fails with `NameError: cannot access free variable 'loaded_model'`. The root cause is Spark Connect serialization semantics, not mlflow itself, but mlflow 2.19.0's UDF code triggers the bug.
+
+**Detect**:
+- `loaded_model = mlflow.pyfunc.spark_udf(spark, model_uri, ...)` followed by `df.withColumn("prediction", loaded_model(struct(*features)))`
+- mlflow version pinned to `==2.19.0` in the environment spec
+- Common in `04.3-Batch-Scoring-*` notebooks (lakehouse-fsi-credit, lakehouse-fsi-fraud, lakehouse-hls-readmission, mlops-end2end)
+
+**Fix Option 1 (preferred, portable across mlflow versions)**: driver-side pandas inference.
+
+```python
+# BEFORE:
+loaded_model = mlflow.pyfunc.spark_udf(spark, "models:/main.churn.model@prod")
+scored = df.withColumn("prediction", loaded_model(struct(*feats)))
+
+# AFTER (Option 1, recommended):
+model = mlflow.pyfunc.load_model("models:/main.churn.model@prod")
+pdf = df.select(*feats, "patient_id").toPandas()
+pdf["prediction"] = model.predict(pdf[feats])
+scored = spark.createDataFrame(pdf)
+```
+
+**Fix Option 2 (fallback, smaller change)**: pin `mlflow>=2.20.0` in the environment spec.
+
+```json
+{
+  "environment_key": "Default",
+  "spec": {
+    "client": "2",
+    "dependencies": ["mlflow>=2.20.0", "scikit-learn==1.3.0"]
+  }
+}
+```
+
+**Recommend Option 1 by default**: works on any mlflow version, no version conflicts with other dependencies in the environment spec. Use Option 2 only when the workload depends on `spark_udf` semantics that cannot be reproduced driver-side (e.g., distributed inference on TB-scale data).
+
+---
+
+## M1: Drop `registered_model_name=` from `log_model` under UC
+
+**Problem**: Under UC (`mlflow.set_registry_uri("databricks-uc")`), passing `registered_model_name=` to `mlflow.<flavor>.log_model(...)` triggers an internal call to `get_model_version_by_alias(..., 'Champion')` that raises `RESOURCE_DOES_NOT_EXIST` for brand-new models (no alias yet exists).
+
+**Detect**:
+- `mlflow.set_registry_uri("databricks-uc")` anywhere in scope (notebook body or via `%run`)
+- Any subsequent `mlflow.<flavor>.log_model(..., registered_model_name=<name>)` (any flavor: `sklearn`, `pytorch`, `tensorflow`, `pyfunc`, etc.)
+
+**Fix**:
+1. Drop `registered_model_name=` from `log_model(...)`.
+2. After the `with mlflow.start_run()` block, call `mlflow.register_model(model_uri=f"runs:/{run.info.run_id}/model", name=<full_name>)`.
+3. Use the returned `r.version` to set aliases.
+
+**Example before** (raises `RESOURCE_DOES_NOT_EXIST` then `TypeError: 'NoneType' object is not iterable`):
+
+```python
+mlflow.set_registry_uri("databricks-uc")
+with mlflow.start_run() as run:
+    mlflow.sklearn.log_model(model, "model", registered_model_name=model_full_name)
+client = MlflowClient()
+v = max(
+    client.get_registered_model(model_full_name).latest_versions,
+    key=lambda x: x.creation_timestamp,
+)
+```
+
+**Example after** (UC-aware):
+
+```python
+mlflow.set_registry_uri("databricks-uc")
+with mlflow.start_run() as run:
+    mlflow.sklearn.log_model(model, "model")  # NO registered_model_name=
+
+r = mlflow.register_model(
+    model_uri=f"runs:/{run.info.run_id}/model",
+    name=model_full_name,
+)
+MlflowClient().set_registered_model_alias(
+    model_full_name,
+    "Champion",
+    version=r.version,
+)
+```
+
+---
+
+## M2: Replace `.latest_versions` access with `search_model_versions` + sort+index
+
+**Problem**: `RegisteredModel.latest_versions` is always `None` on UC. `max(None, key=...)` raises `TypeError: 'NoneType' object is not iterable`.
+
+**Detect**:
+- `mlflow.set_registry_uri("databricks-uc")` is present in scope.
+- Any access to `.latest_versions` on a `RegisteredModel` (e.g., `client.get_registered_model(name).latest_versions`).
+
+**Fix**: replace `.latest_versions` access with `client.search_model_versions(f"name='{model_name}'")` plus sort+index. Use sort+index (not `max(..., key=)`) per A2 to avoid the `from pyspark.sql.functions import *` shadow.
+
+**Example before** (raises `TypeError: 'NoneType' object is not iterable`):
+
+```python
+client = MlflowClient()
+v = max(
+    client.get_registered_model(model_full_name).latest_versions,
+    key=lambda x: x.creation_timestamp,
+)
+```
+
+**Example after**:
+
+```python
+client = MlflowClient()
+_versions = list(client.search_model_versions(f"name='{model_full_name}'"))
+_versions.sort(key=lambda mv: int(mv.version), reverse=True)
+v = _versions[0]
+```
+
+---
+
+## M3: Pass `signature=` to `log_model` under UC (required, not optional)
+
+**Problem**: Under UC (`mlflow.set_registry_uri("databricks-uc")`), `mlflow.<flavor>.log_model(...)` without a `signature=` kwarg raises `MlflowException: Model signature is required for registering a model to Unity Catalog. ...`. The error fires *during* `log_model` (before `mlflow.register_model`), so the run completes but the model artifact is invalid for UC promotion.
+
+**Detect**:
+- `mlflow.set_registry_uri("databricks-uc")` anywhere in scope.
+- Any `mlflow.<flavor>.log_model(...)` call (sklearn, pytorch, pyfunc, etc.) that omits `signature=`.
+- Common in `04.1-Automl-*`, `04.2-Model-Registration-*`, and any cell that builds a model inline before registration.
+
+**Fix**: infer the signature from a sample of the training data and pass it to `log_model`.
+
+**Example before** (raises `MlflowException` under UC):
+
+```python
+mlflow.set_registry_uri("databricks-uc")
+with mlflow.start_run() as run:
+    mlflow.sklearn.log_model(pipe, artifact_path="model")  # no signature= -> UC rejects
+```
+
+**Example after** (UC-aware):
+
+```python
+from mlflow.models.signature import infer_signature
+
+mlflow.set_registry_uri("databricks-uc")
+
+X_sample = pdf[features].head(100)
+y_sample = pipe.predict(X_sample)
+signature = infer_signature(X_sample, y_sample)
+
+with mlflow.start_run() as run:
+    mlflow.sklearn.log_model(
+        pipe,
+        artifact_path="model",
+        signature=signature,
+    )
+```
+
+**Notes**:
+- For `mlflow.pyfunc.log_model`, infer the signature from a representative pandas input + sample prediction from the pyfunc wrapper, not from raw Spark DataFrames.
+- For models with multiple outputs (e.g., classification probabilities), pass the full prediction array; `infer_signature` handles multi-column outputs.
+- Combine with **M1** (no `registered_model_name=`) and **M2** (no `.latest_versions`) — all three apply together on every UC `log_model` call.
+
+---
+
+## P2: Sklearn prediction-column dtype alignment for binary classifiers
+
+**Problem**: When applying the A3 rewrite (`automl.classify` → sklearn Pipeline), `model.predict()` emits `float64` by default. After `spark.createDataFrame(pdf)` round-trips this to Spark, the `prediction` column is `DoubleType`. The original AutoML demo emits `prediction` as `IntegerType` (typical for binary classifiers). Downstream notebooks that MERGE on `prediction` fail with `[DELTA_FAILED_TO_MERGE_FIELDS]: prediction (Double) vs prediction (Integer)`.
+
+**Detect**:
+- A3 rewrite has been applied.
+- Original AutoML demo emits `prediction` as `IntegerType`.
+- Downstream cells write to a Delta table that already has a `prediction` `IntegerType` column (e.g., lakehouse-fsi-credit's `explainability_and_fairness` task).
+
+**Fix**: cast predictions to match the demo's original schema before writing. For binary classifiers, that is `IntegerType`.
+
+**Example before** (in migrated sklearn cell):
+
+```python
+pdf["prediction"] = pipe.predict(pdf[features])  # emits float64
+scored = spark.createDataFrame(pdf)
+scored.write.format("delta").mode("append").saveAsTable(predictions_table)
+# Downstream MERGE fails with DELTA_FAILED_TO_MERGE_FIELDS: prediction (Double) vs prediction (Integer)
+```
+
+**Example after**:
+
+```python
+import pyspark.sql.types as T
+pdf["prediction"] = pipe.predict(pdf[features]).astype("int64")  # cast to int
+scored = spark.createDataFrame(pdf)
+scored = scored.withColumn("prediction", scored["prediction"].cast(T.IntegerType()))
+scored.write.format("delta").mode("append").saveAsTable(predictions_table)
+```
+
+---
+
+## Combined rewrite checklist (A3 + M1 + M2 + P2 together)
+
+When migrating an AutoML notebook with downstream batch scoring, apply **all of these in one pass**:
+
+1. **A3**: rewrite `automl.classify/regress/forecast` as inline sklearn `Pipeline` with `mlflow.autolog(disable=True)`.
+2. **M1**: drop `registered_model_name=` from `log_model`; call `mlflow.register_model(...)` after the run.
+3. **M2**: replace any `.latest_versions` access with `search_model_versions` + sort+index.
+4. **M3**: pass `signature=infer_signature(X_sample, y_sample)` to every `log_model` call under UC (required, not optional).
+5. **A2**: use sort+index everywhere (not `max(..., key=)`) because `from pyspark.sql.functions import *` shadows the builtin.
+6. **P2**: cast `prediction` column to `IntegerType` for binary classifiers before writing to Delta.
+7. **E1**: if the model is loaded inside an SDP `.py` library file via `pyfunc.spark_udf(..., env_manager='local')`, emit `%pip install -q databricks-automl-runtime` at the top of the SDP file (because cloudpickle reconstructs AutoML-trained artifacts and needs the runtime module).
+8. **E2**: in any downstream `04.3-Model-serving-*` companion notebook, flip `force_update = False` → `force_update = True` so the endpoint re-binds to the rewritten signature.
+
+**Verification (post-migration)**:
+- The migrated tree contains zero `from databricks import automl` imports and zero `DBDemos.create_mockup_automl_run` calls.
+- The migrated tree contains zero `registered_model_name=` kwargs on `log_model` (when UC registry is in scope).
+- Every `log_model` call under UC has a `signature=` kwarg derived from `infer_signature(...)`.
+- The migrated tree contains zero `.latest_versions` references.
+- The migrated tree contains zero `mlflow.pyfunc.spark_udf` calls (Option 1 driver-side rewrite applied).
+- Running the migrated job end-to-end on serverless produces a UC-registered model with the demo's expected alias (`prod` or `Champion`), and downstream batch-scoring and explainability tasks pass.
+
+## Documentation
+
+- MLflow Model Registry on UC: https://docs.databricks.com/en/machine-learning/manage-model-lifecycle/index.html
+- MLflow PyFunc: https://mlflow.org/docs/latest/python_api/mlflow.pyfunc.html
+- Spark Connect overview: https://docs.databricks.com/en/spark/connect-vs-classic
+- Serverless ML libraries: https://docs.databricks.com/en/compute/serverless/dependencies

--- a/skills/databricks-serverless-migration/references/mlflow-uc-patterns.md
+++ b/skills/databricks-serverless-migration/references/mlflow-uc-patterns.md
@@ -74,7 +74,15 @@ pipe.fit(pdf[numeric_cols + categorical_cols], pdf["is_fraud"])
 
 model_full_name = f"{catalog}.{db}.dbdemos_fsi_fraud"
 with mlflow.start_run(run_name="serverless_sklearn_rewrite") as run:
-    mlflow.sklearn.log_model(pipe, artifact_path="model")  # no registered_model_name= (see M1)
+    # UC requires signature= on every log_model (see M3 below)
+    from mlflow.models.signature import infer_signature
+    X_sample = pdf[numeric_cols + categorical_cols].head(100)
+    signature = infer_signature(X_sample, pipe.predict(X_sample))
+    mlflow.sklearn.log_model(
+        pipe,
+        artifact_path="model",
+        signature=signature,
+    )  # no registered_model_name= (see M1)
 
 r = mlflow.register_model(
     model_uri=f"runs:/{run.info.run_id}/model",

--- a/skills/databricks-serverless-migration/references/multi-source-enumeration.md
+++ b/skills/databricks-serverless-migration/references/multi-source-enumeration.md
@@ -23,9 +23,9 @@ Parse `bundle_config.py` **statically, via `ast.parse(...)` only**. Walk the res
    - **Git URL**: `git clone <url>` into a sibling location (e.g., `~/.databricks-migration-skill/scratch/<run-id>/external/<repo-name>/`). Honor the declared branch/ref.
    - **S3/ADLS path**: download via `databricks fs cp -r <path> <local>` into the same sibling location.
    - **Workspace path**: export via `databricks workspace export-dir <path> <local>`.
-3. **List external sources as a first-class artifact category** in the migration plan, alongside notebooks, jobs, pipelines. Use a category like `external_sources[]` with each entry containing `source_type` (git / s3 / workspace), `url_or_path`, `ref` (if git), and `local_path` (where you put it).
-4. **Include external-source notebooks in the per-notebook enumeration** (Step 1.5 procedure step 1). Treat them exactly the same as local notebooks: read full source, run Step 2 Analyze, record the structured summary.
-5. **When applying fixes**: write fixes back to the local clone of the external source. Track the upstream-vs-local mapping so the agent can produce a coherent migration plan.
+4. **List external sources as a first-class artifact category** in the migration plan, alongside notebooks, jobs, pipelines. Use a category like `external_sources[]` with each entry containing `source_type` (git / s3 / workspace), `url_or_path`, `ref` (if git), and `local_path` (where you put it).
+5. **Include external-source notebooks in the per-notebook enumeration** (Step 1.5 procedure step 1). Treat them exactly the same as local notebooks: read full source, run Step 2 Analyze, record the structured summary.
+6. **When applying fixes**: write fixes back to the local clone of the external source. Track the upstream-vs-local mapping so the agent can produce a coherent migration plan.
 
 ## Example
 

--- a/skills/databricks-serverless-migration/references/multi-source-enumeration.md
+++ b/skills/databricks-serverless-migration/references/multi-source-enumeration.md
@@ -13,12 +13,13 @@ In Step 1.5 ("Enumerate first"), check for a `bundle_config.py` file at the top 
 - A custom upstream-repo list, e.g., `external_repos = [{"url": "https://...", "ref": "main"}]`.
 - S3 paths or workspace paths in any "source" field.
 
-Be permissive in the parse: parse `bundle_config.py` as Python (read its top-level assignments), then scan all top-level dict / list literals for any value that looks like a git URL (`https://github.com/...`, `git@github.com:...`) or a cloud storage path (`s3://`, `abfss://`, `gs://`).
+Parse `bundle_config.py` **statically, via `ast.parse(...)` only**. Walk the resulting AST for top-level `ast.Assign` nodes and use `ast.literal_eval` on right-hand-side literals (`dict`, `list`, `str`) to recover values. **Never `exec`, `eval`, or `import` the file** — it is workload-supplied Python source and may be untrusted; running it would be arbitrary code execution on the host. After recovering top-level literal values, scan them for any string that looks like a git URL (`https://github.com/...`, `git@github.com:...`) or a cloud storage path (`s3://`, `abfss://`, `gs://`).
 
 ## Procedure
 
-1. **Parse `bundle_config.py`** for any upstream-source declarations.
-2. **For each upstream source**:
+1. **Parse `bundle_config.py`** via `ast.parse` for any upstream-source declarations (see safety note above).
+2. **Show the parsed external sources to the user and require explicit confirmation before any fetch.** Print every git URL, S3/ADLS path, and workspace path you found, and wait for the user to approve. Do not auto-fetch without approval — these URLs come from the workload's own config and may point anywhere.
+3. **For each user-approved upstream source**:
    - **Git URL**: `git clone <url>` into a sibling location (e.g., `~/.databricks-migration-skill/scratch/<run-id>/external/<repo-name>/`). Honor the declared branch/ref.
    - **S3/ADLS path**: download via `databricks fs cp -r <path> <local>` into the same sibling location.
    - **Workspace path**: export via `databricks workspace export-dir <path> <local>`.

--- a/skills/databricks-serverless-migration/references/multi-source-enumeration.md
+++ b/skills/databricks-serverless-migration/references/multi-source-enumeration.md
@@ -1,0 +1,68 @@
+# Multi-source workload enumeration (`bundle_config.py`)
+
+Some demos and customer bundles do not keep all their notebooks in the local source tree. Instead, they declare upstream git repos (or S3 paths) in a `bundle_config.py` file and pull the real task notebooks from there at install or deploy time. The skill must enumerate those upstream sources up front, before per-notebook analysis (Step 1.5), or it will mis-enumerate the workload and miss the real notebooks.
+
+Source: 7-demo dbdemos E2E sweep. The clearest example is `dbt-on-databricks`: its `bundle_config.py` references `https://github.com/databricks-demos/dbt-databricks-c360`, and the real task notebooks (`01-load-data.py`, `03-churn-prediction.py`, etc.) live in that upstream repo, not in the local `dbdemos-notebooks/` tree.
+
+## Detect
+
+In Step 1.5 ("Enumerate first"), check for a `bundle_config.py` file at the top of the workload tree. If present, parse it for upstream-source declarations. Common declaration patterns:
+
+- A `git_source` block: a dict with `git_url`, `git_provider`, `git_branch` keys.
+- An `init_scripts` block referencing an upstream URL.
+- A custom upstream-repo list, e.g., `external_repos = [{"url": "https://...", "ref": "main"}]`.
+- S3 paths or workspace paths in any "source" field.
+
+Be permissive in the parse: parse `bundle_config.py` as Python (read its top-level assignments), then scan all top-level dict / list literals for any value that looks like a git URL (`https://github.com/...`, `git@github.com:...`) or a cloud storage path (`s3://`, `abfss://`, `gs://`).
+
+## Procedure
+
+1. **Parse `bundle_config.py`** for any upstream-source declarations.
+2. **For each upstream source**:
+   - **Git URL**: `git clone <url>` into a sibling location (e.g., `~/.databricks-migration-skill/scratch/<run-id>/external/<repo-name>/`). Honor the declared branch/ref.
+   - **S3/ADLS path**: download via `databricks fs cp -r <path> <local>` into the same sibling location.
+   - **Workspace path**: export via `databricks workspace export-dir <path> <local>`.
+3. **List external sources as a first-class artifact category** in the migration plan, alongside notebooks, jobs, pipelines. Use a category like `external_sources[]` with each entry containing `source_type` (git / s3 / workspace), `url_or_path`, `ref` (if git), and `local_path` (where you put it).
+4. **Include external-source notebooks in the per-notebook enumeration** (Step 1.5 procedure step 1). Treat them exactly the same as local notebooks: read full source, run Step 2 Analyze, record the structured summary.
+5. **When applying fixes**: write fixes back to the local clone of the external source. Track the upstream-vs-local mapping so the agent can produce a coherent migration plan.
+
+## Example
+
+`bundle_config.py` in `dbt-on-databricks`:
+
+```python
+# bundle_config.py (excerpt)
+bundle_name = "dbt-on-databricks"
+
+dbt_project_external = {
+    "url": "https://github.com/databricks-demos/dbt-databricks-c360",
+    "ref": "main",
+    "subdirectory": "dbt-databricks-c360",
+}
+
+notebooks = [
+    "_resources/00-setup.py",
+    "01-wrapper-notebook.py",
+]
+```
+
+**Skill behavior**:
+
+1. Parse `bundle_config.py`, detect `dbt_project_external.url`.
+2. `git clone https://github.com/databricks-demos/dbt-databricks-c360 ~/.databricks-migration-skill/scratch/<run-id>/external/dbt-databricks-c360/`.
+3. Enumerate notebooks from BOTH the local tree (`_resources/00-setup.py`, `01-wrapper-notebook.py`) AND the cloned `dbt-databricks-c360` tree (`01-load-data.py`, `03-churn-prediction.py`, models / seeds / macros if any).
+4. Migration plan lists the upstream repo as a first-class artifact and tracks the per-notebook fixes against the local clone.
+5. **Job-spec migration (H1)**: rewrite `dbt_task.project_directory` to point at the **migrated** workspace location after deploy, e.g., `/Workspace/Users/<me>/dbt-on-databricks-skill-migrated/dbt-databricks-c360`.
+
+## Verification
+
+After Step 1.5 completes for a multi-source workload, verify the enumeration covers all real task notebooks:
+- The enumeration includes notebooks from every upstream source declared in `bundle_config.py`.
+- The migration plan's `external_sources[]` list is non-empty when `bundle_config.py` was present.
+- No "real" task notebook (referenced by the job spec or the SDP pipeline spec) is missing from the per-notebook summary list.
+
+## Documentation
+
+- Databricks Asset Bundles: https://docs.databricks.com/en/dev-tools/bundles/index.html
+- `databricks workspace export-dir`: https://docs.databricks.com/dev-tools/cli/workspace-commands.html
+- `databricks fs cp`: https://docs.databricks.com/dev-tools/cli/fs-commands.html


### PR DESCRIPTION
# serverless-migration v2: UC MLflow patterns + AutoML rewrite + failure reporting + Genie Code install + multi-source enumeration

## Summary

Two rounds of updates to the `databricks-serverless-migration` skill, both driven by field gaps:

### Round 1 (commit `99b3949`) — failure reporting + Genie Code install
1. Auto-file GitHub issue on unmigratable workloads. The Failure Reporting Protocol generates a pre-filled `issues/new` URL plus an optional `gh issue create` command. Decision tree simplified to offer filing for *any* unmigratable case. MUST-NOT-CONTAIN list expanded. Defensive redaction checklist runs before write, and a deterministic post-serialization regex scrub runs before the pre-filled URL is shown.
2. Document Genie Code Agent-mode install. New "Where to Run This Skill" section + `references/install-in-databricks-genie-code.md` covering all three install methods (notebook installer, shell installer, workspace-wide Databricks App), per-user vs workspace-wide paths, and the serverless-no-CLI caveat specific to this skill.

### Round 2 (commit `9ffc6c2`) — UC MLflow + AutoML rewrite + multi-source enumeration

Five new patterns added to the pattern catalog (A2, A3, M1, M2, M3) plus two new reference docs (`mlflow-uc-patterns.md`, `multi-source-enumeration.md`), driven by end-to-end migrating seven Databricks demos to serverless.

- **A2**: builtin `max(..., key=)` / `min(..., key=)` / `sorted(..., key=)` shadowed by `pyspark.sql.functions.max` (raises `TypeError: max() got an unexpected keyword argument 'key'`). Replace with `xs.sort(key=...); top = xs[0]`.
- **A3**: AutoML on serverless → inline scikit-learn `Pipeline` rewrite (`from databricks import automl` is unavailable and the dbdemos mockup fallback hits Spark Connect JSON-serialisability).
- **M1**: `mlflow.<flavor>.log_model(..., registered_model_name=...)` under UC raises `RESOURCE_DOES_NOT_EXIST`. Drop the kwarg, call `mlflow.register_model(...)` after the run and set the alias via `MlflowClient`.
- **M2**: `RegisteredModel.latest_versions` is always `None` on UC. Use `client.search_model_versions(f"name='{name}'")` + sort+index.
- **M3**: UC requires `signature=` on every `log_model`. Infer via `infer_signature(X_sample, model.predict(X_sample))` and pass to `log_model(..., signature=signature)`.

### Review fixes (commits `e8d447d`, `e475bde`, `bbd6e4d`)
- A3 example now includes `signature=` (per M3).
- `configuration-guide.md`: clarified that `environment_key` is for dependency declaration, not a compute selector. Removing cluster references is what makes a task run on serverless.
- Scrubbed internal Slack channels, personal handles, and softened the publishing flow per a public-publishing-review pass.

## Test signal

- **Regression bench** (lint + 16 industry solution accelerator workloads + 15-notebook compatibility suite + sanity) passed on 2026-06-02: 16/16 SUCCESS in 4486s, lint PASS, compat PASS, sanity PASS (9 references resolved), exit code 0.
- **End-to-end on serverless** (seven Databricks demos re-installed, migrated with this skill, run as serverless jobs): all 7 ran SUCCESS.
- **Data-equivalence comparison** (statistical + Delta time-travel + row-level): bit-identical row counts on every user-data table; all observed drift explained by demo data-generator RNG, AutoML retraining, or the required `llama-3-1-405b` → `llama-3-3-70b` LLM substitution.

## Test plan
- [x] CI lint passes on `references/*.md`
- [x] Skill loads and resolves all 9 references
- [x] Industry solution accelerator workloads migrate cleanly
- [x] 15-notebook compatibility suite passes

This pull request and its description were written by Isaac.
