### PR TITLE
skills(experimental): fix VARIANT accessors + ai_query error field in databricks-ai-functions

### DIFF
--- a/experimental/databricks-ai-functions/SKILL.md
+++ b/experimental/databricks-ai-functions/SKILL.md
@@ -58,7 +58,7 @@ SELECT
     ticket_id,
     ticket_text,
     ai_classify(ticket_text, ARRAY('urgent', 'not urgent', 'spam')) AS priority,
-    ai_extract(ticket_text, ARRAY('product', 'error_code', 'date'))  AS entities,
+    ai_extract(ticket_text, '["product", "error_code", "date"]')     AS entities,
     ai_analyze_sentiment(ticket_text)                                 AS sentiment
 FROM support_tickets;
 ```
@@ -69,12 +69,14 @@ from pyspark.sql.functions import expr
 df = spark.table("support_tickets")
 df = (
     df.withColumn("priority",  expr("ai_classify(ticket_text, array('urgent', 'not urgent', 'spam'))"))
-      .withColumn("entities",  expr("ai_extract(ticket_text, array('product', 'error_code', 'date'))"))
+      .withColumn("entities",  expr("ai_extract(ticket_text, '[\"product\", \"error_code\", \"date\"]')"))
       .withColumn("sentiment", expr("ai_analyze_sentiment(ticket_text)"))
 )
-# Access nested STRUCT fields from ai_extract
-df.select("ticket_id", "priority", "sentiment",
-          "entities.product", "entities.error_code", "entities.date").display()
+# ai_extract returns a VARIANT (fields under :response). Use colon (:) notation — dot returns NULL on a VARIANT.
+df.selectExpr("ticket_id", "priority", "sentiment",
+              "entities:response:product::string    AS product",
+              "entities:response:error_code::string AS error_code",
+              "entities:response:date::string       AS date").display()
 ```
 
 ## Common Patterns
@@ -121,12 +123,14 @@ df = (
     spark.read.format("binaryFile")
     .load("/Volumes/catalog/schema/landing/documents/")
     .withColumn("parsed", expr("ai_parse_document(content)"))
+    # ai_parse_document returns a VARIANT — navigate with the colon (:) operator, never dot.
+    # Shape: { "document": { "pages": [...], "elements": [...] }, "error_status": ..., "metadata": ... }
     .selectExpr("path",
-                "parsed:pages[*].elements[*].content AS text_blocks",
-                "parsed:error AS parse_error")
+                "concat_ws('\n', transform(parsed:document:elements, e -> e:content::STRING)) AS text_blocks",
+                "parsed:error_status AS parse_error")
     .filter("parse_error IS NULL")
     .withColumn("summary",  expr("ai_summarize(text_blocks, 50)"))
-    .withColumn("entities", expr("ai_extract(text_blocks, array('date', 'amount', 'vendor'))"))
+    .withColumn("entities", expr("ai_extract(text_blocks, '[\"date\", \"amount\", \"vendor\"]')"))
 )
 ```
 
@@ -194,6 +198,6 @@ FROM ai_forecast(
 | All functions return NULL | Input column is NULL. Filter with `WHERE col IS NOT NULL` before calling. |
 | `ai_translate` fails for a language | Supported: English, German, French, Italian, Portuguese, Hindi, Spanish, Thai. Use `ai_query` with a multilingual model for others. |
 | `ai_classify` returns unexpected labels | Use clear, mutually exclusive label names. Fewer labels (2–5) produces more reliable results. |
-| `ai_query` raises on some rows in a batch job | Add `failOnError => false` — returns a STRUCT with `.response` and `.error` instead of raising. |
+| `ai_query` raises on some rows in a batch job | Add `failOnError => false` — returns a STRUCT with `.response` and `.errorMessage` instead of raising. |
 | Batch job runs slowly | Use DBR **15.4 ML LTS** cluster (not serverless or interactive) for optimized batch inference throughput. |
 | Want to swap models without editing pipeline code | Store all model names and prompts in `config.yml` — see [references/4-document-processing-pipeline.md](references/4-document-processing-pipeline.md) for the pattern. |

--- a/experimental/databricks-ai-functions/references/1-task-functions.md
+++ b/experimental/databricks-ai-functions/references/1-task-functions.md
@@ -98,6 +98,22 @@ df.withColumn(
 
 Returns VARIANT `{"response": {...}, "error_message": null}`. Returns `NULL` if content is `NULL`.
 
+**Versions** — the current `ai_extract` (a JSON-string schema, e.g. `'["brand", "model"]'`, optionally pinned with `options => map('version', '2.1')`) is **v2.1, which returns a VARIANT, not a STRUCT** — so you access its fields with colon notation. The legacy `ai_extract(content, ARRAY('brand', 'model'))` array-of-labels form (v1) returns a STRUCT accessed with dot notation. Prefer the JSON-string → VARIANT (v2.1) form for new pipelines.
+
+**Accessing the result** — `ai_extract` returns a `VARIANT` (the extracted fields live under `:response`), **not a `STRUCT`**. Navigate it with the colon (`:`) path operator and cast the leaf. **Dot notation (`result.response.brand`) returns `NULL` silently on a VARIANT column — always use colon (`:`).**
+
+```sql
+WITH extracted AS (
+  SELECT product_name, ai_extract(product_name, '["brand", "model"]') AS result
+  FROM products
+)
+SELECT
+  result:response:brand::STRING AS brand,    -- colon path, then cast
+  result:response:model::STRING AS model,
+  result:error_message::STRING  AS extract_error
+FROM extracted;
+```
+
 ```sql
 -- simple schema
 SELECT ai_extract(
@@ -333,11 +349,13 @@ error_status[]       -- errors per page (if any)
 ```
 
 ```sql
--- Parse and extract text blocks
+-- Parse and extract text blocks.
+-- The result is a VARIANT { "document": { "pages": [...], "elements": [...] }, "error_status": ..., "metadata": ... }
+-- Navigate it with the colon (:) operator — dot notation returns NULL on a VARIANT column.
 SELECT
     path,
-    parsed:pages[*].elements[*].content AS text_blocks,
-    parsed:error AS parse_error
+    concat_ws('\n', transform(parsed:document:elements, e -> e:content::STRING)) AS text_blocks,
+    parsed:error_status AS parse_error
 FROM (
     SELECT path, ai_parse_document(content) AS parsed
     FROM read_files('/Volumes/catalog/schema/landing/docs/', format => 'binaryFile')
@@ -362,10 +380,11 @@ df = (
     spark.read.format("binaryFile")
     .load("/Volumes/catalog/schema/landing/docs/")
     .withColumn("parsed", expr("ai_parse_document(content)"))
+    # ai_parse_document returns a VARIANT — navigate with the colon (:) operator, never dot.
     .selectExpr(
         "path",
-        "parsed:pages[*].elements[*].content AS text_blocks",
-        "parsed:error AS parse_error",
+        "concat_ws('\n', transform(parsed:document:elements, e -> e:content::STRING)) AS text_blocks",
+        "parsed:error_status AS parse_error",
     )
     .filter("parse_error IS NULL")
 )
@@ -373,7 +392,7 @@ df = (
 # Chain with task-specific functions on the extracted text
 df = (
     df.withColumn("summary",  expr("ai_summarize(text_blocks, 50)"))
-      .withColumn("entities", expr("ai_extract(text_blocks, array('date', 'amount', 'vendor'))"))
+      .withColumn("entities", expr("ai_extract(text_blocks, '[\"date\", \"amount\", \"vendor\"]')"))
       .withColumn("category", expr("ai_classify(text_blocks, array('invoice', 'contract', 'report'))"))
 )
 df.display()

--- a/experimental/databricks-ai-functions/references/2-ai-query.md
+++ b/experimental/databricks-ai-functions/references/2-ai-query.md
@@ -33,7 +33,7 @@ ai_query(
 | `endpoint` | STRING literal | — | Foundation Model name or custom endpoint name. Never guess — use exact names from the [model serving docs](https://docs.databricks.com/machine-learning/foundation-models/supported-models.html). |
 | `request` | STRING or STRUCT | — | Prompt string for chat models; STRUCT for custom ML endpoints |
 | `returnType` | DDL schema (optional) | 15.2+ | Structures the parsed response like `from_json` |
-| `failOnError` | BOOLEAN (optional, default `true`) | 15.3+ | If `false`, returns STRUCT `{response, error}` instead of raising on failure |
+| `failOnError` | BOOLEAN (optional, default `true`) | 15.3+ | If `false`, returns STRUCT `{response, errorMessage}` instead of raising on failure (`errorMessage` is `NULL` on success; `response` is `NULL` on failure) |
 | `modelParameters` | STRUCT (optional) | 15.3+ | Sampling params: `temperature`, `max_tokens`, `top_p`, etc. |
 | `responseFormat` | JSON string (optional) | 15.4+ | Forces structured JSON output: `'{"type":"json_object"}'` |
 | `files` | binary column (optional) | — | Pass binary images directly (JPEG/PNG) — no upload step needed |
@@ -108,7 +108,7 @@ df.select("invoice.numero", "invoice.total", "invoice.itens").display()
 SELECT
     id,
     ai_response.response,
-    ai_response.error
+    ai_response.errorMessage
 FROM (
     SELECT id,
            ai_query(
@@ -217,7 +217,7 @@ def extracted():
 def extraction_errors():
     return (
         dlt.read("extracted")
-        .filter(col("ai_response.error").isNotNull())
-        .select("id", "prompt", col("ai_response.error").alias("error"))
+        .filter(col("ai_response.errorMessage").isNotNull())
+        .select("id", "prompt", col("ai_response.errorMessage").alias("error"))
     )
 ```

--- a/experimental/databricks-ai-functions/references/4-document-processing-pipeline.md
+++ b/experimental/databricks-ai-functions/references/4-document-processing-pipeline.md
@@ -199,7 +199,7 @@ def extracted_line_items():
                 "quantity:DOUBLE, unit_price:DOUBLE, total:DOUBLE>>>"
             )
         )
-        .select("path", "doc_type", "header", "line_items", col("ai_response.error").alias("extraction_error"))
+        .select("path", "doc_type", "header", "line_items", col("ai_response.errorMessage").alias("extraction_error"))
     )
 
 


### PR DESCRIPTION
## Summary

Eval-driven improvement of the `databricks-ai-functions` (experimental) skill. I ran the skill through a full SkillForge **L1–L5** evaluation (7 ground-truth cases, WITH-vs-WITHOUT controlled experiment), found that the skill was making the agent **worse than no skill** on three cases, diagnosed the root cause of each against the live Databricks docs, and fixed them. All corrections reconcile the skill to its own canonical reference content **and** the official function docs.

**What the eval found (baseline):** L5 Output 0.53, with **5 regressions across 3 cases** (the skill steered the agent to wrong output that it got *right* without the skill):

| Case | Root cause in the skill |
|---|---|
| `ai_parse_document` | **Internal contradiction** — the documented output-schema tree shows `document:{pages, elements}` + `error_status`, but the example queries used `parsed:pages[*].elements[*].content` / `parsed:error`. The agent noticed the conflict, stopped to verify against docs, and ran out of turns before answering. |
| `ai_extract` | Body taught the legacy `ARRAY(...)` → STRUCT → **dot** access while the reference said it returns a VARIANT; nothing warned that **dot notation returns `NULL` silently on a VARIANT**. The agent produced a confused hybrid. |
| `ai_query` (`failOnError => false`) | The skill described the returned struct's error field as **`.error`** in several places; the docs confirm it is **`errorMessage`**. |

**What changed:**

1. **`ai_parse_document` accessors** — corrected examples to `parsed:document:pages` / `parsed:document:elements` / `parsed:error_status` (colon-notation), matching the schema tree, `references/4`, and the [ai_parse_document docs](https://docs.databricks.com/aws/en/sql/language-manual/functions/ai_parse_document). *(SKILL.md Pattern 3 + `references/1`)*
2. **`ai_extract` VARIANT access** — standardized on the JSON-string schema, colon-notation access (`result:response:field`), and an explicit "dot notation returns `NULL` on a VARIANT — always use colon" note. *(SKILL.md Quick Start + `references/1`)*
3. **`ai_extract` version distinction** — added a concise note that the current form (JSON-string schema) is **v2.1 → returns a VARIANT (not a STRUCT)**, vs the legacy `ARRAY(...)` → STRUCT form. *(`references/1`)*
4. **`ai_query` error field** — corrected `.error` → `.errorMessage` (the `failOnError => false` struct is `{response, errorMessage}` per the [ai_query docs](https://docs.databricks.com/aws/en/sql/language-manual/functions/ai_query)). *(SKILL.md + `references/2` + `references/4`)*

**Result (clean re-eval):** all **3 regressing cases now POSITIVE** (`ai_extract`, `ai_parse_document`, `ai_translate` → WITH-skill 1.0); `needs_skill` gaps 5 → 1; positives 22 → 29; L5 Output 0.53 → ~0.58–0.61. Fix #4 (`ai_query` field name) is a docs-confirmed mechanical correction that directly targets the one remaining regression + `needs_skill`.

> Scope: prose only — `SKILL.md` + 3 `references/*.md`. No frontmatter / `name` / `description` change, so `agents/openai.yaml` and `manifest.json` are unaffected. `eval/` artifacts are intentionally not committed (consistent with the rest of the repo).

## Documentation safety checklist

- [x] Examples use least-privilege permissions (no unnecessary `ALL PRIVILEGES`, admin tokens, or broad scopes)
- [x] Elevated permissions are explicitly called out where required
- [x] Sensitive values are obfuscated (placeholder workspace IDs, URLs, no real tokens)
- [x] No insecure patterns introduced (e.g. disabled TLS verification, hardcoded credentials)
