### PR TITLE
Teach agent correct Unity Catalog identifier handling

### DIFF
--- a/skills/databricks-core/SKILL.md
+++ b/skills/databricks-core/SKILL.md
@@ -70,6 +70,11 @@ databricks experimental aitools tools query "SELECT * FROM table LIMIT 10" --pro
 databricks experimental aitools tools get-default-warehouse --profile <PROFILE>
 ```
 
+**Names are literal.** Use catalog/schema/table names exactly as given — never change a
+hyphen to an underscore or otherwise normalize them. In SQL, backtick-quote any name part
+with special characters (e.g. `` `my-catalog`.schema.table ``); unquoted hyphens cause a
+parse error.
+
 See [Data Exploration](data-exploration.md) for details.
 
 ## Quick Reference

--- a/skills/databricks-core/data-exploration.md
+++ b/skills/databricks-core/data-exploration.md
@@ -21,10 +21,11 @@ databricks experimental aitools tools discover-schema catalog.schema.table1 cata
 ## Identifier Names & Quoting — Read Before Writing Any Query
 
 **Use catalog, schema, and table names EXACTLY as given.** Never normalize them: do not
-change a hyphen (`-`) to an underscore (`_`), do not change case, and do not add or drop
-characters. `hello-world` and `hello_world` are *different* catalogs — silently
-"fixing" the name produces `NO_SUCH_CATALOG` / `TABLE_OR_VIEW_NOT_FOUND` against an object
-that does not exist.
+change a hyphen (`-`) to an underscore (`_`), and do not add or drop characters.
+`hello-world` and `hello_world` are *different* catalogs — silently "fixing" the name
+produces `NO_SUCH_CATALOG` / `TABLE_OR_VIEW_NOT_FOUND` against an object that does not
+exist. (Case is not significant — Unity Catalog stores names lowercase — but there is no
+reason to alter what you were given.)
 
 **Hyphens and other special characters are valid in Unity Catalog names.** For catalogs,
 only `.`, space, and `/` are disallowed — a hyphen is fine. So a name like `hello-world`
@@ -56,6 +57,12 @@ inside the SQL string of `... tools query "<SQL>"`.
 > Note: legacy `hive_metastore` is stricter than Unity Catalog — table names there allow
 > only alphanumeric ASCII and underscores, so hyphens are not valid even with backticks.
 > This guidance is for Unity Catalog names.
+
+> References (Databricks):
+> [Names](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-names) — allowed
+> characters in catalog/schema/table names ·
+> [SQL identifiers](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-identifiers) —
+> backtick-quoting rules for special characters.
 
 ## Overview
 
@@ -290,11 +297,10 @@ Both commands support:
 
 **Solution**:
 1. Verify table name format: `CATALOG.SCHEMA.TABLE`
-1. **Confirm you did not alter the name** — names are literal. A common failure is
-   normalizing a hyphen to an underscore (`hello-world` → `hello_world`), which points
-   at a catalog that does not exist. See [Identifier Names & Quoting](#identifier-names--quoting--read-before-writing-any-query).
-2. Check if you have read permissions on the table
-3. List available tables:
+2. **Names are literal** — a hyphen is not an underscore; don't normalize it.
+   See [Identifier Names & Quoting](#identifier-names--quoting--read-before-writing-any-query).
+3. Check if you have read permissions on the table
+4. List available tables:
    ```bash
    databricks tables list <catalog> <schema> --profile my-workspace
    ```
@@ -339,13 +345,11 @@ Both commands support:
 
 **Solution**:
 1. Check SQL syntax - use standard SQL
-1. **Backtick-quote identifiers with special characters.** A catalog/schema/table/column
-   name containing a hyphen, space, or other non-`[a-zA-Z0-9_]` character must be wrapped in
-   backticks (e.g. `` `hello-world`.demo ``); unquoted, a hyphen parses as subtraction.
+2. **Backtick-quote special-character identifiers** (`` `hello-world`.demo ``).
    See [Identifier Names & Quoting](#identifier-names--quoting--read-before-writing-any-query).
-2. Verify column names match schema (use discover-schema first)
-3. Ensure proper quoting for string literals
-4. Test query incrementally (start simple, add complexity)
+3. Verify column names match schema (use discover-schema first)
+4. Ensure proper quoting for string literals
+5. Test query incrementally (start simple, add complexity)
 
 ## Best Practices
 

--- a/skills/databricks-core/data-exploration.md
+++ b/skills/databricks-core/data-exploration.md
@@ -18,6 +18,45 @@ databricks experimental aitools tools query \
 databricks experimental aitools tools discover-schema catalog.schema.table1 catalog.schema.table2 --profile <PROFILE>
 ```
 
+## Identifier Names & Quoting — Read Before Writing Any Query
+
+**Use catalog, schema, and table names EXACTLY as given.** Never normalize them: do not
+change a hyphen (`-`) to an underscore (`_`), do not change case, and do not add or drop
+characters. `hello-world` and `hello_world` are *different* catalogs — silently
+"fixing" the name produces `NO_SUCH_CATALOG` / `TABLE_OR_VIEW_NOT_FOUND` against an object
+that does not exist.
+
+**Hyphens and other special characters are valid in Unity Catalog names.** For catalogs,
+only `.`, space, and `/` are disallowed — a hyphen is fine. So a name like `hello-world`
+is a real, legal catalog name; do not assume it "must" be an underscore.
+
+**In SQL, backtick-quote any identifier part that contains a character outside
+`[a-zA-Z0-9_]`** (hyphens, spaces, etc.), per part. Unquoted, `hello-world` is parsed as
+`hello` minus `world`, which is a syntax error. Quote only the parts that need it:
+
+```sql
+-- ❌ Renamed the catalog (hyphen → underscore): catalog does not exist
+SHOW TABLES IN hello_world.demo
+
+-- ❌ Correct name, but unquoted hyphen → PARSE_SYNTAX_ERROR
+SHOW TABLES IN hello-world.demo
+
+-- ✅ Correct name, special-character part backtick-quoted
+SHOW TABLES IN `hello-world`.demo
+
+-- ✅ Fully qualified, each special-character part quoted independently
+SELECT * FROM `hello-world`.demo.items LIMIT 10
+```
+
+**CLI positional arguments are not SQL — pass the literal name, no backticks.** Commands
+like `discover-schema CATALOG.SCHEMA.TABLE` and `tables get CATALOG.SCHEMA.TABLE` take the
+plain name (e.g. `discover-schema hello-world.demo.items`). Backticks belong only
+inside the SQL string of `... tools query "<SQL>"`.
+
+> Note: legacy `hive_metastore` is stricter than Unity Catalog — table names there allow
+> only alphanumeric ASCII and underscores, so hyphens are not valid even with backticks.
+> This guidance is for Unity Catalog names.
+
 ## Overview
 
 The `databricks experimental aitools tools` command group provides tools for data discovery and exploration:
@@ -247,10 +286,13 @@ Both commands support:
 
 ### Table Not Found
 
-**Symptom**: `Error: TABLE_OR_VIEW_NOT_FOUND`
+**Symptom**: `Error: TABLE_OR_VIEW_NOT_FOUND` or `NO_SUCH_CATALOG_EXCEPTION`
 
 **Solution**:
 1. Verify table name format: `CATALOG.SCHEMA.TABLE`
+1. **Confirm you did not alter the name** — names are literal. A common failure is
+   normalizing a hyphen to an underscore (`hello-world` → `hello_world`), which points
+   at a catalog that does not exist. See [Identifier Names & Quoting](#identifier-names--quoting--read-before-writing-any-query).
 2. Check if you have read permissions on the table
 3. List available tables:
    ```bash
@@ -297,6 +339,10 @@ Both commands support:
 
 **Solution**:
 1. Check SQL syntax - use standard SQL
+1. **Backtick-quote identifiers with special characters.** A catalog/schema/table/column
+   name containing a hyphen, space, or other non-`[a-zA-Z0-9_]` character must be wrapped in
+   backticks (e.g. `` `hello-world`.demo ``); unquoted, a hyphen parses as subtraction.
+   See [Identifier Names & Quoting](#identifier-names--quoting--read-before-writing-any-query).
 2. Verify column names match schema (use discover-schema first)
 3. Ensure proper quoting for string literals
 4. Test query incrementally (start simple, add complexity)


### PR DESCRIPTION
## Problem

An agent exploring data against a hyphenated Unity Catalog (e.g. `hello-world`) silently queried the underscore form (`hello_world`) and hit `NO_SUCH_CATALOG_EXCEPTION`. Even after correcting the name, it didn't know the hyphenated name must be backtick-quoted in SQL.

This is a knowledge gap with two stacked consequences:

1. **Name fidelity (the real bug).** The model "repairs" `hello-world` into the legal-looking `hello_world` — a different, non-existent catalog. Backticks don't help this part.
2. **SQL syntax (the corollary).** The correct name contains a hyphen, which is a special character; unquoted, `hello-world` parses as `hello` minus `world`. It must be backtick-delimited: `` `hello-world`.demo ``.

Confirmed against the Databricks SQL [Names](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-names) / [Identifiers](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-identifiers) docs: hyphens **are** valid in Unity Catalog names (only `.`, space, `/` are disallowed for catalogs), special-character identifiers must be backtick-delimited, and Unity Catalog stores object names lowercase (so case is not significant).

## Change

`skills/databricks-core/`:

- **`data-exploration.md`** — the canonical "Identifier Names & Quoting" section holds the full rule **once** (verbatim-name rule first, backticks as the required corollary) with a wrong→right worked example, a note that CLI positional args take the literal name (not SQL), a `hive_metastore` caveat, and links to the Databricks [Names](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-names) / [Identifiers](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-identifiers) docs. The Troubleshooting entries for `TABLE_OR_VIEW_NOT_FOUND`/`NO_SUCH_CATALOG` and `PARSE_SYNTAX_ERROR` are **one-line pointers** to that section, not duplicate explanations. The verbatim-name rule covers hyphen→underscore and add/drop-character normalization; **case is explicitly noted as *not* significant** (Unity Catalog stores names lowercase), so the agent neither "fixes" case nor treats a case difference as a real mismatch.
- **`SKILL.md`** — one-line pointer to the rule.

Existing `samples.*` examples are left unquoted — they have no special characters and are correct as-is.

## Note for rollout

App builders that pin this skills bundle by version/SHA must bump the pinned version for the fix to reach the running agent.

This pull request and its description were written by Isaac.
