### PR TITLE
release: use annotated tags; drop GPG-signing claim from README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,11 +53,24 @@ jobs:
             git push origin HEAD:main
           fi
 
-      - name: Create tag and release
+      - name: Create annotated tag
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Annotated tag (objecttype=tag), not lightweight (objecttype=commit):
+          # records tagger metadata and is the prerequisite for `git tag -v`
+          # verification if tag signing is ever enabled.
+          git tag -a "$VERSION" -m "$VERSION"
+          git push origin "$VERSION"
+
+      - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
         run: |
           gh release create "$VERSION" \
             --title "$VERSION" \
-            --generate-notes
+            --generate-notes \
+            --verify-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,8 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # git identity is already configured by the "Commit version bump"
+          # step above and persists for the job via .git/config.
           # Annotated tag (objecttype=tag), not lightweight (objecttype=commit):
           # records tagger metadata and is the prerequisite for `git tag -v`
           # verification if tag signing is ever enabled.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,8 @@ triggered manually (`workflow_dispatch`) with a `vX.Y.Z` tag. The workflow:
    both `.claude-plugin/plugin.json` and `.cursor-plugin/plugin.json` to the
    release version and regenerates `manifest.json`.
 2. Commits the bump to `main`.
-3. Creates the `vX.Y.Z` tag and GitHub release from that commit.
+3. Creates an annotated `vX.Y.Z` tag (`git tag -a`) at that commit, pushes it,
+   then creates the GitHub release (`gh release create --verify-tag`).
 
 Bumping the plugin `version` on every release is **required**: Claude Code's
 plugin marketplace keys updates on the `version` field, so a release that ships

--- a/README.md
+++ b/README.md
@@ -150,8 +150,7 @@ Please see [SECURITY](./SECURITY) for vulnerability reporting guidelines.
 ## Integrity
 
 Release tags are created by the [Release workflow](./.github/workflows/release.yml)
-and map 1:1 to a published version. (GPG signing is planned once a release signing
-key is provisioned.)
+and map 1:1 to a published version.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Two small release-hygiene changes, extracted from #108 (which is now stale and conflicts with main after #111 landed).

1. The release workflow tagged via `gh release create`, which makes **lightweight** tags (`objecttype=commit`). Lightweight tags carry no tagger metadata and can't be verified with `git tag -v`. This switches to an **annotated** tag.
2. The README "Integrity" section promised future GPG signing. We're not committing to signing, so this drops that claim rather than carrying a promise we may not keep.

## Changes

- **`.github/workflows/release.yml`**: split tag creation from release creation. Create an annotated tag (`git tag -a`) at the version-bump commit, push it, then `gh release create --verify-tag` (confirms the tag exists before creating the release). Placed after the existing "Commit version bump" step so the tag points at the bumped manifests.
- **`README.md`**: remove the "GPG signing is planned..." line from the Integrity section.
- **`CONTRIBUTING.md`**: note the annotated tag in the release steps.

## What's left out of #108

#108 also added a `RELEASING.md`. That overlaps with the Releasing section already in `CONTRIBUTING.md` (added in #111), so I left it out to avoid two sources of truth.

## Test plan

- [x] `python3 scripts/skills.py validate` passes (no skill content touched).
- [x] Workflow YAML parses.
- [ ] Dry-run the Release workflow on a throwaway tag to confirm annotated-tag creation on the protected runner.

This pull request and its description were written by Isaac.
