### PR TITLE
plugin: add marketplace.json + document CLI vs plugin install paths

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "databricks-skills",
+  "owner": {
+    "name": "Databricks"
+  },
+  "metadata": {
+    "description": "Official Databricks agent skills marketplace",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "databricks-skills",
+      "source": "./",
+      "description": "Databricks skills for CLI, Apps, Unity Catalog, Model Serving, Declarative Automation Bundles (DABs), and more. Stable skills only — for experimental skills use `databricks aitools install --experimental`.",
+      "version": "0.1.0"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -4,11 +4,17 @@ Skills for AI coding assistants (Claude Code, Cursor, etc.) that provide Databri
 
 ## Installation
 
+There are two equivalent install paths for the **stable** skills. Pick whichever
+fits your workflow — both write skills into the per-agent directory the CLI/plugin
+detects (`~/.claude/skills/`, `~/.cursor/extensions/<...>`, etc.).
+
+**Via the Databricks CLI (canonical; supports experimental skills):**
+
 ```bash
 databricks aitools install
 ```
 
-This auto-detects your coding agent(s) and installs the stable skills to the
+The CLI auto-detects your coding agent(s) and installs the stable skills to the
 right location:
 
 - **Claude Code** → `~/.claude/skills/`
@@ -19,11 +25,32 @@ For finer control, use the `aitools skills install` subcommand directly — it
 accepts a positional skill name and an `--experimental` flag (see the
 [Experimental Skills](#experimental-skills) section).
 
-**For Cursor (plugin marketplace alternative):**
+**Via the Claude Code plugin marketplace** (stable skills only — installs every
+skill under [`./skills/`](./skills/)):
+
+```text
+/plugin marketplace add databricks/databricks-agent-skills
+/plugin install databricks-skills
+```
+
+**Via the Cursor plugin marketplace:**
 
 ```text
 /add-plugin databricks-skills
 ```
+
+### CLI vs plugin marketplace
+
+| | CLI | Plugin marketplace |
+|---|---|---|
+| Stable skills | ✅ (default) | ✅ |
+| Experimental skills | ✅ (with `--experimental` or by name) | ❌ |
+| Per-skill selection | ✅ (`databricks aitools install <name>`) | ❌ (all-or-nothing) |
+| Updates | `databricks aitools update` | Plugin marketplace update flow |
+| Required outside the agent | Databricks CLI v1.0.0+ | None |
+
+If in doubt, use the CLI — it's the canonical install path and the only one that
+exposes experimental skills.
 
 ## Available Skills
 


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/marketplace.json` so users can install the d-a-s skills plugin directly from inside Claude Code:

      /plugin marketplace add databricks/databricks-agent-skills
      /plugin install databricks-skills

  Without this file the existing `.claude-plugin/plugin.json` is reachable only after cloning the repo.

- `README.md`: documents both install paths (CLI canonical, plugin marketplace alternative for stable skills) and adds a short comparison table covering experimental skills, per-skill selection, and outside-agent prerequisites.

## Background

`databricks-solutions/ai-dev-kit` is in the process of being retired as a skills-distribution mechanism (see a-d-k PRs [#546](https://github.com/databricks-solutions/ai-dev-kit/pull/546), [#547](https://github.com/databricks-solutions/ai-dev-kit/pull/547), [#548](https://github.com/databricks-solutions/ai-dev-kit/pull/548) and the team's `DECOMMISSION_PLAN.md` on the experimental branch). Users will be redirected here for skills.

The migration banner that a-d-k will start showing pre-1.0.0 users tells them to run `/plugin marketplace add databricks/databricks-agent-skills`. Without this PR landing, that command fails to resolve.

The plugin marketplace path is intentionally scoped to stable skills (matches the existing `"skills": "./skills/"` in `plugin.json`). Experimental skills stay CLI-only — the README's comparison table calls that out so users know which knob to reach for.

## Test plan

- [x] `cat .claude-plugin/marketplace.json | python3 -m json.tool` — valid JSON.
- [ ] From a clean Claude Code session: `/plugin marketplace add databricks/databricks-agent-skills` resolves, then `/plugin install databricks-skills` lists the plugin and installs it; `~/.claude/skills/databricks-core/` appears.
- [ ] README renders cleanly on GitHub; the comparison table is legible.

This PR was AI-assisted by Isaac.
