### PR TITLE
scripts(skills): drop dead base_revision plumbing, enforce canonical sorted manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,19 +95,21 @@ This approach:
 
 ### Manifest Management
 
-Sync assets and generate manifest after adding/updating skills:
+`manifest.json` is **generated** by `scripts/skills.py` from the skill directories and frontmatter. Do not edit it by hand. CI rejects manual changes via two checks: content drift (parsed dict doesn't match what `generate` would produce) and canonical form (on-disk bytes don't match `json.dumps(..., indent=2, sort_keys=True)`).
+
+Sync assets and regenerate the manifest after adding or updating skills:
 
 ```bash
 python3 scripts/skills.py
 ```
 
-Validate that assets and manifest are up to date (for CI):
+Validate that assets and manifest are up to date (used by CI):
 
 ```bash
 python3 scripts/skills.py validate
 ```
 
-The manifest is used by the CLI to discover available skills.
+The manifest is consumed by the CLI to discover available skills.
 
 ## Security
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,4 +1,5 @@
 {
+  "//": "GENERATED FILE: DO NOT EDIT. Run `python3 scripts/skills.py generate` to regenerate.",
   "skills": {
     "databricks-agent-bricks": {
       "description": "Create Agent Bricks: Knowledge Assistants (KA) for document Q&A and Supervisor Agents for multi-agent orchestration (MAS).",

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,51 @@
 {
-  "version": "2",
   "skills": {
+    "databricks-agent-bricks": {
+      "description": "Create Agent Bricks: Knowledge Assistants (KA) for document Q&A and Supervisor Agents for multi-agent orchestration (MAS).",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/1-knowledge-assistants.md",
+        "references/2-supervisor-agents.md"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
+    },
+    "databricks-ai-functions": {
+      "description": "Use Databricks built-in AI Functions (ai_classify, ai_extract, ai_summarize, ai_mask, ai_translate, ai_fix_grammar, ai_gen, ai_analyze_sentiment, ai_similarity, ai_parse_document, ai_query, ai_forecast) to add AI capabilities directly to SQL and PySpark pipelines without managing model endpoints. Also covers document parsing and building custom RAG pipelines (parse \u2192 chunk \u2192 index \u2192 query).",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/1-task-functions.md",
+        "references/2-ai-query.md",
+        "references/3-ai-forecast.md",
+        "references/4-document-processing-pipeline.md"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
+    },
+    "databricks-aibi-dashboards": {
+      "description": "Create Databricks AI/BI dashboards. Must use when creating, updating, or deploying Lakeview dashboards as Databricks Dashboard have a unique json structure. CRITICAL: You MUST test ALL SQL queries via CLI BEFORE deploying. Follow guidelines strictly.",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/1-widget-specifications.md",
+        "references/2-advanced-widget-specifications.md",
+        "references/3-filters.md",
+        "references/4-examples.md",
+        "references/5-troubleshooting.md"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
+    },
     "databricks-apps": {
-      "version": "0.1.2",
       "description": "Databricks Apps development and deployment (evaluates analytics vs synced tables data access)",
-      "repo_dir": "skills",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -25,12 +66,33 @@
         "references/other-frameworks.md",
         "references/platform-guide.md",
         "references/testing.md"
-      ]
+      ],
+      "repo_dir": "skills",
+      "version": "0.1.2"
+    },
+    "databricks-apps-python": {
+      "description": "Builds Databricks applications. Prefers AppKit (TypeScript + React SDK) for new apps; falls back to Python frameworks (Dash, Streamlit, Gradio, Flask, FastAPI, Reflex) when Python is required. Handles OAuth authorization, app resources, SQL warehouse and Lakebase connectivity, model serving, foundation model APIs, and deployment. Use when building web apps, dashboards, ML demos, or REST APIs for Databricks, or when the user mentions AppKit, Streamlit, Dash, Gradio, Flask, FastAPI, Reflex, or Databricks app.",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "examples/fm-minimal-chat.py",
+        "examples/fm-parallel-calls.py",
+        "examples/fm-structured-outputs.py",
+        "examples/llm_config.py",
+        "references/1-authorization.md",
+        "references/2-app-resources.md",
+        "references/3-frameworks.md",
+        "references/4-deployment.md",
+        "references/5-lakebase.md",
+        "references/6-cli-approach.md"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
     },
     "databricks-core": {
-      "version": "0.1.0",
       "description": "Core Databricks skill for CLI, auth, and data exploration",
-      "repo_dir": "skills",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -39,12 +101,12 @@
         "data-exploration.md",
         "databricks-cli-auth.md",
         "databricks-cli-install.md"
-      ]
+      ],
+      "repo_dir": "skills",
+      "version": "0.1.0"
     },
     "databricks-dabs": {
-      "version": "0.0.1",
       "description": "Declarative Automation Bundles (DABs) for deploying and managing Databricks resources",
-      "repo_dir": "skills",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -55,12 +117,70 @@
         "references/deploy-and-run.md",
         "references/resource-permissions.md",
         "references/sdp-pipelines.md"
-      ]
+      ],
+      "repo_dir": "skills",
+      "version": "0.0.1"
+    },
+    "databricks-dbsql": {
+      "description": "Databricks SQL (DBSQL) advanced features and SQL warehouse capabilities. This skill MUST be invoked when the user mentions: \"DBSQL\", \"Databricks SQL\", \"SQL warehouse\", \"SQL scripting\", \"stored procedure\", \"CALL procedure\", \"materialized view\", \"CREATE MATERIALIZED VIEW\", \"pipe syntax\", \"|>\", \"geospatial\", \"H3\", \"ST_\", \"spatial SQL\", \"collation\", \"COLLATE\", \"ai_query\", \"ai_classify\", \"ai_extract\", \"ai_gen\", \"AI function\", \"http_request\", \"remote_query\", \"read_files\", \"Lakehouse Federation\", \"recursive CTE\", \"WITH RECURSIVE\", \"multi-statement transaction\", \"temp table\", \"temporary view\", \"pipe operator\". SHOULD also invoke when the user asks about SQL best practices, data modeling patterns, or advanced SQL features on Databricks.",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/ai-functions.md",
+        "references/best-practices.md",
+        "references/geospatial-collations.md",
+        "references/materialized-views-pipes.md",
+        "references/sql-scripting.md"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
+    },
+    "databricks-docs": {
+      "description": "Databricks documentation reference via llms.txt index. Use when other skills do not cover a topic, looking up unfamiliar Databricks features, or needing authoritative docs on APIs, configurations, or platform capabilities.",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
+    },
+    "databricks-execution-compute": {
+      "description": "Execute code and manage compute on Databricks. Use this skill when the user mentions: \"run code\", \"execute\", \"run on databricks\", \"serverless\", \"no cluster\", \"run python\", \"run scala\", \"run sql\", \"run R\", \"run file\", \"push and run\", \"notebook run\", \"batch script\", \"model training\", \"run script on cluster\", \"create cluster\", \"new cluster\", \"resize cluster\", \"modify cluster\", \"delete cluster\", \"terminate cluster\", \"create warehouse\", \"new warehouse\", \"resize warehouse\", \"delete warehouse\", \"node types\", \"runtime versions\", \"DBR versions\", \"spin up compute\", \"provision cluster\".",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/1-databricks-connect.md",
+        "references/2-serverless-job.md",
+        "references/3-interactive-cluster.md",
+        "scripts/compute.py"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
+    },
+    "databricks-iceberg": {
+      "description": "Apache Iceberg tables on Databricks \u2014 Managed Iceberg tables, External Iceberg Reads (fka Uniform), Compatibility Mode, Iceberg REST Catalog (IRC), Iceberg v3, Snowflake interop, PyIceberg, OSS Spark, external engine access and credential vending. Use when creating Iceberg tables, enabling External Iceberg Reads (uniform) on Delta tables (including Streaming Tables and Materialized Views via compatibility mode), configuring external engines to read Databricks tables via Unity Catalog IRC, integrating with Snowflake catalog to read Foreign Iceberg tables",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/1-managed-iceberg-tables.md",
+        "references/2-uniform-and-compatibility.md",
+        "references/3-iceberg-rest-catalog.md",
+        "references/4-snowflake-interop.md",
+        "references/5-external-engine-interop.md"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
     },
     "databricks-jobs": {
-      "version": "0.2.0",
       "description": "Develop and deploy Lakeflow Jobs on Databricks via DABs, Python SDK, or the CLI \u2014 covers all task types, triggers, notifications, and worked examples",
-      "repo_dir": "skills",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -70,12 +190,12 @@
         "references/notifications-monitoring.md",
         "references/task-types.md",
         "references/triggers-schedules.md"
-      ]
+      ],
+      "repo_dir": "skills",
+      "version": "0.2.0"
     },
     "databricks-lakebase": {
-      "version": "0.1.0",
       "description": "Databricks Lakebase Postgres: projects, scaling, connectivity, synced tables, and Data API",
-      "repo_dir": "skills",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -88,24 +208,59 @@
         "references/off-platform.md",
         "references/pgvector.md",
         "references/synced-tables.md"
-      ]
+      ],
+      "repo_dir": "skills",
+      "version": "0.1.0"
+    },
+    "databricks-metric-views": {
+      "description": "Unity Catalog metric views: define, create, query, and manage governed business metrics in YAML. Use when building standardized KPIs, revenue metrics, order analytics, or any reusable business metrics that need consistent definitions across teams and tools.",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/patterns.md",
+        "references/yaml-reference.md"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
+    },
+    "databricks-mlflow-evaluation": {
+      "description": "MLflow 3 GenAI agent evaluation. Use when writing mlflow.genai.evaluate() code, creating @scorer functions, using built-in scorers (Guidelines, Correctness, Safety, RetrievalGroundedness), building eval datasets from traces, setting up trace ingestion and production monitoring, aligning judges with MemAlign from domain expert feedback, or running optimize_prompts() with GEPA for automated prompt improvement.",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/CRITICAL-interfaces.md",
+        "references/GOTCHAS.md",
+        "references/patterns-context-optimization.md",
+        "references/patterns-datasets.md",
+        "references/patterns-evaluation.md",
+        "references/patterns-judge-alignment.md",
+        "references/patterns-prompt-optimization.md",
+        "references/patterns-scorers.md",
+        "references/patterns-trace-analysis.md",
+        "references/patterns-trace-ingestion.md",
+        "references/user-journeys.md"
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
     },
     "databricks-model-serving": {
-      "version": "0.1.0",
       "description": "Databricks Model Serving endpoint management",
-      "repo_dir": "skills",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
         "assets/databricks.png",
         "assets/databricks.svg",
         "references/off-platform-streaming.md"
-      ]
+      ],
+      "repo_dir": "skills",
+      "version": "0.1.0"
     },
     "databricks-pipelines": {
-      "version": "0.3.0",
       "description": "Databricks Spark Declarative Pipelines (SDP) for ETL and streaming",
-      "repo_dir": "skills",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -152,186 +307,12 @@
         "references/view.md",
         "references/workflows.md",
         "references/write-spark-declarative-pipelines.md"
-      ]
-    },
-    "databricks-serverless-migration": {
-      "version": "0.1.0",
-      "description": "Migrate Databricks workloads from classic compute to serverless compute, including compatibility checks and concrete fixes",
+      ],
       "repo_dir": "skills",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/code-patterns.md",
-        "references/compatibility-checks.md",
-        "references/configuration-guide.md",
-        "references/networking-and-security.md",
-        "references/streaming-migration.md"
-      ]
-    },
-    "databricks-agent-bricks": {
-      "version": "0.0.1",
-      "description": "Create Agent Bricks: Knowledge Assistants (KA) for document Q&A and Supervisor Agents for multi-agent orchestration (MAS).",
-      "repo_dir": "experimental",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/1-knowledge-assistants.md",
-        "references/2-supervisor-agents.md"
-      ]
-    },
-    "databricks-ai-functions": {
-      "version": "0.0.1",
-      "description": "Use Databricks built-in AI Functions (ai_classify, ai_extract, ai_summarize, ai_mask, ai_translate, ai_fix_grammar, ai_gen, ai_analyze_sentiment, ai_similarity, ai_parse_document, ai_query, ai_forecast) to add AI capabilities directly to SQL and PySpark pipelines without managing model endpoints. Also covers document parsing and building custom RAG pipelines (parse \u2192 chunk \u2192 index \u2192 query).",
-      "repo_dir": "experimental",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/1-task-functions.md",
-        "references/2-ai-query.md",
-        "references/3-ai-forecast.md",
-        "references/4-document-processing-pipeline.md"
-      ]
-    },
-    "databricks-aibi-dashboards": {
-      "version": "0.0.1",
-      "description": "Create Databricks AI/BI dashboards. Must use when creating, updating, or deploying Lakeview dashboards as Databricks Dashboard have a unique json structure. CRITICAL: You MUST test ALL SQL queries via CLI BEFORE deploying. Follow guidelines strictly.",
-      "repo_dir": "experimental",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/1-widget-specifications.md",
-        "references/2-advanced-widget-specifications.md",
-        "references/3-filters.md",
-        "references/4-examples.md",
-        "references/5-troubleshooting.md"
-      ]
-    },
-    "databricks-apps-python": {
-      "version": "0.0.1",
-      "description": "Builds Databricks applications. Prefers AppKit (TypeScript + React SDK) for new apps; falls back to Python frameworks (Dash, Streamlit, Gradio, Flask, FastAPI, Reflex) when Python is required. Handles OAuth authorization, app resources, SQL warehouse and Lakebase connectivity, model serving, foundation model APIs, and deployment. Use when building web apps, dashboards, ML demos, or REST APIs for Databricks, or when the user mentions AppKit, Streamlit, Dash, Gradio, Flask, FastAPI, Reflex, or Databricks app.",
-      "repo_dir": "experimental",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "examples/fm-minimal-chat.py",
-        "examples/fm-parallel-calls.py",
-        "examples/fm-structured-outputs.py",
-        "examples/llm_config.py",
-        "references/1-authorization.md",
-        "references/2-app-resources.md",
-        "references/3-frameworks.md",
-        "references/4-deployment.md",
-        "references/5-lakebase.md",
-        "references/6-cli-approach.md"
-      ]
-    },
-    "databricks-dbsql": {
-      "version": "0.0.1",
-      "description": "Databricks SQL (DBSQL) advanced features and SQL warehouse capabilities. This skill MUST be invoked when the user mentions: \"DBSQL\", \"Databricks SQL\", \"SQL warehouse\", \"SQL scripting\", \"stored procedure\", \"CALL procedure\", \"materialized view\", \"CREATE MATERIALIZED VIEW\", \"pipe syntax\", \"|>\", \"geospatial\", \"H3\", \"ST_\", \"spatial SQL\", \"collation\", \"COLLATE\", \"ai_query\", \"ai_classify\", \"ai_extract\", \"ai_gen\", \"AI function\", \"http_request\", \"remote_query\", \"read_files\", \"Lakehouse Federation\", \"recursive CTE\", \"WITH RECURSIVE\", \"multi-statement transaction\", \"temp table\", \"temporary view\", \"pipe operator\". SHOULD also invoke when the user asks about SQL best practices, data modeling patterns, or advanced SQL features on Databricks.",
-      "repo_dir": "experimental",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/ai-functions.md",
-        "references/best-practices.md",
-        "references/geospatial-collations.md",
-        "references/materialized-views-pipes.md",
-        "references/sql-scripting.md"
-      ]
-    },
-    "databricks-docs": {
-      "version": "0.0.1",
-      "description": "Databricks documentation reference via llms.txt index. Use when other skills do not cover a topic, looking up unfamiliar Databricks features, or needing authoritative docs on APIs, configurations, or platform capabilities.",
-      "repo_dir": "experimental",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg"
-      ]
-    },
-    "databricks-execution-compute": {
-      "version": "0.0.1",
-      "description": "Execute code and manage compute on Databricks. Use this skill when the user mentions: \"run code\", \"execute\", \"run on databricks\", \"serverless\", \"no cluster\", \"run python\", \"run scala\", \"run sql\", \"run R\", \"run file\", \"push and run\", \"notebook run\", \"batch script\", \"model training\", \"run script on cluster\", \"create cluster\", \"new cluster\", \"resize cluster\", \"modify cluster\", \"delete cluster\", \"terminate cluster\", \"create warehouse\", \"new warehouse\", \"resize warehouse\", \"delete warehouse\", \"node types\", \"runtime versions\", \"DBR versions\", \"spin up compute\", \"provision cluster\".",
-      "repo_dir": "experimental",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/1-databricks-connect.md",
-        "references/2-serverless-job.md",
-        "references/3-interactive-cluster.md",
-        "scripts/compute.py"
-      ]
-    },
-    "databricks-iceberg": {
-      "version": "0.0.1",
-      "description": "Apache Iceberg tables on Databricks \u2014 Managed Iceberg tables, External Iceberg Reads (fka Uniform), Compatibility Mode, Iceberg REST Catalog (IRC), Iceberg v3, Snowflake interop, PyIceberg, OSS Spark, external engine access and credential vending. Use when creating Iceberg tables, enabling External Iceberg Reads (uniform) on Delta tables (including Streaming Tables and Materialized Views via compatibility mode), configuring external engines to read Databricks tables via Unity Catalog IRC, integrating with Snowflake catalog to read Foreign Iceberg tables",
-      "repo_dir": "experimental",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/1-managed-iceberg-tables.md",
-        "references/2-uniform-and-compatibility.md",
-        "references/3-iceberg-rest-catalog.md",
-        "references/4-snowflake-interop.md",
-        "references/5-external-engine-interop.md"
-      ]
-    },
-    "databricks-metric-views": {
-      "version": "0.0.1",
-      "description": "Unity Catalog metric views: define, create, query, and manage governed business metrics in YAML. Use when building standardized KPIs, revenue metrics, order analytics, or any reusable business metrics that need consistent definitions across teams and tools.",
-      "repo_dir": "experimental",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/patterns.md",
-        "references/yaml-reference.md"
-      ]
-    },
-    "databricks-mlflow-evaluation": {
-      "version": "0.0.1",
-      "description": "MLflow 3 GenAI agent evaluation. Use when writing mlflow.genai.evaluate() code, creating @scorer functions, using built-in scorers (Guidelines, Correctness, Safety, RetrievalGroundedness), building eval datasets from traces, setting up trace ingestion and production monitoring, aligning judges with MemAlign from domain expert feedback, or running optimize_prompts() with GEPA for automated prompt improvement.",
-      "repo_dir": "experimental",
-      "files": [
-        "SKILL.md",
-        "agents/openai.yaml",
-        "assets/databricks.png",
-        "assets/databricks.svg",
-        "references/CRITICAL-interfaces.md",
-        "references/GOTCHAS.md",
-        "references/patterns-context-optimization.md",
-        "references/patterns-datasets.md",
-        "references/patterns-evaluation.md",
-        "references/patterns-judge-alignment.md",
-        "references/patterns-prompt-optimization.md",
-        "references/patterns-scorers.md",
-        "references/patterns-trace-analysis.md",
-        "references/patterns-trace-ingestion.md",
-        "references/user-journeys.md"
-      ]
+      "version": "0.3.0"
     },
     "databricks-python-sdk": {
-      "version": "0.0.1",
       "description": "Databricks development guidance including Python SDK, Databricks Connect, CLI, and REST API. Use when working with databricks-sdk, databricks-connect, or Databricks APIs.",
-      "repo_dir": "experimental",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -343,12 +324,28 @@
         "examples/4-unity-catalog.py",
         "examples/5-serving-and-vector-search.py",
         "references/doc-index.md"
-      ]
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
+    },
+    "databricks-serverless-migration": {
+      "description": "Migrate Databricks workloads from classic compute to serverless compute, including compatibility checks and concrete fixes",
+      "files": [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "assets/databricks.png",
+        "assets/databricks.svg",
+        "references/code-patterns.md",
+        "references/compatibility-checks.md",
+        "references/configuration-guide.md",
+        "references/networking-and-security.md",
+        "references/streaming-migration.md"
+      ],
+      "repo_dir": "skills",
+      "version": "0.1.0"
     },
     "databricks-spark-structured-streaming": {
-      "version": "0.0.1",
       "description": "Comprehensive guide to Spark Structured Streaming for production workloads. Use when building streaming pipelines, working with Kafka ingestion, implementing Real-Time Mode (RTM), configuring triggers (processingTime, availableNow), handling stateful operations with watermarks, optimizing checkpoints, performing stream-stream or stream-static joins, writing to multiple sinks, or tuning streaming cost and performance.",
-      "repo_dir": "experimental",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -363,12 +360,12 @@
         "references/stream-stream-joins.md",
         "references/streaming-best-practices.md",
         "references/trigger-and-cost-optimization.md"
-      ]
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
     },
     "databricks-synthetic-data-gen": {
-      "version": "0.0.1",
       "description": "Generate realistic synthetic data using Spark + Faker (strongly recommended). Supports serverless execution, multiple output formats (Parquet/JSON/CSV/Delta), and scales from thousands to millions of rows. For small datasets (<10K rows), can optionally generate locally and upload to volumes. Use when user mentions 'synthetic data', 'test data', 'generate data', 'demo dataset', 'Faker', or 'sample data'.",
-      "repo_dir": "experimental",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -377,12 +374,12 @@
         "references/1-data-patterns.md",
         "references/2-troubleshooting.md",
         "scripts/generate_synthetic_data.py"
-      ]
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
     },
     "databricks-unity-catalog": {
-      "version": "0.0.1",
       "description": "Unity Catalog system tables and volumes. Use when querying system tables (audit, lineage, billing) or working with volume file operations (upload, download, list files in /Volumes/).",
-      "repo_dir": "experimental",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -391,24 +388,24 @@
         "references/5-system-tables.md",
         "references/6-volumes.md",
         "references/7-data-profiling.md"
-      ]
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
     },
     "databricks-unstructured-pdf-generation": {
-      "version": "0.0.1",
       "description": "Generate PDF documents from HTML and upload to Unity Catalog volumes. Use for creating test PDFs, demo documents, reports, or evaluation datasets.",
-      "repo_dir": "experimental",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
         "assets/databricks.png",
         "assets/databricks.svg",
         "scripts/pdf_generator.py"
-      ]
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
     },
     "databricks-vector-search": {
-      "version": "0.0.1",
       "description": "Patterns for Databricks Vector Search: create endpoints and indexes, query with filters, manage embeddings. Use when building RAG applications, semantic search, or similarity matching. Covers both storage-optimized and standard endpoints.",
-      "repo_dir": "experimental",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -418,12 +415,12 @@
         "references/index-types.md",
         "references/search-modes.md",
         "references/troubleshooting-and-operations.md"
-      ]
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
     },
     "databricks-zerobus-ingest": {
-      "version": "0.0.1",
       "description": "Build Zerobus Ingest clients for near real-time data ingestion into Databricks Delta tables via gRPC. Use when creating producers that write directly to Unity Catalog tables without a message bus, working with the Zerobus Ingest SDK in Python/Java/Go/TypeScript/Rust, generating Protobuf schemas from UC tables, or implementing stream-based ingestion with ACK handling and retry logic.",
-      "repo_dir": "experimental",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -434,12 +431,12 @@
         "references/3-multilanguage-clients.md",
         "references/4-protobuf-schema.md",
         "references/5-operations-and-limits.md"
-      ]
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
     },
     "spark-python-data-source": {
-      "version": "0.0.1",
       "description": "Build custom Python data sources for Apache Spark using the PySpark DataSource API \u2014 batch and streaming readers/writers for external systems. Use this skill whenever someone wants to connect Spark to an external system (database, API, message queue, custom protocol), build a Spark connector or plugin in Python, implement a DataSourceReader or DataSourceWriter, pull data from or push data to a system via Spark, or work with the PySpark DataSource API in any way. Even if they just say \"read from X in Spark\" or \"write DataFrame to Y\" and there's no native connector, this skill applies.",
-      "repo_dir": "experimental",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -453,7 +450,10 @@
         "references/streaming-patterns.md",
         "references/testing-patterns.md",
         "references/type-conversion.md"
-      ]
+      ],
+      "repo_dir": "experimental",
+      "version": "0.0.1"
     }
-  }
+  },
+  "version": "2"
 }

--- a/scripts/skills.py
+++ b/scripts/skills.py
@@ -298,16 +298,11 @@ def generate_manifest(repo_root: Path) -> dict:
     truth for whether the skill is experimental; consumers derive that state
     from `repo_dir`.
     """
-    manifest_path = repo_root / "manifest.json"
-    existing_skills = {}
-    if manifest_path.exists():
-        existing_skills = json.loads(manifest_path.read_text()).get("skills", {})
-
     skills: dict = {}
     for skill_dir in iter_skill_dirs(repo_root):
-        _add_skill(skills, _build_stable_entry(skill_dir, existing_skills))
+        _add_skill(skills, _build_stable_entry(skill_dir))
     for skill_dir in iter_experimental_skill_dirs(repo_root):
-        _add_skill(skills, _build_experimental_entry(skill_dir, existing_skills))
+        _add_skill(skills, _build_experimental_entry(skill_dir))
 
     return {
         "version": "2",
@@ -329,7 +324,7 @@ def _add_skill(skills: dict, entry: tuple[str, dict]) -> None:
     skills[name] = skill
 
 
-def _build_stable_entry(skill_dir: Path, existing_skills: dict) -> tuple[str, dict]:
+def _build_stable_entry(skill_dir: Path) -> tuple[str, dict]:
     if skill_dir.name not in SKILL_METADATA:
         raise ValueError(
             f"Missing SKILL_METADATA entry for skill '{skill_dir.name}'. "
@@ -356,17 +351,13 @@ def _build_stable_entry(skill_dir: Path, existing_skills: dict) -> tuple[str, di
     if metadata.get("min_cli_version"):
         skill_entry["min_cli_version"] = metadata["min_cli_version"]
 
-    existing = existing_skills.get(skill_dir.name, {})
-    if "base_revision" in existing:
-        skill_entry["base_revision"] = existing["base_revision"]
-
     return skill_dir.name, skill_entry
 
 
 # Experimental skills have a looser contract than stable: no agents/openai.yaml
 # required, no shared-asset sync, no SKILL_METADATA entry required. Description
 # is scraped from SKILL.md frontmatter on a best-effort basis.
-def _build_experimental_entry(skill_dir: Path, existing_skills: dict) -> tuple[str, dict]:
+def _build_experimental_entry(skill_dir: Path) -> tuple[str, dict]:
     files = sorted(str(f.relative_to(skill_dir)) for f in iter_skill_files(skill_dir))
 
     skill_entry = {
@@ -376,10 +367,6 @@ def _build_experimental_entry(skill_dir: Path, existing_skills: dict) -> tuple[s
         "files": files,
     }
 
-    existing = existing_skills.get(skill_dir.name, {})
-    if "base_revision" in existing:
-        skill_entry["base_revision"] = existing["base_revision"]
-
     return skill_dir.name, skill_entry
 
 
@@ -387,42 +374,43 @@ def _build_experimental_entry(skill_dir: Path, existing_skills: dict) -> tuple[s
 # Validation
 # ---------------------------------------------------------------------------
 
-def normalize_manifest(manifest: dict) -> dict:
-    """Normalize manifest for comparison by excluding volatile fields."""
-    normalized = manifest.copy()
-    normalized["skills"] = _normalize_skill_map(manifest.get("skills", {}))
-    return normalized
+def serialize_manifest(manifest: dict) -> str:
+    """Render manifest as its canonical on-disk form.
 
-
-def _normalize_skill_map(skill_map: dict) -> dict:
-    out = {}
-    for name, skill in skill_map.items():
-        skill_copy = skill.copy()
-        skill_copy.pop("base_revision", None)
-        out[name] = skill_copy
-    return out
+    `sort_keys=True` makes the skills map and each entry's keys alphabetical
+    (the `files` arrays are already sorted at generation time). Validation
+    requires the on-disk file to byte-equal this output — drift, hand-edits,
+    or unsorted insertions all fail the check.
+    """
+    return json.dumps(manifest, indent=2, sort_keys=True) + "\n"
 
 
 def validate_manifest(repo_root: Path) -> bool:
-    """Validate that manifest.json is up to date. Returns True if valid."""
+    """Validate that manifest.json is up to date AND in canonical sorted form."""
     manifest_path = repo_root / "manifest.json"
 
     if not manifest_path.exists():
         print("ERROR: manifest.json does not exist", file=sys.stderr)
         return False
 
-    current_manifest = json.loads(manifest_path.read_text())
+    current_text = manifest_path.read_text()
+    current_manifest = json.loads(current_text)
     expected_manifest = generate_manifest(repo_root)
 
-    current_normalized = normalize_manifest(current_manifest)
-    expected_normalized = normalize_manifest(expected_manifest)
-
-    if current_normalized != expected_normalized:
-        print("ERROR: manifest.json is out of date", file=sys.stderr)
+    if current_manifest != expected_manifest:
+        print("ERROR: manifest.json content is out of date", file=sys.stderr)
         print("\nExpected:", file=sys.stderr)
-        print(json.dumps(expected_normalized, indent=2), file=sys.stderr)
+        print(serialize_manifest(expected_manifest), file=sys.stderr)
         print("\nActual:", file=sys.stderr)
-        print(json.dumps(current_normalized, indent=2), file=sys.stderr)
+        print(serialize_manifest(current_manifest), file=sys.stderr)
+        return False
+
+    if current_text != serialize_manifest(current_manifest):
+        print(
+            "ERROR: manifest.json is not in canonical sorted form. "
+            "Keys must be alphabetical at every level.",
+            file=sys.stderr,
+        )
         return False
 
     return True
@@ -466,7 +454,7 @@ def main() -> None:
 
             manifest = generate_manifest(repo_root)
             manifest_path = repo_root / "manifest.json"
-            manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+            manifest_path.write_text(serialize_manifest(manifest))
             print(f"Generated {manifest_path}")
             print(
                 f"Found {len(manifest['skills'])} skill(s): "

--- a/scripts/skills.py
+++ b/scripts/skills.py
@@ -305,6 +305,7 @@ def generate_manifest(repo_root: Path) -> dict:
         _add_skill(skills, _build_experimental_entry(skill_dir))
 
     return {
+        "//": "GENERATED FILE: DO NOT EDIT. Run `python3 scripts/skills.py generate` to regenerate.",
         "version": "2",
         "skills": skills,
     }


### PR DESCRIPTION
## Summary

Two related cleanups to `manifest.json` hygiene.

### 1. Drop `base_revision` plumbing

The `base_revision` field was added in [#30](https://github.com/databricks/databricks-agent-skills/pull/30) as a per-skill upstream-revision tag, intended to track where a synced skill came from in a-d-k. It never got a consumer:

- `databricks/cli`'s `aitools install` ignores it (`gh search code base_revision --owner=databricks` returns only this repo's own `scripts/skills.py`).
- No skill on `main` carries it. A few feature branches populated it while iterating on a-d-k ports (e.g. `origin/experimental-aidevkit` had `"base_revision": "e742f36e8ab1"` for some skills), but those values never reached `main`.
- The generator just round-tripped the field if present in the prior manifest, and `normalize_manifest` stripped it before the validate diff — so it couldn't fail CI either.

It's dead weight that future maintainers have to reason about. Dropped:

- `_build_stable_entry`'s existing-entry-preservation branch (and the now-unused `existing_skills` parameter).
- `_build_experimental_entry`'s equivalent.
- `generate_manifest`'s existing-manifest read (only used to feed `existing_skills`).
- `normalize_manifest` and `_normalize_skill_map` — the only volatile field they normalized was `base_revision`, so `validate_manifest` can compare dicts directly now.

If per-skill upstream sync tracking does become useful later, re-add the field at the same time as the tool that consumes it. The long-term sync plan in [#73 TODO #3](https://github.com/databricks/databricks-agent-skills/pull/73) is git-subtree-based, which tracks revisions intrinsically — `base_revision` doesn't help there.

### 2. Enforce canonical sorted form

The on-disk `manifest.json` is now required to be byte-equal to the canonical serialization (`json.dumps(manifest, indent=2, sort_keys=True) + "\n"`). That means:

- The `skills` map's keys are alphabetical across stable **+** experimental (no more stable-first grouping; that was a side-effect of build order, not a deliberate choice).
- Each skill entry's keys are alphabetical: `description`, `files`, `min_cli_version?`, `repo_dir`, `version`.
- The top-level keys (`skills`, `version`) are alphabetical.
- `files` arrays remain sorted by the generator (already enforced).

`scripts/skills.py validate` now does two checks:

1. **Content lint** — the parsed dict equals what `generate_manifest` would produce. Catches stale content, unsorted/missing/extra `files` entries, drift between SKILL.md frontmatter and manifest.
2. **Canonical-form lint** — the on-disk bytes equal `serialize_manifest(current)`. Catches hand-edited sort drift (re-ordered skill names, re-ordered per-skill keys) even when the parsed content is correct.

The writer at `scripts/skills.py generate` uses the same `serialize_manifest` helper, so files emitted by the generator always pass the lint.

## Diff shape

| File | Change |
|---|---|
| `scripts/skills.py` | −47 / +35 lines: drop `base_revision` branches + dead normalize machinery; add `serialize_manifest` helper; rework `validate_manifest` to do the two checks above. |
| `manifest.json` | 220-line swap: skills now in one alphabetical run (`databricks-agent-bricks`, `databricks-ai-functions`, ...) and per-skill keys alphabetised. No semantic change for `aitools install`. |

## Test plan

- [x] `python3 scripts/skills.py generate` clean — regenerates the canonical sorted manifest.
- [x] `python3 scripts/skills.py validate` passes.
- [x] Lint catches a manually-reversed `skills` map: emits `ERROR: manifest.json is not in canonical sorted form. Keys must be alphabetical at every level.`
- [x] Lint catches a manually-reversed `files` array inside a skill entry: emits `ERROR: manifest.json content is out of date`.
- [ ] CI green on this branch.

This pull request and its description were written by Claude.