### PR TITLE
skills(experimental): fix Gradio OBO + framework config drift in databricks-apps-python

### DIFF
--- a/experimental/databricks-apps-python/references/3-frameworks.md
+++ b/experimental/databricks-apps-python/references/3-frameworks.md
@@ -45,6 +45,7 @@ app = dash.Dash(
 **Critical**: Always use `@st.cache_resource` for database connections.
 
 ```python
+import os
 import streamlit as st
 from databricks.sdk.core import Config
 from databricks import sql
@@ -56,7 +57,7 @@ def get_connection():
     cfg = Config()
     return sql.connect(
         server_hostname=cfg.host,
-        http_path="/sql/1.0/warehouses/<id>",
+        http_path=f"/sql/1.0/warehouses/{os.getenv('DATABRICKS_WAREHOUSE_ID')}",
         credentials_provider=lambda: cfg.authenticate,
     )
 ```
@@ -93,8 +94,9 @@ cfg = Config()
 
 def predict(message, request: gr.Request):
     user_token = request.headers.get("x-forwarded-access-token")
-    # Query model serving endpoint
-    headers = {**cfg.authenticate(), "Content-Type": "application/json"}
+    # Call the serving endpoint with the USER's token (on-behalf-of) so Unity Catalog
+    # row/column filters are enforced — NOT cfg.authenticate() (the app service-principal token).
+    headers = {"Authorization": f"Bearer {user_token}", "Content-Type": "application/json"}
     resp = requests.post(
         f"https://{cfg.host}/serving-endpoints/my-model/invocations",
         headers=headers,
@@ -130,6 +132,7 @@ demo.launch(server_name="0.0.0.0", server_port=port)
 **Critical**: Deploy with Gunicorn — never use Flask's dev server in production.
 
 ```python
+import os
 from flask import Flask, request, jsonify
 from databricks.sdk.core import Config
 from databricks import sql
@@ -141,12 +144,21 @@ cfg = Config()
 def get_data():
     conn = sql.connect(
         server_hostname=cfg.host,
-        http_path="/sql/1.0/warehouses/<id>",
+        http_path=f"/sql/1.0/warehouses/{os.getenv('DATABRICKS_WAREHOUSE_ID')}",
         credentials_provider=lambda: cfg.authenticate,
     )
     with conn.cursor() as cursor:
         cursor.execute("SELECT * FROM catalog.schema.table LIMIT 10")
         return jsonify(cursor.fetchall())
+```
+
+```yaml
+# app.yaml — deploy with Gunicorn (never the Flask dev server); bind to 0.0.0.0:8000.
+# Pass the warehouse ID via valueFrom so it is never hardcoded in source.
+command: ["gunicorn", "app:app", "-w", "4", "-b", "0.0.0.0:8000"]
+env:
+  - name: DATABRICKS_WAREHOUSE_ID
+    valueFrom: sql-warehouse
 ```
 
 | Detail | Value |
@@ -169,6 +181,7 @@ def get_data():
 **Critical**: Deploy with uvicorn.
 
 ```python
+import os
 from fastapi import FastAPI, Request
 from databricks.sdk.core import Config
 from databricks import sql
@@ -181,7 +194,7 @@ async def get_data(request: Request):
     user_token = request.headers.get("x-forwarded-access-token")
     conn = sql.connect(
         server_hostname=cfg.host,
-        http_path="/sql/1.0/warehouses/<id>",
+        http_path=f"/sql/1.0/warehouses/{os.getenv('DATABRICKS_WAREHOUSE_ID')}",
         access_token=user_token,
     )
     with conn.cursor() as cursor:
@@ -209,6 +222,7 @@ async def get_data(request: Request):
 **Best for**: Full-stack Python apps with reactive UIs, no JavaScript required.
 
 ```python
+import os
 import reflex as rx
 from databricks.sdk.core import Config
 
@@ -221,7 +235,7 @@ class State(rx.State):
         from databricks import sql
         conn = sql.connect(
             server_hostname=cfg.host,
-            http_path="/sql/1.0/warehouses/<id>",
+            http_path=f"/sql/1.0/warehouses/{os.getenv('DATABRICKS_WAREHOUSE_ID')}",
             credentials_provider=lambda: cfg.authenticate,
         )
         with conn.cursor() as cursor:

--- a/experimental/databricks-apps-python/references/5-lakebase.md
+++ b/experimental/databricks-apps-python/references/5-lakebase.md
@@ -40,6 +40,12 @@ env:
       resource: database
 ```
 
+4. Add the Postgres driver to **`requirements.txt`** — `psycopg2`/`asyncpg` are **NOT** pre-installed in the Databricks Apps runtime, so the app crashes on start without it:
+
+```
+psycopg2-binary
+```
+
 ---
 
 ## Connection Patterns


### PR DESCRIPTION
## Summary

Eval-driven improvement of the `databricks-apps-python` (experimental) skill. I ran it through a full SkillForge **L1–L5** evaluation (5 ground-truth cases, WITH-vs-WITHOUT controlled experiment), found a security bug plus a cluster of best-practice failures, traced each to its root cause, and fixed them. Every change reconciles a drifted **reference example** to the skill's own canonical rules + the official Databricks Apps docs — `SKILL.md` itself is untouched.

### Headline fix — Gradio On-Behalf-Of (OBO) auth was broken

`references/3-frameworks.md` read the user's token from `x-forwarded-access-token` but then called the serving endpoint with `{**cfg.authenticate(), ...}` — the **app service-principal token**. So `user_token` was dead code, on-behalf-of identity was never used, and **Unity Catalog row/column security was silently bypassed**. The eval case for this scored **0.0 WITH the skill** (the skill taught the broken pattern). Fixed to call the endpoint with the user's token:

```python
headers = {"Authorization": f"Bearer {user_token}", "Content-Type": "application/json"}
```

### Cluster fix — reference examples drifted from the skill's own MUST rules

| What | Was | Now |
|---|---|---|
| SQL warehouse ID in all 4 framework examples (Streamlit/Flask/FastAPI/Reflex) | hardcoded `"/sql/1.0/warehouses/<id>"` | `f"/sql/1.0/warehouses/{os.getenv('DATABRICKS_WAREHOUSE_ID')}"` (matches `SKILL.md` + `2-app-resources.md`) |
| Flask deployment | gunicorn command only in a side table | added a complete `app.yaml` block (gunicorn, `0.0.0.0:8000`, `valueFrom`) |
| Lakebase | `psycopg2` requirement buried in Common Issues | added the `requirements.txt` (`psycopg2-binary`) step into Setup |

### Result (clean re-eval, `regressions_new == 0`)

| Metric | Before | After | Δ |
|---|---|---|---|
| **L5 Output** | **0.451** | **0.696** | **+0.245** |
| Composite | 0.797 | 0.858 | +0.061 |
| Regressions | 1 | **0** | −1 |
| needs_skill gaps | 26 | 15 | −11 |
| Positives (helping) | 17 | 34 | **+17** |

**L5 per-case (WITH-skill pass rate):**

| Case | Before | After |
|---|---|---|
| `user_auth_token_wrong_framework_header` (Gradio OBO) | 0.00 | **0.90** |
| `flask_gunicorn_dev_server_regression` | 0.27 | **0.91** |
| `hardcoded_warehouse_id_no_valuefrom` | 0.64 (REGRESSION) | **0.91** (no regression) |
| `streamlit_connection_cache_missing` | 0.75 | 0.33 † |
| `lakebase_missing_requirements_txt` | 0.30 | 0.30 |

† `streamlit` is classified NEEDS_SKILL (not a regression; WITH 0.33 > WITHOUT 0.17) and is attributed to L5 grading variance — the `@st.cache_resource` guidance it tests is unchanged. `lakebase` was unchanged this run. Both are follow-ups, not regressions.

> Scope: prose only — `references/3-frameworks.md` + `references/5-lakebase.md`. No frontmatter / `name` / `description` change, so `agents/openai.yaml` and `manifest.json` are unaffected. `eval/` artifacts are intentionally not committed (consistent with the rest of the repo). One ground-truth assertion (`os.getenv('...'` single-quote-only regex on the warehouse case) is over-specific and is being handled separately in the eval, not the skill.

## Documentation safety checklist

- [x] Examples use least-privilege permissions (no unnecessary `ALL PRIVILEGES`, admin tokens, or broad scopes) — the OBO fix uses the **user's** token instead of the broader service-principal token
- [x] Elevated permissions are explicitly called out where required
- [x] Sensitive values are obfuscated (warehouse ID now via `valueFrom`/`os.getenv`, never hardcoded; no real tokens)
- [x] No insecure patterns introduced (the change *removes* a security bug — silent RLS bypass)
