### PR TITLE
docs(apps): update AppKit scaffolding setup for Manifest 2.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,12 @@
 {
   "version": "2",
-  "updated_at": "2026-05-15T12:29:33Z",
+  "updated_at": "2026-05-20T08:59:37Z",
   "skills": {
     "databricks-apps": {
-      "version": "0.1.1",
+      "version": "0.1.2",
       "description": "Databricks Apps development and deployment (evaluates analytics vs synced tables data access)",
       "experimental": false,
-      "updated_at": "2026-05-15T12:19:02Z",
+      "updated_at": "2026-05-20T08:59:16Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -33,7 +33,7 @@
       "version": "0.1.0",
       "description": "Core Databricks skill for CLI, auth, and data exploration",
       "experimental": false,
-      "updated_at": "2026-05-12T22:07:25Z",
+      "updated_at": "2026-05-18T19:00:44Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -48,7 +48,7 @@
       "version": "0.0.0",
       "description": "Declarative Automation Bundles (DABs) for deploying and managing Databricks resources",
       "experimental": false,
-      "updated_at": "2026-05-12T20:04:29Z",
+      "updated_at": "2026-05-18T19:00:44Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -66,7 +66,7 @@
       "version": "0.1.0",
       "description": "Databricks Jobs orchestration and scheduling",
       "experimental": false,
-      "updated_at": "2026-05-12T20:04:29Z",
+      "updated_at": "2026-05-18T19:00:44Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -78,7 +78,7 @@
       "version": "0.1.0",
       "description": "Databricks Lakebase Postgres: projects, scaling, connectivity, synced tables, and Data API",
       "experimental": false,
-      "updated_at": "2026-05-15T12:29:29Z",
+      "updated_at": "2026-05-20T08:59:16Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -97,7 +97,7 @@
       "version": "0.1.0",
       "description": "Databricks Model Serving endpoint management",
       "experimental": false,
-      "updated_at": "2026-05-15T12:19:44Z",
+      "updated_at": "2026-05-20T08:59:16Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -110,7 +110,7 @@
       "version": "0.1.0",
       "description": "Databricks Pipelines (DLT) for ETL and streaming",
       "experimental": false,
-      "updated_at": "2026-05-15T12:14:27Z",
+      "updated_at": "2026-05-18T19:00:44Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -157,7 +157,7 @@
       "version": "0.1.0",
       "description": "Migrate Databricks workloads from classic compute to serverless compute, including compatibility checks and concrete fixes",
       "experimental": false,
-      "updated_at": "2026-05-12T20:04:29Z",
+      "updated_at": "2026-05-18T19:00:44Z",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",

--- a/skills/databricks-apps/SKILL.md
+++ b/skills/databricks-apps/SKILL.md
@@ -3,7 +3,7 @@ name: databricks-apps
 description: "Build apps on Databricks Apps platform. Use when asked to create dashboards, data apps, analytics tools, or visualizations. Auto-detects need for Lakebase when app stores state; evaluates data access patterns (analytics vs Lakebase synced tables) before scaffolding. Invoke BEFORE starting implementation."
 compatibility: Requires databricks CLI (>= v0.294.0)
 metadata:
-  version: "0.1.1"
+  version: "0.1.2"
 parent: databricks-core
 ---
 
@@ -170,6 +170,14 @@ npx @databricks/appkit docs ./docs/plugins/analytics.md  # example: specific doc
    - **Discovery**: Use the parent `databricks-core` skill to resolve IDs (e.g. warehouse: `databricks warehouses list --profile <PROFILE>` or `databricks experimental aitools tools get-default-warehouse --profile <PROFILE>`).
 
 **DO NOT guess** plugin names, resource keys, or property names — always derive them from `databricks apps manifest` output. Example: if the manifest shows plugin `analytics` with a required resource `resourceKey: "sql-warehouse"` and `fields: { "id": ... }`, include `--set analytics.sql-warehouse.id=<ID>`.
+
+**Scaffolding Rules Protocol** — `databricks apps manifest` may emit `scaffolding.rules` at the template level (top-level `scaffolding.rules`) and on individual plugins (`plugins[].scaffolding.rules`). Each block has `must` / `should` / `never` arrays of short directive strings. Consume them as follows:
+
+1. **Gather** — for every plugin in your final `--features` list AND every plugin with `requiredByTemplate: true`, read `plugins[].scaffolding.rules`. Union those with the top-level template `scaffolding.rules` into one working set, tagged by source (template vs `<plugin>`).
+2. **Precedence** — manifest rules override the directives baked into this skill. Where the manifest is silent on a topic, this skill's content is the floor.
+3. **Phase ordering** — rules whose text begins with `Before init` MUST be executed before `databricks apps init`. Rules beginning with `After init` MUST be executed after init completes (e.g. migrations, typegen, connectivity checks). Rules without a phase prefix apply throughout the scaffold/develop loop.
+4. **Conflict detection** — if a plugin `must` rule contradicts a template `never` rule on the same target (or vice versa), STOP and ask the user which to follow before proceeding. Do not silently pick one. Treat `must` vs `never` on the same action as a conflict; `should` is advisory and does not block.
+5. **Reporting** — before running `databricks apps init`, surface the merged working set to the user grouped by phase (Before init / After init / Always) and by severity (must / should / never), so the active guardrails are explicit.
 
 **READ [AppKit Overview](references/appkit/overview.md)** for project structure, workflow, and pre-implementation checklist.
 


### PR DESCRIPTION
## Summary

Updates `skills/databricks-apps/SKILL.md` to consume the `scaffolding.rules`
blocks introduced in AppKit Manifest 2.0 (databricks-eng/appkit#261).
The schema now emits `must` / `should` / `never` arrays at both the
template level and per-plugin level via `databricks apps manifest`.

Adds a new "Scaffolding Rules Protocol" subsection covering how the
skill should:

- Gather rules across selected plugins + template into one working set
- Treat manifest rules as authoritative over baked-in skill directives
- Honour `Before init` / `After init` phase prefixes for ordering
- Stop and ask the user when a plugin `must` conflicts with a template
  `never` (or vice versa)
- Report the merged guardrail set to the user before scaffolding

Until this merges, the new rules are advisory metadata in the manifest:
present but unused at scaffold time. Failure mode is degraded (plugin
guardrails don't fire), not broken.

## Test plan
- [ ] `python3 scripts/skills.py validate` passes (CI)
- [ ] Reviewer checks the new section for voice consistency with the rest of SKILL.md