### PR TITLE
plugin: add marketplace.json + document CLI vs plugin install paths

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "databricks-skills",
+  "owner": {
+    "name": "Databricks"
+  },
+  "metadata": {
+    "description": "Official Databricks agent skills marketplace",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "databricks-skills",
+      "source": "./",
+      "description": "Databricks skills for CLI, Apps, Unity Catalog, Model Serving, Declarative Automation Bundles (DABs), and more. Stable skills only — for experimental skills use `databricks aitools install --experimental`.",
+      "version": "0.1.0"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,11 +1,9 @@
 {
   "name": "databricks-skills",
+  "description": "Official Databricks agent skills marketplace",
+  "version": "0.1.0",
   "owner": {
     "name": "Databricks"
-  },
-  "metadata": {
-    "description": "Official Databricks agent skills marketplace",
-    "version": "0.1.0"
   },
   "plugins": [
     {

--- a/README.md
+++ b/README.md
@@ -4,9 +4,14 @@ Skills for AI coding assistants (Claude Code, Cursor, etc.) that provide Databri
 
 ## Installation
 
-There are two equivalent install paths for the **stable** skills. Pick whichever
-fits your workflow — both write skills into the per-agent directory the CLI/plugin
-detects (`~/.claude/skills/`, `~/.cursor/extensions/<...>`, etc.).
+Two install paths cover the **stable** skills. They install to different places
+but end up loaded by the same agents — pick whichever fits your workflow.
+
+- **Databricks CLI** writes SKILL.md files directly into each agent's skill
+  directory (`~/.claude/skills/`, `~/.cursor/extensions/<...>`, etc.).
+- **Plugin marketplaces** (Claude Code, Cursor) cache the plugin under the
+  agent's plugin directory (e.g. `~/.claude/plugins/cache/databricks-skills/`);
+  the agent discovers skills from there.
 
 **Via the Databricks CLI (canonical; supports experimental skills):**
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,17 @@ Skills for AI coding assistants (Claude Code, Cursor, etc.) that provide Databri
 
 ## Installation
 
+There are two equivalent install paths for the **stable** skills. Pick whichever
+fits your workflow — both write skills into the per-agent directory the CLI/plugin
+detects (`~/.claude/skills/`, `~/.cursor/extensions/<...>`, etc.).
+
+**Via the Databricks CLI (canonical; supports experimental skills):**
+
 ```bash
 databricks aitools install
 ```
 
-This auto-detects your coding agent(s) and installs the stable skills to the
+The CLI auto-detects your coding agent(s) and installs the stable skills to the
 right location:
 
 - **Claude Code** → `~/.claude/skills/`
@@ -19,11 +25,32 @@ For finer control, use the `aitools skills install` subcommand directly — it
 accepts a positional skill name and an `--experimental` flag (see the
 [Experimental Skills](#experimental-skills) section).
 
-**For Cursor (plugin marketplace alternative):**
+**Via the Claude Code plugin marketplace** (stable skills only — installs every
+skill under [`./skills/`](./skills/)):
+
+```text
+/plugin marketplace add databricks/databricks-agent-skills
+/plugin install databricks-skills
+```
+
+**Via the Cursor plugin marketplace:**
 
 ```text
 /add-plugin databricks-skills
 ```
+
+### CLI vs plugin marketplace
+
+| | CLI | Plugin marketplace |
+|---|---|---|
+| Stable skills | ✅ (default) | ✅ |
+| Experimental skills | ✅ (with `--experimental` or by name) | ❌ |
+| Per-skill selection | ✅ (`databricks aitools install <name>`) | ❌ (all-or-nothing) |
+| Updates | `databricks aitools update` | Plugin marketplace update flow |
+| Required outside the agent | Databricks CLI v1.0.0+ | None |
+
+If in doubt, use the CLI — it's the canonical install path and the only one that
+exposes experimental skills.
 
 ## Available Skills
 


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/marketplace.json` so users can install the d-a-s skills plugin directly from inside Claude Code:

      /plugin marketplace add databricks/databricks-agent-skills
      /plugin install databricks-skills

  Without this file the existing `.claude-plugin/plugin.json` is reachable only after cloning the repo.

- `README.md`: documents both install paths (CLI canonical, plugin marketplace alternative for stable skills) and adds a short comparison table covering experimental skills, per-skill selection, and outside-agent prerequisites. The two paths install to *different* locations (CLI writes into `~/.claude/skills/`; plugin caches under `~/.claude/plugins/cache/<marketplace>/<plugin>/`) — the README now spells that out instead of pretending they share a target.

## Background

`databricks-solutions/ai-dev-kit` is in the process of being retired as a skills-distribution mechanism (see a-d-k PRs [#546](https://github.com/databricks-solutions/ai-dev-kit/pull/546), [#547](https://github.com/databricks-solutions/ai-dev-kit/pull/547), [#548](https://github.com/databricks-solutions/ai-dev-kit/pull/548) and the team's `DECOMMISSION_PLAN.md` on the experimental branch). Users will be redirected here for skills.

The migration banner that a-d-k will start showing pre-1.0.0 users tells them to run `/plugin marketplace add databricks/databricks-agent-skills`. Without this PR landing, that command fails to resolve.

The plugin marketplace path is intentionally scoped to stable skills (matches the existing `"skills": "./skills/"` in `plugin.json`). Experimental skills stay CLI-only — the README's comparison table calls that out so users know which knob to reach for.

This supersedes #92 (which was opened from a personal fork).

## Test plan

- [x] `python3 -m json.tool .claude-plugin/marketplace.json` — valid JSON.
- [x] `claude plugin validate --strict .` on the branch — marketplace manifest passes strict validation.
- [x] From a clean Claude Code session, `claude plugin marketplace add <path>` + `claude plugin install databricks-skills` succeeds; `claude plugin details databricks-skills` registers exactly the 8 stable skills (`databricks-apps`, `-core`, `-dabs`, `-jobs`, `-lakebase`, `-model-serving`, `-pipelines`, `-serverless-migration`); experimental skills correctly excluded from the registered set even though they're present in the plugin cache.
- [x] Plugin files land at `~/.claude/plugins/cache/databricks-skills/databricks-skills/0.1.0/skills/<skill>/SKILL.md` (the plugin path; not `~/.claude/skills/`, which is the CLI path).
- [ ] README renders cleanly on GitHub; the comparison table is legible.

This PR was AI-assisted by Isaac.