### PR TITLE
ci: add code-freeze check to block non-sync-bot PRs

### DIFF
--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -1,0 +1,37 @@
+name: Code Freeze
+
+# This repository is a read-only mirror. Its contents are synced one-way by an
+# internal Databricks GitHub App. Direct pull requests are not accepted.
+#
+# This check only reports pass/fail. It blocks merges only once it is added as a
+# required status check on the `main` ruleset. The sync apps are bypass actors
+# on that ruleset, so their automated syncs are unaffected.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  merge_group:
+
+permissions: {}
+
+jobs:
+  code-freeze:
+    name: code-freeze
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+    steps:
+      - name: Reject pull requests not from the sync bots
+        if: github.event_name == 'pull_request'
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          case "$PR_AUTHOR" in
+            'databricks-ci-ghec-1[bot]' | 'databricks-ci-ghec-2[bot]')
+              echo "Author '$PR_AUTHOR' is a sync bot. Allowing."
+              exit 0
+              ;;
+          esac
+          echo "::error::This repository is a read-only mirror and is frozen."
+          echo "::error::Direct pull requests are not accepted."
+          exit 1


### PR DESCRIPTION
## Summary

This repository is becoming a read-only mirror, synced one-way by the internal `databricks-ci-ghec-1` / `databricks-ci-ghec-2` GitHub Apps. This adds a `code-freeze` workflow that fails any pull request **not** authored by those sync bots, so direct contributions are rejected.

**Before:** anyone with write access can open and merge PRs.
**Now:** every non-bot PR gets a red `code-freeze` check; the two sync apps pass.

### How it works

- Runs on `pull_request` and `merge_group` (so it reports green to the merge queue and never stalls it).
- Allows `databricks-ci-ghec-1[bot]` and `databricks-ci-ghec-2[bot]`; fails everyone else with a "read-only mirror" message.
- `permissions: {}` (no token scopes needed); it only reads the PR author from the event.

### Enforcement (follow-up)

The workflow only produces a check result. It hard-blocks merges only once `code-freeze` is added as a **required status check** on the `main` ruleset. Both sync apps are already bypass actors on that ruleset, so their syncs are unaffected. Repo admins also retain bypass.

> Note: this PR's own `code-freeze` check will fail (the author is not a sync bot). That is expected. The check is not required yet, so it stays advisory until the ruleset is updated.

## Documentation safety checklist

- [x] Examples use least-privilege permissions (no unnecessary `ALL PRIVILEGES`, admin tokens, or broad scopes)
- [x] Elevated permissions are explicitly called out where required
- [x] Sensitive values are obfuscated (placeholder workspace IDs, URLs, no real tokens)
- [x] No insecure patterns introduced (e.g. disabled TLS verification, hardcoded credentials)

This pull request and its description were written by Isaac.
