### PR TITLE
Add PAE team as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @lennartkats-db @simonfaltum @databricks/eng-apps-devex
+* @lennartkats-db @simonfaltum @databricks/eng-apps-devex @databricks/eng-dev-ecosystem
 /skills/ @lennartkats-db @simonfaltum # net-new skills must be approved by @lennartkats-db
 /skills/databricks-core/ @lennartkats-db @simonfaltum @camielstee-db @databricks/eng-apps-devex
 /skills/databricks-apps/ @databricks/eng-apps-devex
@@ -9,4 +9,4 @@
 
 /experimental/ @lennartkats-db @simonfaltum @calreynolds @dustinvannoy-db
 
-/.github/CODEOWNERS @lennartkats-db @simonfaltum @fjakobs
+/.github/CODEOWNERS @lennartkats-db @simonfaltum @fjakobs @databricks/eng-dev-ecosystem


### PR DESCRIPTION
Adds the PAE Developer Ecosystem team (@databricks/eng-dev-ecosystem) as a code owner on two lines in .github/CODEOWNERS: the catch-all `*` rule and the `/.github/CODEOWNERS` rule itself.

This broadens review coverage to the PAE team for changes across the repo and to the CODEOWNERS file.