### PR TITLE
Add guidance for adding Lakebase and Model Serving to existing apps

### DIFF
--- a/skills/databricks-apps/SKILL.md
+++ b/skills/databricks-apps/SKILL.md
@@ -114,7 +114,7 @@ After completing the decision gate above, use this routing table:
 - **Read lakehouse data at low latency (lookups, search, catalogs)**: Use Lakebase synced tables — see [Lakebase Guide](references/appkit/lakebase.md)
 - **Read/write persistent data (users, orders, CRUD state)**: Use Lakebase pool via tRPC — see [Lakebase Guide](references/appkit/lakebase.md)
 - **Natural language query interface over tables (Genie)**: Use `genie()` plugin — see [Genie Guide](references/appkit/genie.md)
-- **Call ML model endpoint**: Use tRPC — see [Model Serving Guide](references/appkit/model-serving.md)
+- **Call ML model endpoint**: Use `serving()` plugin — see [Model Serving Guide](references/appkit/model-serving.md)
 - **Trigger or monitor a Lakeflow Job from the app**: Use the `jobs()` plugin — see [Jobs Guide](references/appkit/jobs.md)
 - **⚠️ NEVER use tRPC to run SELECT queries against the warehouse** — always use SQL files in `config/queries/`
 - **⚠️ NEVER use `useAnalyticsQuery` for Lakebase data** — it queries the SQL warehouse only

--- a/skills/databricks-apps/references/appkit/lakebase.md
+++ b/skills/databricks-apps/references/appkit/lakebase.md
@@ -14,7 +14,7 @@ Use Lakebase when your app needs **persistent read/write storage** — forms, CR
 
 ## Scaffolding
 
-**ALWAYS scaffold with the correct feature flags** — do not add Lakebase manually to an analytics-only scaffold.
+**Scaffolding is the fastest way to get started.** If you already have an app, see *Adding Lakebase to an Existing App* below.
 
 **Lakebase only** (no analytics SQL warehouse):
 ```bash
@@ -48,6 +48,76 @@ databricks postgres list-branches projects/<PROJECT_ID> --profile <PROFILE>
 # List databases → use the name field
 databricks postgres list-databases projects/<PROJECT_ID>/branches/<BRANCH_ID> --profile <PROFILE>
 ```
+
+## Adding Lakebase to an Existing App
+
+**`databricks.yml`** — add Lakebase variables, user_api_scopes, and resource:
+
+```yaml
+variables:
+  lakebase_branch:
+    description: Lakebase branch resource name
+  lakebase_database:
+    description: Lakebase database resource name
+
+resources:
+  apps:
+    app:
+      user_api_scopes:
+        # ... existing scopes ...
+        - postgres
+      resources:
+        # ... existing resources ...
+        - name: postgres
+          postgres:
+            branch: ${var.lakebase_branch}
+            database: ${var.lakebase_database}
+
+targets:
+  default:
+    variables:
+      lakebase_branch: projects/<PROJECT_ID>/branches/<BRANCH_ID>
+      lakebase_database: projects/<PROJECT_ID>/branches/<BRANCH_ID>/databases/<DB_ID>
+```
+
+Use the `databricks-lakebase` skill to create a Lakebase project and discover branch/database resource names.
+
+**`app.yaml`** — add env injection:
+
+```yaml
+env:
+  # ... existing env vars ...
+  - name: LAKEBASE_ENDPOINT
+    valueFrom: postgres
+```
+
+Other Lakebase env vars (`PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, `PGSSLMODE`) are auto-injected by the platform when the `postgres` resource is configured. Only `LAKEBASE_ENDPOINT` must be set explicitly.
+
+**`server/server.ts`** — register the plugin:
+
+```typescript
+import { createApp, server, analytics, lakebase } from "@databricks/appkit";
+
+createApp({
+  plugins: [server(), analytics(), lakebase()],
+}).catch(console.error);
+```
+
+Preserve existing plugins and add `lakebase()` to the array.
+
+**`server/.env`** — for local development:
+
+```dotenv
+PGHOST=<host from endpoint>
+PGPORT=5432
+PGDATABASE=<your database name>
+PGSSLMODE=require
+LAKEBASE_ENDPOINT=projects/<PROJECT_ID>/branches/<BRANCH_ID>/endpoints/<ENDPOINT_ID>
+```
+
+Get connection details from `databricks postgres get-endpoint`. See *Local Development* below for the full workflow.
+
+Run `npm run sync` to update plugin metadata (also runs automatically during `npm run dev` and `npm run build`). Deploy the app before local development — see *Local Development > Prerequisites* below. Update smoke tests if headings or routes changed, then `databricks apps validate`.
 
 ## Project Structure (after `databricks apps init --features lakebase`)
 

--- a/skills/databricks-apps/references/appkit/lakebase.md
+++ b/skills/databricks-apps/references/appkit/lakebase.md
@@ -51,7 +51,7 @@ databricks postgres list-databases projects/<PROJECT_ID>/branches/<BRANCH_ID> --
 
 ## Adding Lakebase to an Existing App
 
-**`databricks.yml`** — add Lakebase variables, user_api_scopes, and resource:
+**`databricks.yml`** — add Lakebase variables and resource:
 
 ```yaml
 variables:
@@ -63,9 +63,6 @@ variables:
 resources:
   apps:
     app:
-      user_api_scopes:
-        # ... existing scopes ...
-        - postgres
       resources:
         # ... existing resources ...
         - name: postgres
@@ -81,6 +78,8 @@ targets:
 ```
 
 Use the `databricks-lakebase` skill to create a Lakebase project and discover branch/database resource names.
+
+For per-user connections (OBO/RLS), also add `postgres` to `user_api_scopes` — see `npx @databricks/appkit docs ./docs/plugins/lakebase.md` for OBO setup.
 
 **`app.yaml`** — add env injection:
 
@@ -117,7 +116,7 @@ LAKEBASE_ENDPOINT=projects/<PROJECT_ID>/branches/<BRANCH_ID>/endpoints/<ENDPOINT
 
 Get connection details from `databricks postgres get-endpoint`. See *Local Development* below for the full workflow.
 
-Run `npm run sync` to update plugin metadata (also runs automatically during `npm run dev` and `npm run build`). Deploy the app before local development — see *Local Development > Prerequisites* below. Update smoke tests if headings or routes changed, then `databricks apps validate`.
+Deploy the app before local development — see *Local Development > Prerequisites* below. Update smoke tests if headings or routes changed, then `databricks apps validate`.
 
 ## Project Structure (after `databricks apps init --features lakebase`)
 

--- a/skills/databricks-apps/references/appkit/model-serving.md
+++ b/skills/databricks-apps/references/appkit/model-serving.md
@@ -79,7 +79,7 @@ Preserve existing plugins and add `serving()` to the array.
 DATABRICKS_SERVING_ENDPOINT_NAME=<your-endpoint-name>
 ```
 
-Run `npm run sync` to update plugin metadata (also runs automatically during `npm run dev` and `npm run build`). Update smoke tests if headings or routes changed, then `databricks apps validate`.
+Update smoke tests if headings or routes changed, then `databricks apps validate`.
 
 ## Serving Plugin API
 

--- a/skills/databricks-apps/references/appkit/model-serving.md
+++ b/skills/databricks-apps/references/appkit/model-serving.md
@@ -27,82 +27,196 @@ databricks apps init --name <APP_NAME> --features serving \
   --run none --profile <PROFILE>
 ```
 
-**If no `serving` plugin** (add manually to an existing app):
+**If adding to an existing app**, see *Adding Model Serving to an Existing App* below.
 
-Use the `databricks-model-serving` skill to create a serving endpoint first, then follow the resource declaration and tRPC patterns below.
+Use the `databricks-model-serving` skill to create a serving endpoint first if one doesn't exist yet.
 
-## Resource Declaration
+## Adding Model Serving to an Existing App
 
-Add the serving endpoint resource to `databricks.yml`:
+**`databricks.yml`** — add serving endpoint resource and user_api_scopes:
 
 ```yaml
 resources:
   apps:
-    my_app:
+    app:
+      user_api_scopes:
+        # ... existing scopes ...
+        - serving.serving-endpoints
       resources:
-        - name: my-model-endpoint
+        # ... existing resources ...
+        - name: serving-endpoint
           serving_endpoint:
             name: <ENDPOINT_NAME>
-            permission: CAN_QUERY          # auto-granted to SP on deploy
+            permission: CAN_QUERY
 ```
 
-Add environment variable injection in `app.yaml`:
+**`app.yaml`** — add env injection:
 
 ```yaml
 env:
-  - name: SERVING_ENDPOINT
+  # ... existing env vars ...
+  - name: DATABRICKS_SERVING_ENDPOINT_NAME
     valueFrom: serving-endpoint
 ```
 
 The injected value is the endpoint **name** (not a URL). Use it in server-side code to call the endpoint.
 
-## Non-Streaming Query Pattern (tRPC)
-
-Always use tRPC for model serving calls — do NOT call endpoints directly from the client.
+**`server/server.ts`** — register the plugin:
 
 ```typescript
-// server/server.ts (or server/trpc.ts)
-import { initTRPC } from "@trpc/server";
-import { getExecutionContext } from "@databricks/appkit";
-import { z } from "zod";
-import superjson from "superjson";
+import { createApp, server, analytics, serving } from "@databricks/appkit";
 
-const t = initTRPC.create({ transformer: superjson });
-const publicProcedure = t.procedure;
+createApp({
+  plugins: [server(), analytics(), serving()],
+}).catch(console.error);
+```
 
-export const appRouter = t.router({
-  queryModel: publicProcedure
-    .input(z.object({ prompt: z.string() }))
-    .query(async ({ input: { prompt } }) => {
-      const { serviceDatabricksClient: client } = getExecutionContext();
-      const response = await client.servingEndpoints.query({
-        name: process.env.SERVING_ENDPOINT,
-        messages: [{ role: "user", content: prompt }],
-      });
-      return response;
-    }),
+Preserve existing plugins and add `serving()` to the array.
+
+**`server/.env`** — for local development:
+
+```dotenv
+DATABRICKS_SERVING_ENDPOINT_NAME=<your-endpoint-name>
+```
+
+Run `npm run sync` to update plugin metadata (also runs automatically during `npm run dev` and `npm run build`). Update smoke tests if headings or routes changed, then `databricks apps validate`.
+
+## Serving Plugin API
+
+Access model serving through the plugin handle returned by `createApp()`:
+
+```typescript
+import { createApp, server, serving } from "@databricks/appkit";
+
+const appkit = await createApp({
+  plugins: [server(), serving()],
+});
+
+// Non-streaming invocation
+const result = await appkit.serving().invoke({
+  messages: [{ role: "user", content: "Hello" }],
+});
+
+// Streaming invocation
+for await (const chunk of appkit.serving().stream({
+  messages: [{ role: "user", content: "Hello" }],
+})) {
+  console.log(chunk);
+}
+
+// On-behalf-of user (OBO) — uses the requesting user's identity
+const result = await appkit.serving().asUser(req).invoke({
+  messages: [{ role: "user", content: prompt }],
 });
 ```
 
-## Client-side Pattern
+All serving routes execute on behalf of the authenticated user (OBO) by default. For programmatic access via `exports()`, use `.asUser(req)` to run in user context.
+
+## Named Endpoints
+
+Use endpoint aliases to reference multiple serving endpoints by name:
 
 ```typescript
-// client/src/components/ChatComponent.tsx
-import { trpc } from "@/lib/trpc";
-
-const result = await trpc.queryModel.query({ prompt: userInput });
-const answer = result.choices?.[0]?.message?.content;
+serving({
+  endpoints: {
+    llm: { env: "DATABRICKS_SERVING_ENDPOINT_NAME" },
+    classifier: { env: "DATABRICKS_SERVING_ENDPOINT_CLASSIFIER" },
+  },
+  timeout: 120000, // optional, default 2 min
+})
 ```
 
-For AppKit's built-in serving plugin streaming (SSE via `stream()` and `useServingStream`), see `npx @databricks/appkit docs ./docs/plugins/model-serving.md`.
+Each alias maps to an environment variable holding the actual endpoint name. Access by alias:
+
+```typescript
+const result = await appkit.serving("llm").invoke({ messages });
+const classification = await appkit.serving("classifier").invoke({ inputs: ["text"] });
+```
+
+If an endpoint serves multiple models, use `servedModel` to target a specific model directly:
+
+```typescript
+serving({
+  endpoints: {
+    llm: { env: "DATABRICKS_SERVING_ENDPOINT_NAME", servedModel: "llama-v2" },
+  },
+})
+```
+
+## HTTP Endpoints
+
+The plugin auto-registers routes under `/api/serving`:
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/serving/invoke` | `POST` | Non-streaming (default mode) |
+| `/api/serving/stream` | `POST` | Streaming SSE (default mode) |
+| `/api/serving/:alias/invoke` | `POST` | Non-streaming (named mode) |
+| `/api/serving/:alias/stream` | `POST` | Streaming SSE (named mode) |
+
+## Frontend
+
+Use the built-in React hooks from `@databricks/appkit-ui/react` — do NOT call serving endpoints directly from the client.
+
+**Streaming** (chat, real-time inference):
+
+```tsx
+import { useServingStream } from "@databricks/appkit-ui/react";
+
+function ChatStream() {
+  const { stream, chunks, streaming, error, reset } = useServingStream(
+    { messages: [{ role: "user", content: "Hello" }] },
+    {
+      alias: "llm",
+      onComplete: (finalChunks) => console.log("Done:", finalChunks.length, "chunks"),
+    },
+  );
+
+  return (
+    <>
+      <button onClick={stream} disabled={streaming}>Send</button>
+      <button onClick={reset}>Reset</button>
+      {chunks.map((chunk, i) => <pre key={i}>{JSON.stringify(chunk)}</pre>)}
+      {error && <p>{error}</p>}
+    </>
+  );
+}
+```
+
+**Non-streaming** (one-shot inference, classification):
+
+```tsx
+import { useServingInvoke } from "@databricks/appkit-ui/react";
+
+function Classify() {
+  const { invoke, data, loading, error } = useServingInvoke(
+    { inputs: ["sample text"] },
+    { alias: "classifier" },
+  );
+
+  return (
+    <>
+      <button onClick={() => invoke()} disabled={loading}>Classify</button>
+      {data && <pre>{JSON.stringify(data)}</pre>}
+      {error && <p>{error}</p>}
+    </>
+  );
+}
+```
+
+Both hooks accept `autoStart: true` to invoke automatically on mount.
+
+For the full hook API and type generation details, see `npx @databricks/appkit docs ./docs/plugins/model-serving.md`.
 
 For off-platform streaming (AI SDK v6 with Databricks AI Gateway), see the **`databricks-model-serving`** skill.
+
+AppKit integrates with **Model Serving endpoints**. AI Gateway (beta) endpoints are not directly supported — use the underlying Model Serving endpoint name instead. AI Gateway features (rate limits, usage tracking) can be configured on Model Serving endpoints via the `databricks-model-serving` skill.
 
 ## Troubleshooting
 
 | Error | Cause | Solution |
 |-------|-------|---------|
 | `PERMISSION_DENIED` on query | SP missing CAN_QUERY | Declare `serving_endpoint` resource in `databricks.yml` with `permission: CAN_QUERY` |
-| `SERVING_ENDPOINT` env var empty | Missing env injection | Add `valueFrom: serving-endpoint` to `app.yaml` env section |
+| `DATABRICKS_SERVING_ENDPOINT_NAME` env var empty | Missing env injection | Add `valueFrom: serving-endpoint` to `app.yaml` env section |
 | 504 Gateway Timeout | Inference exceeds 120s proxy limit | Reduce `max_tokens` or use WebSockets — see [Platform Guide](../platform-guide.md) |
-| `getExecutionContext` undefined | Called outside AppKit server context | Ensure call is inside a tRPC procedure on the server side |
+| Unknown serving endpoint alias | Alias not configured or env var not set | Check `serving()` config in `server.ts` and `DATABRICKS_SERVING_ENDPOINT_*` in `app.yaml` / `.env` |

--- a/skills/databricks-apps/references/appkit/overview.md
+++ b/skills/databricks-apps/references/appkit/overview.md
@@ -12,7 +12,7 @@ Before scaffolding, decide which data pattern the app needs:
 | **Lakebase synced tables** (low-latency reads) | Point lookups, entity search, catalogs from lakehouse data | `--features lakebase` (no `--set` flags needed) + sync Delta table via `databricks-lakebase` skill |
 | **Lakebase (OLTP)** (read/write) | CRUD forms, persistent state, user data | `--features lakebase --set lakebase.postgres.branch=<BRANCH> --set lakebase.postgres.database=<DB>` |
 | **Genie** (NL queries) | Chat interface over Unity Catalog tables | `--features genie --set genie.<resourceKey>.<field>=<value>` (check manifest) |
-| **Model Serving** (ML inference) | Chat, AI features, model predictions | Add `serving_endpoint` resource to `databricks.yml` (or `--features serving` if available in manifest) |
+| **Model Serving** (ML inference) | Chat, AI features, model predictions | `--features serving --set serving.serving-endpoint.name=<NAME>` (check manifest) |
 | **Jobs** (trigger Lakeflow Jobs) | Kick off and monitor pre-existing notebooks / Python / SQL / dbt jobs | `--features jobs --set jobs.<resourceKey>.<field>=<JOB_ID>` (check manifest) |
 | **Multiple** | Combine plugins as needed (e.g. dashboard + CRUD, analytics + Genie) | `--features analytics,lakebase,genie,...` with all required `--set` flags per plugin |
 
@@ -128,7 +128,7 @@ Do not guess paths — run without args first, then pick from the index.
 | Add API mutation endpoints | [tRPC](trpc.md) — only if you need server-side logic |
 | Use Lakebase for CRUD / persistent state | [Lakebase](lakebase.md) — Lakebase plugin API, tRPC patterns, schema init |
 | Add Genie chat | [Genie](genie.md) — space creation, plugin setup, frontend components |
-| Call ML model serving endpoints | [Model Serving](model-serving.md) — resource declaration, tRPC query pattern |
+| Call ML model serving endpoints | [Model Serving](model-serving.md) — serving plugin, frontend hooks |
 | Trigger / monitor Lakeflow Jobs from the app | [Jobs](jobs.md) — env discovery, JobHandle API, SSE streaming |
 
 ## Critical Rules
@@ -145,5 +145,5 @@ Do not guess paths — run without args first, then pick from the index.
 - **Display data from SQL?**
   - Chart/Table → `BarChart`, `LineChart`, `DataTable` components
   - Custom layout (KPIs, cards) → `useAnalyticsQuery` hook
-- **Call Databricks API?** → tRPC (serving endpoints, MLflow, Jobs)
+- **Call Databricks API?** → Dedicated plugin (serving, jobs, files) or tRPC for other APIs
 - **Modify data?** → tRPC mutations

--- a/skills/databricks-apps/references/appkit/trpc.md
+++ b/skills/databricks-apps/references/appkit/trpc.md
@@ -7,7 +7,7 @@
 Use tRPC ONLY for:
 
 - **Mutations**: Creating, updating, or deleting data (INSERT, UPDATE, DELETE)
-- **External APIs**: Calling Databricks APIs (serving endpoints, jobs, MLflow, etc.)
+- **External APIs**: Calling Databricks APIs not covered by a dedicated plugin (MLflow, Workspace API, etc.)
 - **Complex business logic**: Multi-step operations that cannot be expressed in SQL
 - **File operations**: File uploads, processing, transformations
 - **Custom computations**: Operations requiring TypeScript/Node.js logic
@@ -46,6 +46,8 @@ databricks apps manifest --profile <PROFILE>
 - **lakebase** — provides Lakebase plugin for PostgreSQL CRUD (use plugin in tRPC routes, don't create raw connections)
 - **genie** — provides Genie AI-powered data exploration (check before building custom natural-language-to-SQL routes)
 - **files** — provides file storage and retrieval helpers (check before writing custom file upload/download routes)
+- **serving** — provides model serving endpoint proxy with invoke/stream (do NOT reimplement with tRPC)
+- **jobs** — provides Lakeflow Job triggering and monitoring (do NOT reimplement with tRPC)
 
 If a plugin already covers your use case, use the plugin's API instead of writing a custom tRPC route.
 
@@ -69,15 +71,12 @@ const t = initTRPC.create({ transformer: superjson });
 const publicProcedure = t.procedure;
 
 export const appRouter = t.router({
-  // Example: Query a serving endpoint
-  queryModel: publicProcedure
-    .input(z.object({ prompt: z.string() }))
-    .query(async ({ input: { prompt } }) => {
+  // Example: Call a Databricks API (e.g. MLflow)
+  getExperiment: publicProcedure
+    .input(z.object({ experimentId: z.string() }))
+    .query(async ({ input: { experimentId } }) => {
       const { serviceDatabricksClient: client } = getExecutionContext();
-      const response = await client.servingEndpoints.query({
-        name: "your-endpoint-name",
-        messages: [{ role: "user", content: prompt }],
-      });
+      const response = await client.experiments.getExperiment({ experiment_id: experimentId });
       return response;
     }),
 
@@ -102,8 +101,8 @@ function MyComponent() {
   const [result, setResult] = useState(null);
 
   useEffect(() => {
-    trpc.queryModel
-      .query({ prompt: "Hello" })
+    trpc.getExperiment
+      .query({ experimentId: "123" })
       .then(setResult)
       .catch(console.error);
   }, []);
@@ -123,11 +122,10 @@ function MyComponent() {
    - **Custom display (KPIs, cards, lists)?** → Use `useAnalyticsQuery` hook
    - **Never** use tRPC for SQL SELECT statements
 
-2. **Need to call a Databricks API?** → Use tRPC
-   - Serving endpoints (model inference)
-   - MLflow operations
-   - Jobs API
-   - Workspace API
+2. **Need to call a Databricks API?**
+   - Serving endpoints → use `serving()` plugin (see [Model Serving Guide](model-serving.md))
+   - Jobs → use `jobs()` plugin (see [Jobs Guide](jobs.md))
+   - MLflow, Workspace API, other APIs → use tRPC
 
 3. **Need to modify data?** → Use tRPC mutations
    - INSERT, UPDATE, DELETE operations
@@ -142,7 +140,7 @@ function MyComponent() {
 **Summary:**
 
 - ✅ SQL queries → Visualization components or `useAnalyticsQuery`
-- ✅ Databricks APIs → tRPC
+- ✅ Databricks APIs without a plugin → tRPC
 - ✅ Data mutations → tRPC
 - ❌ SQL queries → tRPC (NEVER do this)
 - ❌ Files operations → tRPC (NEVER do this)


### PR DESCRIPTION
## Summary

- **lakebase.md**: Replaced "do not add Lakebase manually" blocker with a full "Adding Lakebase to an Existing App" section (following the genie.md pattern) — covers `databricks.yml`, `app.yaml`, `server.ts`, and `.env` changes
- **model-serving.md**: Major rewrite — replaced outdated tRPC + `getExecutionContext()` pattern with the modern `serving()` plugin API, including "Adding to Existing App" section, `useServingStream`/`useServingInvoke` hooks, HTTP endpoints, and named endpoint aliases
- **SKILL.md**: Updated routing table to reference `serving()` plugin instead of tRPC
- **trpc.md**: Added serving/jobs to plugin checklist, replaced serving endpoint example with generic API example, updated decision tree to prefer plugins over tRPC
- **overview.md**: Updated Model Serving init command and decision tree references

All patterns verified against appkit source code (manifests, templates, plugin implementations, and official docs).

## Test plan

- [ ] Verify `python3 scripts/skills.py validate` passes
- [ ] Review lakebase.md "Adding to Existing App" section matches genie.md pattern
- [ ] Review model-serving.md matches appkit docs for serving plugin API
- [ ] Verify no stale `getExecutionContext` + `servingEndpoints.query` patterns remain in model-serving or SKILL.md contexts

This pull request and its description were written by Isaac.