### PR TITLE
feat(plugin): add databricks-experimental as a skills-only plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,6 +11,12 @@
       "source": "./",
       "category": "development",
       "description": "Databricks skills for the CLI, Apps, Lakebase, Model Serving, Lakeflow Jobs, Spark Declarative Pipelines, Declarative Automation Bundles (DABs), and classic-to-serverless migration."
+    },
+    {
+      "name": "databricks-experimental",
+      "source": "./experimental",
+      "category": "development",
+      "description": "Experimental Databricks skills: best-effort, unstable content that may change or be removed without notice. Skills only by design; install the stable databricks plugin alongside it for the routing hooks and slash commands."
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,14 @@ changing hook behavior.
 These ship via the plugin marketplace
 (whole-repo source); `databricks aitools install` currently installs skills only.
 
+`experimental/` is also its own **skills-only** plugin (`databricks-experimental`,
+manifest at `experimental/.claude-plugin/plugin.json`, marketplace source
+`./experimental`). Never add hooks or commands under `experimental/`; hooks
+stack across enabled plugins, so they live in the stable plugin only, and
+`scripts/skills.py validate` rejects violations. Both Claude plugin manifests
+share one version, bumped in lockstep by `scripts/bump_version.py` on release.
+See CONTRIBUTING.md ("The experimental plugin is skills-only").
+
 ## Security
 
 When documenting examples, obfuscate sensitive info:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,33 @@ These components ship via the plugin marketplace (the whole repo is the plugin).
 `databricks aitools install` packages `skills/` only today; extending it to
 hooks/commands is CLI-side follow-up work.
 
+### The experimental plugin is skills-only
+
+`experimental/` ships as a second Claude Code plugin, `databricks-experimental`
+(marketplace `source: "./experimental"`, manifest at
+`experimental/.claude-plugin/plugin.json` with `"skills": "./"` because the
+skill dirs sit at the plugin root). The stable plugin is the platform layer;
+this one is a content pack installed alongside it. Policy, enforced by
+`scripts/skills.py validate`:
+
+- **No hooks, ever.** Claude Code runs hooks from every enabled plugin with no
+  shadowing or precedence: a hook here would stack with the stable plugin's on
+  every prompt, session start, or tool call, and experimental-bar code must not
+  run in that always-on hot path. If a hook idea needs incubation, it goes into
+  the stable plugin's `hooks/` behind the normal review bar.
+- **Commands only case by case, never duplicating a stable command.** They are
+  namespaced (`/databricks-experimental:<name>`) so they cannot collide, but
+  near-duplicates of `/databricks:doctor` and friends only confuse. Today there
+  are none, and the validator rejects the directory outright; relaxing that is
+  a deliberate decision, not a drive-by.
+- **Skill names must stay distinct from stable skill names.** Graduation is a
+  pure file move (`experimental/<name>/` to `skills/<name>/` in one PR, shipped
+  atomically in one release); manifest generation already rejects a name
+  present in both trees.
+- **One version for both plugins.** `scripts/bump_version.py` bumps the stable,
+  Cursor, and experimental manifests in lockstep on release; the validator
+  rejects skew between the two Claude plugin manifests.
+
 ## Security
 
 Please see [SECURITY](./SECURITY) for vulnerability reporting guidelines.
@@ -98,8 +125,9 @@ Releases are cut by the **Release** workflow (`.github/workflows/release.yml`),
 triggered manually (`workflow_dispatch`) with a `vX.Y.Z` tag. The workflow:
 
 1. Runs `scripts/bump_version.py <version>`, which sets the `version` field in
-   both `.claude-plugin/plugin.json` and `.cursor-plugin/plugin.json` to the
-   release version and regenerates `manifest.json`.
+   `.claude-plugin/plugin.json`, `.cursor-plugin/plugin.json`, and
+   `experimental/.claude-plugin/plugin.json` to the release version and
+   regenerates `manifest.json`.
 2. Commits the bump to `main`.
 3. Creates an annotated `vX.Y.Z` tag (`git tag -a`) at that commit, pushes it,
    then creates the GitHub release (`gh release create --verify-tag`).

--- a/README.md
+++ b/README.md
@@ -30,12 +30,20 @@ For finer control, use the `aitools skills install` subcommand directly — it
 accepts a positional skill name and an `--experimental` flag (see the
 [Experimental Skills](#experimental-skills) section).
 
-**Via the Claude Code plugin marketplace** (stable skills only — installs every
-skill under [`./skills/`](./skills/)):
+**Via the Claude Code plugin marketplace** (installs every stable skill under
+[`./skills/`](./skills/), plus the plugin's commands and hooks):
 
 ```text
 /plugin marketplace add databricks/databricks-agent-skills
 /plugin install databricks@databricks-agent-skills
+```
+
+Experimental skills are a separate, optional plugin on the same marketplace
+(all-or-nothing, skills-only, unstable; see
+[Experimental Skills](#experimental-skills)):
+
+```text
+/plugin install databricks-experimental@databricks-agent-skills
 ```
 
 **Via the Cursor plugin marketplace:**
@@ -49,14 +57,14 @@ skill under [`./skills/`](./skills/)):
 | | CLI | Plugin marketplace |
 |---|---|---|
 | Stable skills | ✅ (default) | ✅ |
-| Experimental skills | ✅ (with `--experimental` or by name) | ❌ |
-| Per-skill selection | ✅ (`databricks aitools install <name>`) | ❌ (all-or-nothing) |
-| Commands & hooks | ❌ (skills only today, see below) | ✅ |
+| Experimental skills | ✅ (with `--experimental` or by name) | ✅ (`databricks-experimental` plugin, Claude Code only) |
+| Per-skill selection | ✅ (`databricks aitools install <name>`) | ❌ (all-or-nothing per plugin) |
+| Commands & hooks | ❌ (skills only today, see below) | ✅ (stable plugin) |
 | Updates | `databricks aitools update` | Plugin marketplace update flow |
 | Required outside the agent | Databricks CLI v1.0.0+ | None |
 
-If in doubt, use the CLI — it's the canonical install path and the only one that
-exposes experimental skills.
+If in doubt, use the CLI: it's the canonical install path and the only one with
+per-skill selection.
 
 ## Available Skills
 
@@ -87,6 +95,13 @@ originally imported from
   Pass `--experimental` to install all of them, or install a specific one
   by name (with the `--experimental` flag — e.g. `databricks aitools install
   databricks-iceberg --experimental`).
+- On Claude Code they are also available as a separate plugin:
+  `/plugin install databricks-experimental@databricks-agent-skills`
+  (all-or-nothing). The plugin is **skills-only by design**: hooks and
+  commands ship only with the stable `databricks` plugin, so the two never
+  conflict. Install it alongside the stable plugin, not instead of it. It is
+  listed only on this repo's self-hosted marketplace, never on Anthropic's
+  community or official listings.
 - See [`experimental/README.md`](./experimental/README.md) for the full list
   and caveats.
 
@@ -125,6 +140,11 @@ skills, not commands, so they aren't duplicated here.)
 - **Auth-failure hint** (PostToolUse on Bash): when a `databricks` command fails
   with an auth-shaped error, adds one line suggesting `/databricks:doctor` or
   `databricks auth login` before retrying. Never blocks or rewrites commands.
+
+The `databricks-experimental` plugin deliberately ships none of these: the
+stable plugin is the platform layer (routing, context, auth hints, commands)
+for both, and Claude Code runs hooks from every enabled plugin, so a second
+copy would fire alongside the first on every prompt.
 
 > **Distribution parity (follow-up).** The plugin marketplace ships the whole
 > repo (`marketplace.json` `source: "./"`), so commands and hooks come with it.

--- a/experimental/.claude-plugin/plugin.json
+++ b/experimental/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "databricks-experimental",
+  "description": "Experimental Databricks skills: best-effort, unstable content that may change or be removed without notice. Skills only by design; install the stable databricks plugin alongside it for the routing hooks and slash commands.",
+  "version": "0.2.0",
+  "author": {
+    "name": "Databricks",
+    "url": "https://databricks.com"
+  },
+  "homepage": "https://github.com/databricks/databricks-agent-skills",
+  "repository": "https://github.com/databricks/databricks-agent-skills",
+  "license": "LicenseRef-Databricks",
+  "keywords": [
+    "databricks",
+    "experimental"
+  ],
+  "skills": "./"
+}

--- a/experimental/README.md
+++ b/experimental/README.md
@@ -34,6 +34,24 @@ databricks aitools install --experimental
 databricks aitools install databricks-iceberg --experimental
 ```
 
+On Claude Code, they are also available as a plugin (all-or-nothing) from this
+repo's marketplace:
+
+```text
+/plugin marketplace add databricks/databricks-agent-skills
+/plugin install databricks-experimental@databricks-agent-skills
+```
+
+The plugin is **skills-only by design** (manifest at
+[`.claude-plugin/plugin.json`](./.claude-plugin/plugin.json)). The stable
+`databricks` plugin is the platform layer: prompt-routing hooks, the session
+context primer, auth-failure hints, `/databricks:doctor`, and
+`/databricks:setup` all ship there, and this plugin assumes it is installed
+alongside. Never add hooks or commands under `experimental/`: Claude Code runs
+hooks from every enabled plugin with no precedence, so a second copy would
+stack with the stable plugin's on every prompt. `scripts/skills.py validate`
+enforces this (see [CONTRIBUTING.md](../CONTRIBUTING.md)).
+
 See the root [README](../README.md) for details on the stable install path.
 
 ## Available Skills

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python3
 """Bump the plugin manifest versions to a release version + regenerate manifest.
 
-Given a `vX.Y.Z` (or `X.Y.Z`) release version, set the `version` field in both
-`.claude-plugin/plugin.json` and `.cursor-plugin/plugin.json`, then regenerate
-`manifest.json` so the released commit ships a current manifest.
+Given a `vX.Y.Z` (or `X.Y.Z`) release version, set the `version` field in
+`.claude-plugin/plugin.json`, `.cursor-plugin/plugin.json`, and
+`experimental/.claude-plugin/plugin.json`, then regenerate `manifest.json` so
+the released commit ships a current manifest.
 
 Why this exists: Claude Code's plugin marketplace keys updates on the `version`
 field in `.claude-plugin/plugin.json`. If a release ships without bumping that
 field, marketplace clients keep the cached copy and never see the new skills.
 This makes the release tag the single source of truth for the plugin version.
+All plugin manifests move in lockstep (one tag, one version, every plugin);
+`skills.py validate` rejects skew between the stable and experimental plugin.
 
 Run by `.github/workflows/release.yml`. Stdlib-only (no pip), so it runs on the
 protected runner that can't reach pypi.org.
@@ -22,7 +25,7 @@ import skills  # sibling module in scripts/
 
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
 
-# Matches the first `"version": "..."` field. Both manifests carry exactly one
+# Matches the first `"version": "..."` field. Each manifest carries exactly one
 # top-level `version` key, so a targeted in-place replacement keeps the diff to
 # a single line and avoids reformatting the JSON (which a load/dump round-trip
 # would risk).
@@ -31,6 +34,7 @@ VERSION_FIELD_RE = re.compile(r'("version"\s*:\s*")[^"]*(")')
 PLUGIN_MANIFESTS = (
     Path(".claude-plugin") / "plugin.json",
     Path(".cursor-plugin") / "plugin.json",
+    skills.EXPERIMENTAL_PLUGIN_MANIFEST,
 )
 
 

--- a/scripts/skills.py
+++ b/scripts/skills.py
@@ -20,6 +20,13 @@ SHARED_ASSETS = [
 STABLE_REPO_DIR = "skills"
 EXPERIMENTAL_REPO_DIR = "experimental"
 
+# experimental/ also ships as its own Claude Code plugin (marketplace source
+# "./experimental"). See check_experimental_plugin for the policy it must obey.
+EXPERIMENTAL_PLUGIN_NAME = "databricks-experimental"
+EXPERIMENTAL_PLUGIN_MANIFEST = (
+    Path(EXPERIMENTAL_REPO_DIR) / ".claude-plugin" / "plugin.json"
+)
+
 # Stable-skill -> Claude marketplace plugin keyword. Used by
 # check_plugin_manifest to verify .claude-plugin/plugin.json keywords stay
 # aligned with the shipped skills. Descriptions live in each skill's SKILL.md
@@ -449,18 +456,35 @@ def validate_plugin_manifests(repo_root: Path) -> list[str]:
                 "Add it so the Claude marketplace listing stays in sync."
             )
 
-    plugin_name = plugin.get("name")
     market_plugins = marketplace.get("plugins", [])
-    market_entry = next((p for p in market_plugins if p.get("name") == plugin_name), None)
-    if market_entry is None:
-        errors.append(
-            f".claude-plugin/marketplace.json has no entry for plugin '{plugin_name}'."
+
+    # Every plugin served from this repo (the stable plugin at the root, the
+    # experimental plugin at experimental/) needs a marketplace entry whose
+    # description matches its plugin.json, or the two drift independently.
+    manifests = [(plugin, plugin_path)]
+    experimental_path = repo_root / EXPERIMENTAL_PLUGIN_MANIFEST
+    if experimental_path.exists():
+        try:
+            manifests.append(
+                (json.loads(experimental_path.read_text()), experimental_path)
+            )
+        except json.JSONDecodeError:
+            pass  # check_experimental_plugin reports the broken manifest
+    for manifest_obj, manifest_path in manifests:
+        plugin_name = manifest_obj.get("name")
+        market_entry = next(
+            (p for p in market_plugins if p.get("name") == plugin_name), None
         )
-    else:
-        if market_entry.get("description") != plugin.get("description"):
+        if market_entry is None:
             errors.append(
-                ".claude-plugin/marketplace.json plugin description must match "
-                ".claude-plugin/plugin.json description (they drift independently otherwise)."
+                f".claude-plugin/marketplace.json has no entry for plugin '{plugin_name}'."
+            )
+            continue
+        if market_entry.get("description") != manifest_obj.get("description"):
+            errors.append(
+                f".claude-plugin/marketplace.json description for '{plugin_name}' "
+                f"must match {manifest_path.relative_to(repo_root)} "
+                "(they drift independently otherwise)."
             )
 
     return errors
@@ -586,6 +610,134 @@ def check_plugin_components(repo_root: Path) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
+# Experimental plugin (skills-only by policy)
+# ---------------------------------------------------------------------------
+#
+# experimental/ ships as its own Claude Code plugin (databricks-experimental,
+# marketplace source "./experimental") so experimental content installs and
+# updates through the agent just like the stable plugin. It is skills-only BY
+# POLICY, not by omission: Claude Code runs hooks from every enabled plugin
+# with no shadowing or precedence, so any hook here would stack with the
+# stable plugin's hooks on every prompt, session start, or tool call, and
+# experimental-bar code must not run in that always-on hot path. The stable
+# plugin is the platform layer (router, context primer, auth hints, slash
+# commands); this plugin is a content pack that assumes the stable plugin is
+# installed alongside it. Keeping it self-contained also keeps graduation a
+# pure file move (experimental/<name>/ -> skills/<name>/ in one release).
+
+
+def check_experimental_plugin(repo_root: Path) -> list[str]:
+    """Validate the experimental plugin manifest and its skills-only policy.
+
+    - experimental/.claude-plugin/plugin.json must exist, parse, and be named
+      EXPERIMENTAL_PLUGIN_NAME (the marketplace entry points at it)
+    - it must declare "skills": "./": the skill dirs sit at the plugin root
+      (there is no experimental/skills/), so without the field the plugin
+      silently ships zero skills
+    - it must NOT declare hooks/commands/agents/mcpServers, and no
+      experimental/hooks/ or experimental/commands/ dirs may exist (see the
+      skills-only policy comment above)
+    - its "version" must equal the stable plugin's: scripts/bump_version.py
+      bumps both in lockstep on release, so a mismatch means one side was
+      hand-edited
+    - its marketplace entry must use source "./experimental"
+
+    Returns a list of error strings (empty means all good).
+    """
+    errors: list[str] = []
+
+    manifest_path = repo_root / EXPERIMENTAL_PLUGIN_MANIFEST
+    if not manifest_path.exists():
+        return [
+            f"Missing {EXPERIMENTAL_PLUGIN_MANIFEST} (the marketplace entry "
+            f"'{EXPERIMENTAL_PLUGIN_NAME}' points at experimental/, so the "
+            "manifest must exist)."
+        ]
+    try:
+        plugin = json.loads(manifest_path.read_text())
+    except json.JSONDecodeError as exc:
+        return [f"{EXPERIMENTAL_PLUGIN_MANIFEST} is not valid JSON: {exc}"]
+
+    if plugin.get("name") != EXPERIMENTAL_PLUGIN_NAME:
+        errors.append(
+            f"{EXPERIMENTAL_PLUGIN_MANIFEST} must be named "
+            f"'{EXPERIMENTAL_PLUGIN_NAME}', got {plugin.get('name')!r}."
+        )
+
+    declared_skills = plugin.get("skills")
+    declared_list = (
+        [declared_skills] if isinstance(declared_skills, str) else declared_skills
+    )
+    if not isinstance(declared_list, list) or not any(
+        isinstance(p, str) and _norm_rel_path(p) in ("", ".") for p in declared_list
+    ):
+        errors.append(
+            f'{EXPERIMENTAL_PLUGIN_MANIFEST} must declare "skills": "./" so the '
+            "skill directories at the plugin root (experimental/<name>/) are "
+            "scanned; there is no experimental/skills/, so without it the "
+            "plugin ships zero skills."
+        )
+
+    for forbidden_key in ("hooks", "commands", "agents", "mcpServers"):
+        if forbidden_key in plugin:
+            errors.append(
+                f"{EXPERIMENTAL_PLUGIN_MANIFEST} declares '{forbidden_key}'. The "
+                "experimental plugin is skills-only by policy; that "
+                "infrastructure belongs in the stable plugin (see the comment "
+                "above check_experimental_plugin)."
+            )
+    for forbidden_dir in ("hooks", "commands", "agents"):
+        if (repo_root / EXPERIMENTAL_REPO_DIR / forbidden_dir).exists():
+            errors.append(
+                f"experimental/{forbidden_dir}/ exists. The experimental plugin "
+                "is skills-only by policy; hooks and commands belong to the "
+                "stable plugin (see the comment above check_experimental_plugin)."
+            )
+
+    stable_path = repo_root / ".claude-plugin" / "plugin.json"
+    try:
+        stable = json.loads(stable_path.read_text()) if stable_path.exists() else {}
+    except json.JSONDecodeError:
+        stable = {}  # validate_plugin_manifests reports the broken manifest
+    stable_version = stable.get("version")
+    if stable_version and plugin.get("version") != stable_version:
+        errors.append(
+            f"Version skew: .claude-plugin/plugin.json is {stable_version!r} "
+            f"but {EXPERIMENTAL_PLUGIN_MANIFEST} is {plugin.get('version')!r}. "
+            "scripts/bump_version.py bumps both in lockstep on release; they "
+            "must match."
+        )
+
+    marketplace_path = repo_root / ".claude-plugin" / "marketplace.json"
+    try:
+        marketplace = (
+            json.loads(marketplace_path.read_text())
+            if marketplace_path.exists()
+            else {}
+        )
+    except json.JSONDecodeError:
+        marketplace = {}  # validate_plugin_manifests reports the broken manifest
+    entry = next(
+        (
+            p
+            for p in marketplace.get("plugins", [])
+            if p.get("name") == EXPERIMENTAL_PLUGIN_NAME
+        ),
+        None,
+    )
+    if entry is not None and _norm_rel_path(entry.get("source", "")) != _norm_rel_path(
+        f"./{EXPERIMENTAL_REPO_DIR}"
+    ):
+        errors.append(
+            f"marketplace.json entry '{EXPERIMENTAL_PLUGIN_NAME}' must use "
+            f'"source": "./{EXPERIMENTAL_REPO_DIR}", got '
+            f"{entry.get('source')!r}."
+        )
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -659,6 +811,17 @@ def main() -> None:
                     file=sys.stderr,
                 )
                 for err in component_errors:
+                    print(f"  - {err}", file=sys.stderr)
+                ok = False
+
+            experimental_errors = check_experimental_plugin(repo_root)
+            if experimental_errors:
+                print(
+                    "ERROR: experimental plugin (experimental/.claude-plugin/) "
+                    "is misconfigured:",
+                    file=sys.stderr,
+                )
+                for err in experimental_errors:
                     print(f"  - {err}", file=sys.stderr)
                 ok = False
 


### PR DESCRIPTION
> **Stacked on #128.** Base is `simonfaltum/plugin-hooks-commands`; only the last commit is new here. Merge #128 first, then retarget this to `main`.

## Why

Experimental skills are installable today only through the CLI's files overlay (`databricks aitools install --experimental`), so they never get the out-of-band updates the plugin channel provides, and graduating a skill to stable leaves CLI users with duplicate copies to clean up. The aitools plugin-first proposal moves experimental content to its own plugin in this repo's marketplace so the agent keeps it updated and graduation becomes a pure file move.

The plugin is deliberately **skills-only**, and that is a policy, not a gap: Claude Code runs hooks from every enabled plugin with no shadowing or precedence, so any hook shipped here would stack with the stable plugin's hooks (#128) on every prompt, session start, and tool call. The stable `databricks` plugin is the platform layer (prompt router, context primer, auth hints, slash commands); `databricks-experimental` is a content pack that assumes the stable plugin is installed alongside it. This also means weekly-churn experimental code never runs in the always-on hook hot path.

## Changes

Before: one plugin (`databricks`) in the marketplace; experimental skills reachable only via the CLI files overlay. Now: a second plugin, `databricks-experimental`, in the same self-hosted marketplace.

- `.claude-plugin/marketplace.json`: second entry, `source: "./experimental"`.
- `experimental/.claude-plugin/plugin.json` (new): name `databricks-experimental`, `"skills": "./"` (the skill dirs sit directly at the plugin root; there is no `experimental/skills/`), version `0.2.0` in lockstep with the stable manifest, and a description that states the content is unstable and may change or be removed.
- `scripts/skills.py`: new `check_experimental_plugin` in `validate` enforces the policy: manifest exists, parses, correct name, `"skills": "./"` present (without it the plugin silently ships zero skills), no `hooks`/`commands`/`agents`/`mcpServers` keys and no `experimental/hooks|commands|agents` dirs, version lockstep with the stable manifest, marketplace source correct. Marketplace description sync now covers both plugins.
- `scripts/bump_version.py`: the release bump now sets the experimental manifest too, so one tag means one version across all plugin manifests.
- Docs: README (marketplace install for both plugins, updated CLI vs marketplace table), `experimental/README.md` (plugin install + the skills-only rule), CONTRIBUTING ("The experimental plugin is skills-only" policy section, release step update), CLAUDE.md.

Notes:

- The plugin stays on this repo's self-hosted marketplace only. It is never submitted to Anthropic's community or official listings; the stable plugin is the candidate for those.
- Skill-name collisions between `skills/` and `experimental/` are already rejected at manifest generation, which keeps graduation atomic. Users who update the two plugins at different times can briefly see a graduated skill twice (namespaced `databricks:<name>` and `databricks-experimental:<name>`); updating both plugins resolves it, and `aitools update` on the plugin channel will do that in one go (CLI-side work, tracked in the aitools plugin-first proposal).
- An explicit `version` field pins marketplace updates to release bumps, matching the stable plugin's release-gated model (omitting it would make every commit to `main` an update, which conflicts with release gating).

## Test plan

- [x] `python3 scripts/skills.py validate` passes
- [x] Negative tests: validator rejects an `experimental/hooks/` dir and a version skew between the two manifests (verified manually, then reverted)
- [x] `python3 scripts/bump_version.py v0.2.0` smoke test: reports all three manifests, regenerates manifest.json as a no-op (cursor side effect reverted; the release workflow owns that bump)
- [x] `claude plugin validate` passes on both the plugin manifest and the marketplace manifest
- [x] Real install in an isolated `CLAUDE_CONFIG_DIR`: `claude plugin marketplace add <repo>` + `claude plugin install databricks-experimental@databricks-agent-skills` run headlessly with no prompts; `claude plugin details` shows all 17 experimental skills, 0 hooks, 0 commands, ~1.7k always-on tokens
- [x] Stable plugin installed alongside in the same config: inventory unchanged (skills + 2 commands + 3 hooks, no experimental leakage), both plugins coexist
- [x] All hook test suites still pass (router 16, context 11, auth-helper 8)

This pull request and its description were written by Isaac.
