### PR TITLE
docs: note ai-dev-kit deprecation in README + experimental/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ Stable skills shipped from [`skills/`](./skills/):
 ## Experimental Skills
 
 The [`experimental/`](./experimental/) directory contains additional skills
-imported from [databricks-solutions/ai-dev-kit](https://github.com/databricks-solutions/ai-dev-kit)
-on a **best-effort basis**.
+originally imported from
+[databricks-solutions/ai-dev-kit](https://github.com/databricks-solutions/ai-dev-kit)
+(now deprecated — this repo is the source of truth going forward) on a
+**best-effort basis**.
 
 - Experimental skills are **not officially supported** — they may be used, but
   do not follow the same review / quality bar as the stable skills under

--- a/experimental/README.md
+++ b/experimental/README.md
@@ -1,18 +1,20 @@
 > ⚠️ **Experimental: best-effort, not officially supported**
 >
-> The skills in this directory are imported from
+> The skills in this directory were originally imported from
 > [databricks-solutions/ai-dev-kit](https://github.com/databricks-solutions/ai-dev-kit)
-> on a best-effort basis. They may be useful, but they are **not officially
-> supported** as part of `databricks-agent-skills`:
+> on a best-effort basis. **`ai-dev-kit` is now deprecated** —
+> `databricks/databricks-agent-skills` is the canonical home for these skills
+> going forward, and updates land here directly rather than via re-sync.
+>
+> They are still **not officially supported** as part of `databricks-agent-skills`:
 >
 > - They do not follow the same review / quality bar as the skills in
 >   [`../skills/`](../skills/).
-> - They may be out of date relative to upstream `ai-dev-kit`.
 > - They are not installed by `databricks aitools install` by default —
 >   you have to opt in (see the root README).
 >
 > File issues against this directory in this repo; do not file issues against
-> `ai-dev-kit` for skills installed via `databricks-agent-skills`.
+> the deprecated `ai-dev-kit` repo.
 
 ---
 


### PR DESCRIPTION
## Summary

`ai-dev-kit` (`databricks-solutions/ai-dev-kit`) was the historical upstream for `experimental/` skills. It is now **deprecated** — DAS is the canonical home and updates land here directly rather than via re-sync from a-d-k.

Updates both READMEs to reflect that.

## Changes

- **`README.md`** "Experimental Skills" — clarify "originally imported" rather than "imported", and call out that a-d-k is deprecated.
- **`experimental/README.md`** — same framing in the top warning block; drop the now-obsolete "may be out of date relative to upstream ai-dev-kit" bullet, and redirect issue-filing away from the deprecated a-d-k repo.

No code or skill content changes.

## Why

External readers (especially downstream consumers like CoDA and the ai-dev-kit Genie Code installer) need a single sentence they can point at when they say "go to DAS, not a-d-k". Sister-PRs landing today:

- [databricks-solutions/ai-dev-kit#552](https://github.com/databricks-solutions/ai-dev-kit/pull/552) / [#553](https://github.com/databricks-solutions/ai-dev-kit/pull/553) — Genie Code installer adds DAS as upstream source.
- [datasciencemonkey/coding-agents-databricks-apps#163](https://github.com/datasciencemonkey/coding-agents-databricks-apps/pull/163) — CoDA's `refresh-databricks-skills` skill repoints from a-d-k to DAS.

## Test plan

- [x] `python3 scripts/skills.py validate` passes (`Everything is up to date.`).
- [ ] CI green.

This pull request and its description were written by Claude.