### PR TITLE
docs(experimental/databricks-apps-python): drop stale databricks-app-apx Related Skills entry

### DIFF
--- a/experimental/databricks-apps-python/SKILL.md
+++ b/experimental/databricks-apps-python/SKILL.md
@@ -252,7 +252,6 @@ class EntityIn(BaseModel):
 
 ## Related Skills
 
-- **databricks-app-apx** - full-stack apps with FastAPI + React
 - **databricks-dabs** - deploying apps via DABs
 - **[databricks-python-sdk](../databricks-python-sdk/SKILL.md)** - backend SDK integration
 - **databricks-lakebase** - adding persistent PostgreSQL state (autoscaling managed PG with branching)


### PR DESCRIPTION
## Summary

Removes the last dangling `databricks-app-apx` reference in this repo — one line in `experimental/databricks-apps-python/SKILL.md` ("Related Skills" bullet).

## Why

`databricks-app-apx` was the FastAPI+React stack referenced from ai-dev-kit's `databricks-apps-python`. It has been removed upstream (a-d-k is deprecated; the apx-on-CLI flow merged into the stable `databricks-apps` skill via #84/#73). I grepped the entire repo and this bullet is the only remaining mention — README, install scripts, and stable skills no longer reference it.

## Test plan

- [x] `python3 scripts/skills.py validate` passes (`Everything is up to date.`)
- [x] `grep -rn databricks-app-apx .` returns no remaining hits.
- [ ] CI green.

This pull request and its description were written by Claude.