### PR TITLE
chore(skills): unify Codex metadata + icons across stable and experimental

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,12 +37,14 @@ Then apply these patterns:
 - Pattern 2
 ```
 
+See [CONTRIBUTING.md](./CONTRIBUTING.md#skill-anatomy) for the full per-skill file layout, including the auto-generated Codex metadata (`agents/openai.yaml`) and shared icons (`assets/databricks.{svg,png}`) that every skill ships.
+
 ### Skills management
 
 ```bash
-python3 scripts/skills.py              # sync assets + generate manifest (default)
-python3 scripts/skills.py sync         # copy shared assets into each skill dir
-python3 scripts/skills.py validate     # check assets + manifest are up to date (CI)
+python3 scripts/skills.py              # sync Codex metadata + icons, then generate manifest (default)
+python3 scripts/skills.py sync         # sync Codex metadata + icons only
+python3 scripts/skills.py validate     # check Codex metadata + icons + manifest are up to date (CI)
 ```
 
 ## Security

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,57 @@
+## Skill anatomy
+
+Every skill — stable (`skills/<name>/`) or experimental (`experimental/<name>/`) — ships the same set of files:
+
+```
+<name>/
+├── SKILL.md                         # required: skill prose + frontmatter
+├── references/*.md                  # optional: supporting reference content
+├── agents/openai.yaml               # required: Codex marketplace metadata
+└── assets/
+    ├── databricks.svg               # required: icon (Codex marketplace)
+    └── databricks.png               # required: icon (Codex marketplace)
+```
+
+**`SKILL.md`** is what every coding agent (Claude Code, Cursor, Codex CLI, OpenCode, Copilot, Antigravity) reads. Frontmatter carries `name`, `description`, and optional `metadata.version` + `parent`.
+
+**`agents/openai.yaml`** is Codex CLI's plugin-marketplace metadata format: `display_name`, `short_description`, `icon_small`, `icon_large`, `brand_color`, `default_prompt`. It controls how the skill renders in Codex's in-app marketplace. Other agents ignore this file. The repo ships it for every skill so the manifest is a single feed for all agents.
+
+**`assets/databricks.{svg,png}`** are the icons referenced by `agents/openai.yaml`'s `icon_small` / `icon_large`. Identical across all skills (the Databricks logo); `scripts/skills.py` copies them in from the repo-root `/assets/`.
+
+### Adding or updating a skill
+
+`scripts/skills.py generate` (and `sync`) auto-synthesise both `agents/openai.yaml` and the icons for any skill that's missing them. Hand-authored `agents/openai.yaml` is preserved as-is, so you can curate the display name / short description / default prompt before running `generate` — the synthesiser only writes when the file is absent.
+
+If the synthesised display name comes out wrong (e.g. acronyms or product names that get mis-cased by hyphen-titlecasing), add an entry to `DISPLAY_NAME_OVERRIDES` in `scripts/skills.py` rather than hand-authoring the whole `openai.yaml`.
+
+**Workflow for a new skill**:
+
+```bash
+# 1. Create the skill directory + SKILL.md (and references/ if needed).
+mkdir -p skills/databricks-foo/references
+$EDITOR skills/databricks-foo/SKILL.md      # write SKILL.md with frontmatter
+
+# 2. For stable skills only: add a description to scripts/skills.py SKILL_METADATA.
+
+# 3. Generate Codex metadata + icons + manifest in one shot.
+python3 scripts/skills.py generate
+
+# 4. Confirm validate passes (this is what CI runs).
+python3 scripts/skills.py validate
+```
+
+`generate` is idempotent — re-running it never overwrites your `SKILL.md`, `references/`, or hand-edited `agents/openai.yaml`; it only fills in what's missing.
+
+### CI
+
+`.github/workflows/validate-manifest.yml` runs `python3 scripts/skills.py validate` on every PR that touches `skills/**`, `experimental/**`, `assets/**`, `scripts/skills.py`, or `manifest.json`. Validation enforces:
+
+- Every skill has `agents/openai.yaml`.
+- Every skill ships `assets/databricks.svg` + `assets/databricks.png` byte-identical to the repo-root source.
+- `manifest.json` matches what `scripts/skills.py generate` would produce.
+
+If validation fails the error tells you which file is missing or stale; the fix is always `python3 scripts/skills.py generate` and committing the result.
+
 ## Security
 
 Please see [SECURITY](./SECURITY) for vulnerability reporting guidelines.

--- a/scripts/skills.py
+++ b/scripts/skills.py
@@ -348,10 +348,6 @@ def _build_stable_entry(skill_dir: Path, existing_skills: dict) -> tuple[str, di
             "Add it to SKILL_METADATA dict."
         )
 
-    # Codex metadata + assets are enforced uniformly by check_codex_metadata
-    # (which runs in validate). generate auto-synthesizes any missing ones
-    # via ensure_codex_metadata before this point.
-
     metadata = SKILL_METADATA[skill_dir.name]
     files = sorted(str(f.relative_to(skill_dir)) for f in iter_skill_files(skill_dir))
 

--- a/scripts/skills.py
+++ b/scripts/skills.py
@@ -119,56 +119,10 @@ def iter_skill_files(skill_path: Path):
 # Sync
 # ---------------------------------------------------------------------------
 
-def sync_assets(repo_root: Path) -> int:
-    """Copy shared assets from repo root into each skill directory.
-
-    Only writes when content differs. Uses shutil.copy2 to preserve mtime
-    from the source.
-
-    Returns count of files written.
-    """
-    for asset_rel in SHARED_ASSETS:
-        source = repo_root / asset_rel
-        if not source.exists():
-            raise ValueError(f"Missing shared asset '{asset_rel}' at repo root.")
-
-    synced = 0
-    for skill_dir in iter_skill_dirs(repo_root):
-        for asset_rel in SHARED_ASSETS:
-            source = repo_root / asset_rel
-            dest = skill_dir / asset_rel
-            dest.parent.mkdir(parents=True, exist_ok=True)
-
-            if dest.exists() and dest.read_bytes() == source.read_bytes():
-                continue
-
-            shutil.copy2(source, dest)
-            synced += 1
-
-    return synced
-
-
-def check_assets_synced(repo_root: Path) -> list[str]:
-    """Validate that all shared assets are present and up-to-date.
-
-    Returns a list of error messages (empty means all good).
-    """
-    errors: list[str] = []
-    for asset_rel in SHARED_ASSETS:
-        source = repo_root / asset_rel
-        if not source.exists():
-            errors.append(f"Missing shared asset '{asset_rel}' at repo root.")
-            continue
-
-        source_bytes = source.read_bytes()
-        for skill_dir in iter_skill_dirs(repo_root):
-            dest = skill_dir / asset_rel
-            if not dest.exists():
-                errors.append(f"Missing '{asset_rel}' in skill '{skill_dir.name}'.")
-            elif dest.read_bytes() != source_bytes:
-                errors.append(f"Stale '{asset_rel}' in skill '{skill_dir.name}'.")
-
-    return errors
+def iter_all_skill_dirs(repo_root: Path):
+    """Yield every skill directory across stable and experimental."""
+    yield from iter_skill_dirs(repo_root, parent=STABLE_REPO_DIR)
+    yield from iter_skill_dirs(repo_root, parent=EXPERIMENTAL_REPO_DIR)
 
 
 # ---------------------------------------------------------------------------
@@ -261,19 +215,40 @@ def synthesize_openai_yaml(skill_name: str, short_description: str) -> str:
     )
 
 
-def ensure_experimental_codex_metadata(repo_root: Path) -> int:
-    """Synthesize agents/openai.yaml and copy shared assets for experimental skills.
+def ensure_codex_metadata(repo_root: Path) -> int:
+    """Ensure every skill has agents/openai.yaml + shared assets.
 
-    Only writes when files are missing — upstream ai-dev-kit can override by
-    shipping its own agents/openai.yaml or assets/ in the skill. Returns the
-    number of files written.
+    Applies uniformly to stable (`skills/`) and experimental (`experimental/`)
+    skills:
+
+    - **assets**: copies `assets/databricks.{svg,png}` from the repo root into
+      each skill's `assets/` directory. Overwrites stale copies (content mismatch
+      against the source) so the bundled icons never drift; preserves source
+      mtime via `shutil.copy2` so skill `updated_at` timestamps stay stable.
+    - **agents/openai.yaml**: synthesises a Codex marketplace metadata file
+      from the SKILL.md frontmatter when one is missing. Hand-authored
+      `openai.yaml` is preserved as-is, so skill authors can curate the
+      display name / short description / default prompt without their work
+      being overwritten on every `generate`.
+
+    Returns the number of files written (assets and openai.yaml combined).
+
+    This is the single source of truth for the "every skill ships icons +
+    Codex metadata" contract. `check_codex_metadata` is its validation
+    counterpart.
     """
     written = 0
-    for skill_dir in iter_experimental_skill_dirs(repo_root):
+    # Source-of-truth assets at the repo root must exist before we copy
+    # anything; surface that as a clean error instead of a per-skill failure.
+    for asset_rel in SHARED_ASSETS:
+        if not (repo_root / asset_rel).exists():
+            raise ValueError(f"Missing shared asset '{asset_rel}' at repo root.")
+
+    for skill_dir in iter_all_skill_dirs(repo_root):
         for asset_rel in SHARED_ASSETS:
             source = repo_root / asset_rel
             dest = skill_dir / asset_rel
-            if dest.exists():
+            if dest.exists() and dest.read_bytes() == source.read_bytes():
                 continue
             dest.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(source, dest)
@@ -288,6 +263,43 @@ def ensure_experimental_codex_metadata(repo_root: Path) -> int:
         )
         written += 1
     return written
+
+
+def check_codex_metadata(repo_root: Path) -> list[str]:
+    """Validate every skill has shared assets + agents/openai.yaml.
+
+    Mirror of `ensure_codex_metadata`: each skill must ship the icons
+    `assets/databricks.{svg,png}` (byte-identical to the repo-root source)
+    and an `agents/openai.yaml` marketplace metadata file. Applies to both
+    stable and experimental skills.
+
+    Returns a list of error messages; empty list means everything is in
+    order. The CI workflow `validate-manifest.yml` runs this on every PR
+    that touches `skills/`, `experimental/`, `assets/`, `scripts/skills.py`,
+    or `manifest.json`.
+    """
+    errors: list[str] = []
+    for asset_rel in SHARED_ASSETS:
+        if not (repo_root / asset_rel).exists():
+            errors.append(f"Missing shared asset '{asset_rel}' at repo root.")
+    if errors:
+        return errors
+
+    for skill_dir in iter_all_skill_dirs(repo_root):
+        for asset_rel in SHARED_ASSETS:
+            source = repo_root / asset_rel
+            dest = skill_dir / asset_rel
+            if not dest.exists():
+                errors.append(f"Missing '{asset_rel}' in skill '{skill_dir.name}'.")
+            elif dest.read_bytes() != source.read_bytes():
+                errors.append(f"Stale '{asset_rel}' in skill '{skill_dir.name}'.")
+
+        if not (skill_dir / "agents" / "openai.yaml").exists():
+            errors.append(
+                f"Missing 'agents/openai.yaml' in skill '{skill_dir.name}'."
+            )
+
+    return errors
 
 
 def generate_manifest(repo_root: Path) -> dict:
@@ -336,12 +348,9 @@ def _build_stable_entry(skill_dir: Path, existing_skills: dict) -> tuple[str, di
             "Add it to SKILL_METADATA dict."
         )
 
-    openai_yaml = skill_dir / "agents" / "openai.yaml"
-    if not openai_yaml.exists():
-        raise ValueError(
-            f"Missing agents/openai.yaml in skill '{skill_dir.name}'. "
-            "Each skill must include Codex marketplace metadata."
-        )
+    # Codex metadata + assets are enforced uniformly by check_codex_metadata
+    # (which runs in validate). generate auto-synthesizes any missing ones
+    # via ensure_codex_metadata before this point.
 
     metadata = SKILL_METADATA[skill_dir.name]
     files = sorted(str(f.relative_to(skill_dir)) for f in iter_skill_files(skill_dir))
@@ -442,9 +451,9 @@ def main() -> None:
         default="generate",
         choices=["sync", "generate", "validate"],
         help=(
-            "sync: copy shared assets into each skill directory. "
-            "generate: sync + create manifest.json (default). "
-            "validate: check assets and manifest are up to date."
+            "sync: ensure every skill has assets + agents/openai.yaml. "
+            "generate: sync + (re)build manifest.json (default). "
+            "validate: check assets, metadata, and manifest are up to date."
         ),
     )
 
@@ -453,16 +462,12 @@ def main() -> None:
 
     match args.mode:
         case "sync":
-            synced = sync_assets(repo_root)
-            print(f"Synced {synced} asset(s)")
-            generated = ensure_experimental_codex_metadata(repo_root)
-            print(f"Generated {generated} experimental Codex metadata file(s)")
+            written = ensure_codex_metadata(repo_root)
+            print(f"Wrote {written} Codex-metadata file(s)")
 
         case "generate":
-            synced = sync_assets(repo_root)
-            print(f"Synced {synced} asset(s)")
-            generated = ensure_experimental_codex_metadata(repo_root)
-            print(f"Generated {generated} experimental Codex metadata file(s)")
+            written = ensure_codex_metadata(repo_root)
+            print(f"Wrote {written} Codex-metadata file(s)")
 
             manifest = generate_manifest(repo_root)
             manifest_path = repo_root / "manifest.json"
@@ -476,10 +481,13 @@ def main() -> None:
         case "validate":
             ok = True
 
-            asset_errors = check_assets_synced(repo_root)
-            if asset_errors:
-                print("ERROR: Shared assets are out of sync:", file=sys.stderr)
-                for err in asset_errors:
+            metadata_errors = check_codex_metadata(repo_root)
+            if metadata_errors:
+                print(
+                    "ERROR: Skill assets / Codex metadata are out of sync:",
+                    file=sys.stderr,
+                )
+                for err in metadata_errors:
                     print(f"  - {err}", file=sys.stderr)
                 ok = False
 


### PR DESCRIPTION
## Summary

Stable and experimental skills had two different contracts for Codex CLI marketplace metadata (`agents/openai.yaml` + `assets/databricks.{svg,png}`):

| | stable (`skills/`) | experimental (`experimental/`) |
|---|---|---|
| `agents/openai.yaml` | hand-authored, required | auto-synthesised from `SKILL.md` frontmatter |
| `assets/databricks.{svg,png}` | manual copy needed | `sync_assets()` copied them in |
| CI enforcement | partial (only via `_build_stable_entry`) | full (`check_assets_synced` + `ensure_experimental_codex_metadata`) |

So adding a stable skill needed manual icon copies + a hand-authored YAML; adding an experimental one was `python3 scripts/skills.py generate`. Stable also had no CI check that the icons were actually present.

This PR makes the contract uniform: every skill gets icons + `agents/openai.yaml` auto-generated when missing, hand-authored YAML is preserved as an override, and one CI cycle (`python3 scripts/skills.py validate`) enforces it for both directories.

- `iter_all_skill_dirs(repo_root)` walks every skill across `skills/` and `experimental/`.
- `ensure_codex_metadata(repo_root)` replaces `sync_assets()` and `ensure_experimental_codex_metadata()`. Copies shared icons if missing/stale; synthesises `agents/openai.yaml` only when absent (so curated YAML like `databricks-core`'s `display_name: \"Databricks\"` survives).
- `check_codex_metadata(repo_root)` mirrors the same checks for `validate`. The redundant per-skill openai.yaml existence check in `_build_stable_entry` is gone.
- `main()` `sync` + `generate` call `ensure_codex_metadata`; `validate` calls `check_codex_metadata` then `validate_manifest`.
- `.github/workflows/validate-manifest.yml` already covered both `skills/**` and `experimental/**`; no workflow change needed — one CI cycle covers both.
- `CONTRIBUTING.md` gets a new \"Skill anatomy\" section explaining what these files are, who consumes them (Codex CLI marketplace), why the repo ships them for every skill, the auto-generation + hand-authoring escape hatch, and `DISPLAY_NAME_OVERRIDES` for acronym/product-name casing. `CLAUDE.md` links to it.

## Why

PR #73 (experimental import) added the auto-gen path for experimental skills only. Reviewers' question on that PR — \"what are these files, why do we ship them, how do new skills get them?\" — pointed at the asymmetry. This is the follow-up.

## Test plan

- [x] `python3 scripts/skills.py generate` on clean tree → no diff (no-op).
- [x] `python3 scripts/skills.py sync` on clean tree → no diff.
- [x] Removed `skills/databricks-core/{agents/openai.yaml,assets/databricks.png}` + `experimental/databricks-ai-functions/agents/openai.yaml` → `validate` exits 1 listing all three missing files; `generate` heals all three; hand-authored stable YAML preserved when restored from backup before re-running `generate`.
- [x] No stale references to the removed helpers (`sync_assets`, `check_assets_synced`, `ensure_experimental_codex_metadata`) anywhere in the repo.

This pull request and its description were written by Claude.