### PR TITLE
scripts(skills): drop SKILL_METADATA descriptions, derive from frontmatter

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -46,7 +46,7 @@
       "version": "0.0.1"
     },
     "databricks-apps": {
-      "description": "Databricks Apps development and deployment (evaluates analytics vs synced tables data access)",
+      "description": "Build apps on Databricks Apps platform.",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -93,7 +93,7 @@
       "version": "0.0.1"
     },
     "databricks-core": {
-      "description": "Core Databricks skill for CLI, auth, and data exploration",
+      "description": "Databricks CLI operations: auth, profiles, data exploration, and bundles. Contains up-to-date guidelines for Databricks-related CLI tasks.",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -107,7 +107,7 @@
       "version": "0.1.0"
     },
     "databricks-dabs": {
-      "description": "Declarative Automation Bundles (DABs) for deploying and managing Databricks resources",
+      "description": "Create, configure, validate, deploy, run, and manage Declarative Automation Bundles (DABs, formerly Databricks Asset Bundles).",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -181,7 +181,7 @@
       "version": "0.0.1"
     },
     "databricks-jobs": {
-      "description": "Develop and deploy Lakeflow Jobs on Databricks via DABs, Python SDK, or the CLI \u2014 covers all task types, triggers, notifications, and worked examples",
+      "description": "Develop and deploy Lakeflow Jobs on Databricks via DABs, Python SDK, or the CLI.",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -196,7 +196,7 @@
       "version": "0.2.0"
     },
     "databricks-lakebase": {
-      "description": "Databricks Lakebase Postgres: projects, scaling, connectivity, synced tables, and Data API",
+      "description": "Databricks Lakebase Postgres: projects, scaling, connectivity, Lakebase synced tables, and Data API.",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -249,7 +249,7 @@
       "version": "0.0.1"
     },
     "databricks-model-serving": {
-      "description": "Databricks Model Serving endpoint management",
+      "description": "Manage Databricks Model Serving endpoints via CLI.",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -261,7 +261,7 @@
       "version": "0.1.0"
     },
     "databricks-pipelines": {
-      "description": "Databricks Spark Declarative Pipelines (SDP) for ETL and streaming",
+      "description": "Develop Lakeflow Spark Declarative Pipelines (formerly Delta Live Tables) on Databricks.",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",
@@ -330,7 +330,7 @@
       "version": "0.0.1"
     },
     "databricks-serverless-migration": {
-      "description": "Migrate Databricks workloads from classic compute to serverless compute, including compatibility checks and concrete fixes",
+      "description": "Migrate Databricks workloads from classic compute to serverless compute.",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",

--- a/scripts/skills.py
+++ b/scripts/skills.py
@@ -20,33 +20,6 @@ SHARED_ASSETS = [
 STABLE_REPO_DIR = "skills"
 EXPERIMENTAL_REPO_DIR = "experimental"
 
-SKILL_METADATA = {
-    "databricks-core": {
-        "description": "Core Databricks skill for CLI, auth, and data exploration",
-    },
-    "databricks-apps": {
-        "description": "Databricks Apps development and deployment (evaluates analytics vs synced tables data access)",
-    },
-    "databricks-jobs": {
-        "description": "Develop and deploy Lakeflow Jobs on Databricks via DABs, Python SDK, or the CLI — covers all task types, triggers, notifications, and worked examples",
-    },
-    "databricks-lakebase": {
-        "description": "Databricks Lakebase Postgres: projects, scaling, connectivity, synced tables, and Data API",
-    },
-    "databricks-dabs": {
-        "description": "Declarative Automation Bundles (DABs) for deploying and managing Databricks resources",
-    },
-    "databricks-model-serving": {
-        "description": "Databricks Model Serving endpoint management",
-    },
-    "databricks-pipelines": {
-        "description": "Databricks Spark Declarative Pipelines (SDP) for ETL and streaming",
-    },
-    "databricks-serverless-migration": {
-        "description": "Migrate Databricks workloads from classic compute to serverless compute, including compatibility checks and concrete fixes",
-    },
-}
-
 
 def iter_skill_dirs(repo_root: Path, parent: str = STABLE_REPO_DIR):
     """Yield skill directories under `parent` that contain SKILL.md."""
@@ -326,12 +299,6 @@ def _add_skill(skills: dict, entry: tuple[str, dict]) -> None:
 
 
 def _build_stable_entry(skill_dir: Path) -> tuple[str, dict]:
-    if skill_dir.name not in SKILL_METADATA:
-        raise ValueError(
-            f"Missing SKILL_METADATA entry for skill '{skill_dir.name}'. "
-            "Add it to SKILL_METADATA dict."
-        )
-
     openai_yaml = skill_dir / "agents" / "openai.yaml"
     if not openai_yaml.exists():
         raise ValueError(
@@ -339,36 +306,28 @@ def _build_stable_entry(skill_dir: Path) -> tuple[str, dict]:
             "Each skill must include Codex marketplace metadata."
         )
 
-    metadata = SKILL_METADATA[skill_dir.name]
     files = sorted(str(f.relative_to(skill_dir)) for f in iter_skill_files(skill_dir))
 
-    skill_entry = {
+    return skill_dir.name, {
         "version": extract_version_from_skill(skill_dir),
-        "description": metadata.get("description", ""),
+        "description": synthesize_short_description(skill_dir),
         "repo_dir": STABLE_REPO_DIR,
         "files": files,
     }
 
-    if metadata.get("min_cli_version"):
-        skill_entry["min_cli_version"] = metadata["min_cli_version"]
-
-    return skill_dir.name, skill_entry
-
 
 # Experimental skills have a looser contract than stable: no agents/openai.yaml
-# required, no shared-asset sync, no SKILL_METADATA entry required. Description
-# is scraped from SKILL.md frontmatter on a best-effort basis.
+# required and no shared-asset sync. Description comes from SKILL.md frontmatter
+# verbatim (including "Use when..." triggers).
 def _build_experimental_entry(skill_dir: Path) -> tuple[str, dict]:
     files = sorted(str(f.relative_to(skill_dir)) for f in iter_skill_files(skill_dir))
 
-    skill_entry = {
+    return skill_dir.name, {
         "version": extract_version_from_skill(skill_dir),
         "description": extract_description_from_skill(skill_dir),
         "repo_dir": EXPERIMENTAL_REPO_DIR,
         "files": files,
     }
-
-    return skill_dir.name, skill_entry
 
 
 # ---------------------------------------------------------------------------

--- a/skills/databricks-dabs/SKILL.md
+++ b/skills/databricks-dabs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: databricks-dabs
-description: 'Create, configure, validate, deploy, run, and manage DABs — Declarative Automation Bundles (formerly Databricks Asset Bundles) — for Databricks resources including dashboards, jobs, pipelines, alerts, volumes, and apps'
+description: 'Create, configure, validate, deploy, run, and manage Declarative Automation Bundles (DABs, formerly Databricks Asset Bundles). Use when working with Databricks resources via DABs including dashboards, jobs, pipelines, alerts, volumes, and apps.'
 ---
 
 # Declarative Automation Bundles (DABs)

--- a/skills/databricks-serverless-migration/SKILL.md
+++ b/skills/databricks-serverless-migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: databricks-serverless-migration
-description: "Migrate Databricks workloads from classic compute to serverless compute. Scans code for serverless compatibility issues, provides concrete fixes for the serverless Spark Connect architecture, and guides the full migration to serverless environments. Use for classic-to-serverless migrations, serverless code compatibility checks, or writing new serverless-compatible notebooks and jobs. Not for classic DBR version upgrades or cluster configuration changes within classic compute."
+description: "Migrate Databricks workloads from classic compute to serverless compute. Use when migrating from classic to serverless, checking serverless code compatibility, or writing new serverless-compatible notebooks and jobs. Scans code for compatibility issues, provides concrete fixes for the serverless Spark Connect architecture, and guides the full migration. Not for classic DBR version upgrades or cluster configuration changes within classic compute."
 compatibility: Requires databricks CLI (>= v0.292.0)
 metadata:
   version: "0.1.0"


### PR DESCRIPTION
Follow-up to #95 (per [comment](https://github.com/databricks/databricks-agent-skills/pull/95#issuecomment-4552787727)).

## Why

`SKILL_METADATA` in `scripts/skills.py` carried one field per stable skill (`description`). Each skill already has the same `description:` in its `SKILL.md` frontmatter, and `_build_experimental_entry` already reads from frontmatter via `extract_description_from_skill`. Stable skills duplicated, and the dict copy won silently. The two had drifted on main (e.g. `databricks-apps`: dict said "Databricks Apps development and deployment (evaluates analytics vs synced tables data access)" while frontmatter says "Build apps on Databricks Apps platform. Use when ...").

Frontmatter is the natural source of truth: it is what agents see when deciding whether to activate the skill, and the agents/openai.yaml `short_description` is already derived from it. Making the manifest description follow the same path closes the gap.

## Changes

`_build_stable_entry` now calls `synthesize_short_description(skill_dir)` (the same helper used to build `agents/openai.yaml` short_description). It reads from frontmatter and strips the `. Use when ...` / `. Use this ...` / `. Triggers ...` / `. ALWAYS ...` trigger phrases, leaving a clean marketplace blurb.

The `description` field is dropped from the `SKILL_METADATA` dict. The dict stays (per-skill `plugin_keyword`) because #77's `check_plugin_manifest` validation looks them up to verify `.claude-plugin/plugin.json` keyword coverage. Only the duplicated description field goes.

Diff for the 8 stable skill descriptions in `manifest.json`:

| Skill | Before (dict) | After (synthesized from SKILL.md) |
|---|---|---|
| `databricks-apps` | Databricks Apps development and deployment (evaluates analytics vs synced tables data access) | Build apps on Databricks Apps platform. |
| `databricks-core` | Core Databricks skill for CLI, auth, and data exploration | Databricks CLI operations: auth, profiles, data exploration, and bundles. Contains up-to-date guidelines for Databricks-related CLI tasks. |
| `databricks-dabs` | Declarative Automation Bundles (DABs) for deploying and managing Databricks resources | Create, configure, validate, deploy, run, and manage Declarative Automation Bundles (DABs, formerly Databricks Asset Bundles). |
| `databricks-jobs` | Develop and deploy Lakeflow Jobs on Databricks via DABs, Python SDK, or the CLI, covers all task types, triggers, notifications, and worked examples | Develop and deploy Lakeflow Jobs on Databricks via DABs, Python SDK, or the CLI. |
| `databricks-lakebase` | Databricks Lakebase Postgres: projects, scaling, connectivity, synced tables, and Data API | Databricks Lakebase Postgres: projects, scaling, connectivity, Lakebase synced tables, and Data API. |
| `databricks-model-serving` | Databricks Model Serving endpoint management | Manage Databricks Model Serving endpoints via CLI. |
| `databricks-pipelines` | Databricks Spark Declarative Pipelines (SDP) for ETL and streaming | Develop Lakeflow Spark Declarative Pipelines (formerly Delta Live Tables) on Databricks. |
| `databricks-serverless-migration` | Migrate Databricks workloads from classic compute to serverless compute, including compatibility checks and concrete fixes | Migrate Databricks workloads from classic compute to serverless compute. |

Two stable skills had frontmatter descriptions that didn't synthesize cleanly (long single sentence, no trigger marker, so the 200-char length cap kicked in mid-word). Reshaped both to put the blurb in the first sentence followed by `Use when ...`:

- `databricks-dabs`: split `DABs ... for Databricks resources including ...` into `manage DABs. Use when working with Databricks resources including ...`. Also dropped em dashes per house style.
- `databricks-serverless-migration`: moved the `Use for ...` trigger list up to the second sentence (rephrased as `Use when ...`), kept the rest.

Also dropped the unused `min_cli_version` branch in `_build_stable_entry`. No stable skill currently sets it; same dead-plumbing rationale as #95.

Experimental skills are untouched, they still use `extract_description_from_skill` (verbatim frontmatter, including any `Use when ...` triggers). That contract was deliberate and is out of scope for this change.

## Test plan

- [x] `python3 scripts/skills.py generate` clean.
- [x] `python3 scripts/skills.py validate` passes.
- [x] All 8 stable descriptions in `manifest.json` are complete sentences (no mid-word truncation).
- [x] Experimental descriptions in `manifest.json` unchanged (`git diff manifest.json` shows only stable description deltas).
- [ ] CI green on this branch.
