### PR TITLE
Add warehouse mutations guide and sharpen app data-path docs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -64,6 +64,7 @@
         "references/appkit/proto-contracts.md",
         "references/appkit/proto-first.md",
         "references/appkit/sql-queries.md",
+        "references/appkit/warehouse-mutations.md",
         "references/other-frameworks.md",
         "references/platform-guide.md",
         "references/testing.md"

--- a/skills/databricks-apps/SKILL.md
+++ b/skills/databricks-apps/SKILL.md
@@ -13,15 +13,32 @@ parent: databricks-core
 
 Build apps that deploy to Databricks Apps platform.
 
+## Pick your write path first
+
+When the app must **persist or mutate data**, choose the backend before scaffolding or adding routes. Do not default every form to Lakebase or every save to Delta — match where the data must live.
+
+| Need | Write path | Read next |
+|------|------------|-----------|
+| App-owned state (forms, CRUD, todos, sessions) — Postgres is the system of record | Custom route in `onPluginsReady` + `appkit.lakebase.query()` | [Lakebase Guide](references/appkit/lakebase.md) |
+| User action must update an **existing Delta / UC table now** (small scoped DML) | Custom route + `appkit.analytics.query()` with fixed SQL + Zod | [Warehouse Mutations Guide](references/appkit/warehouse-mutations.md) |
+| Large, multi-step, or async lakehouse write (batch ETL, heavy MERGE) | Custom route validates input → `jobs()` plugin runs a job | [Jobs Guide](references/appkit/jobs.md) |
+| App writes Postgres; curated data should appear in Delta **later** (async OK) | Lakebase OLTP write + [Lakehouse Sync](../databricks-lakebase/references/lakehouse-sync.md) (UI-only) | **`databricks-lakebase`** skill |
+| Read-only dashboard / KPI from warehouse | No write path — `config/queries/` + `useAnalyticsQuery` | [SQL Queries Guide](references/appkit/sql-queries.md) |
+
+**If unclear**, ask: *Should this data live in Postgres (app state), in Delta/UC (lakehouse), or run as a background job?*
+
+Route mechanics (Express + `onPluginsReady`) are the same for all mutation paths — see [Custom Endpoints Guide](references/appkit/custom-endpoints.md).
+
 ## Required Reading by Phase
 
 | Phase | READ BEFORE proceeding |
 |-------|------------------------|
-| Scaffolding | **⚠️ STOP — review the State Storage Guidance and complete the Data Access Decision Gate below before scaffolding.** Parent `databricks-core` skill (auth, warehouse discovery); then run `databricks apps manifest` + `databricks apps init` with `--features` and `--set` (see AppKit section below) |
+| Scaffolding | **⚠️ STOP — complete *Pick your write path first* (if the app writes data), State Storage Guidance, and the Data Access Decision Gate below before scaffolding.** Parent `databricks-core` skill (auth, warehouse discovery); then run `databricks apps manifest` + `databricks apps init` with `--features` and `--set` (see AppKit section below) |
 | Writing SQL queries | [SQL Queries Guide](references/appkit/sql-queries.md) |
 | Writing UI components | [Frontend Guide](references/appkit/frontend.md) |
 | Using `useAnalyticsQuery` | [AppKit SDK](references/appkit/appkit-sdk.md) |
 | Adding API endpoints | [Custom Endpoints Guide](references/appkit/custom-endpoints.md) |
+| Writing to Delta / UC tables (warehouse DML) | [Warehouse Mutations Guide](references/appkit/warehouse-mutations.md) |
 | Using Lakebase (OLTP database) | [Lakebase Guide](references/appkit/lakebase.md) |
 | Adding Genie chat / Genie-powered apps | [Genie Guide](references/appkit/genie.md) — follow the Genie agent workflow below |
 | Using Model Serving (ML inference) | [Model Serving Guide](references/appkit/model-serving.md) |
@@ -63,11 +80,17 @@ Before writing any SQL, use the parent `databricks-core` skill for data explorat
 
 **State Storage Guidance (evaluate BEFORE the Decision Gate):**
 
-If the user's app description involves storing or persisting data — forms, CRUD operations, user submissions, orders, todos, or other user-generated content — the app likely needs a Lakebase database.
+If the user's app description involves storing or persisting data — forms, CRUD operations, user submissions, orders, todos, or other user-generated content — use *Pick your write path first* above. **Lakebase is the default for app-owned OLTP state**, but Delta DML or Jobs may be correct if the user needs writes to land in Unity Catalog or run asynchronously.
 
-1. **Ask the user** whether the app needs persistent storage (Lakebase) before scaffolding. Do not silently add Lakebase.
-2. If confirmed, use the **`databricks-lakebase`** skill to create a Lakebase project and obtain the branch and database resource names.
-3. Scaffold with `--features lakebase` and pass `--set lakebase.postgres.branch=<BRANCH_NAME> --set lakebase.postgres.database=<DATABASE_NAME>`.
+1. **Ask the user** where writes must land (Postgres app state vs Delta/UC table vs background job) before scaffolding. Do not silently add Lakebase or warehouse DML.
+2. If Lakebase is chosen, use the **`databricks-lakebase`** skill to create a Lakebase project and obtain resource names.
+3. Run `databricks apps manifest --profile <PROFILE>` and derive **all three** required Lakebase `--set` fields from the `lakebase` plugin's `postgres` resource (`project`, `branch`, `database` — do not guess keys or omit `project`):
+   ```bash
+   --set lakebase.postgres.project=<PROJECT_NAME> \
+   --set lakebase.postgres.branch=<BRANCH_NAME> \
+   --set lakebase.postgres.database=<DATABASE_NAME>
+   ```
+   Values are full resource paths (e.g. `projects/<id>`, `projects/<id>/branches/<id>`, `projects/<id>/branches/<id>/databases/<id>`). Discover them with `databricks postgres list-projects`, `list-branches`, and `list-databases` — field descriptions in the manifest match those commands.
 4. If the app **also** reads from Unity Catalog tables, proceed to the Data Access Decision Gate below to determine whether to add `--features analytics` or use Lakebase synced tables.
 
 Do NOT add Lakebase to analytics, dashboard, or visualization apps unless the user explicitly requests persistent write-back storage. Read-only data display, filters, and preferences do not require a database.
@@ -103,7 +126,16 @@ After the user chooses:
 
 **DO NOT** write UI code before running typegen — types won't exist and you'll waste time on compilation errors.
 
-**Lakebase apps** (`--features lakebase`): No SQL files or typegen. See [Lakebase Guide](references/appkit/lakebase.md) for the `onPluginsReady` pattern: initialize schema at startup, register Express routes in `server/server.ts`, then build the React frontend.
+**Lakebase apps** (`--features lakebase`):
+
+1. Read [Lakebase Guide](references/appkit/lakebase.md) sections **What the scaffold gives you** and **Lakebase route modules — typing** — the template ships todo CRUD boilerplate and a hand-written `AppKitWithLakebase` interface; replace both. For extracted route modules, use generic `setupXRoutes<T>(appkit: T)` called from `onPluginsReady` — do not add `appkit-types.ts`.
+2. Initialize schema and register CRUD routes in `onPluginsReady` (see [Lakebase Guide](references/appkit/lakebase.md))
+3. Replace scaffold UI (`LakebasePage.tsx`, routes, headings) with your domain — use domain names, not "todo" or "lakebase" in user-facing code
+4. Build the React frontend (fetch `/api/...` routes — **not** `useAnalyticsQuery`)
+5. Update `tests/smoke.spec.ts` selectors to match your UI (do not assert Lakebase-backed empty states during validate — Lakebase is unavailable locally)
+6. Run `databricks apps validate --profile <PROFILE>`
+
+No SQL files or typegen for pure Lakebase CRUD apps.
 
 ## When to Use What
 
@@ -114,6 +146,7 @@ After completing the decision gate above, use this routing table:
 - **Read analytics data → need computation before display**: Still use `useAnalyticsQuery`, transform client-side
 - **Read lakehouse data at low latency (lookups, search, catalogs)**: Use Lakebase synced tables — see [Lakebase Guide](references/appkit/lakebase.md)
 - **Read/write persistent data (users, orders, CRUD state)**: Use Lakebase via Express routes in `onPluginsReady` — see [Lakebase Guide](references/appkit/lakebase.md)
+- **Write to Delta / Unity Catalog tables from the app**: Custom endpoint + `appkit.analytics.query()` — see [Warehouse Mutations Guide](references/appkit/warehouse-mutations.md). Prefer Lakebase or Jobs when those fit better.
 - **Natural language query interface over tables (Genie)**: Use `genie()` plugin — see [Genie Guide](references/appkit/genie.md)
 - **Call ML model endpoint**: Use `serving()` plugin — see [Model Serving Guide](references/appkit/model-serving.md)
 - **Trigger or monitor a Lakeflow Job from the app**: Use the `jobs()` plugin — see [Jobs Guide](references/appkit/jobs.md)
@@ -213,6 +246,38 @@ App names must be lowercase with hyphens only (≤26 chars).
 Databricks Apps supports any framework that runs as an HTTP server. LLMs already know these frameworks — the challenge is Databricks platform integration.
 
 **READ [Other Frameworks Guide](references/other-frameworks.md) BEFORE building any non-AppKit app.** It covers port/host configuration, `app.yaml` and `databricks.yml` setup, dependency management, networking, and framework-specific gotchas.
+
+## Deployment Workflow (FOLLOW THIS ORDER)
+
+⚠️ **USER CONSENT REQUIRED** — always confirm with the user before deploying. See [Platform Guide](references/platform-guide.md) for permissions, destructive updates, and runtime limits.
+
+### First deploy (app does not exist in workspace yet)
+
+A freshly scaffolded app has bundle config but **no workspace app resource** until you deploy the bundle. Running `databricks apps deploy` alone often fails with **app does not exist**.
+
+1. **Register the app resource**: `databricks bundle deploy -t <TARGET> --profile <PROFILE>`
+2. **Deploy code and start the app** (pick one):
+   - **Recommended**: `databricks apps deploy -t <TARGET> --profile <PROFILE>` (validates, uploads, applies config, restarts)
+   - **Alternative**: `databricks bundle run <APP_RESOURCE_NAME> -t <TARGET> --profile <PROFILE>` after `bundle deploy`
+3. **Lakebase OLTP apps only**: after the first successful deploy, the Service Principal owns the schema. Do **not** run `npm run dev` against Lakebase until step 2 succeeds — see [Lakebase Guide](references/appkit/lakebase.md) *Local Development*.
+
+Check whether the app exists: `databricks apps get <APP_NAME> --profile <PROFILE>` — if `active_deployment` is missing, you are still on the first-deploy path.
+
+### Subsequent deploys (app already exists)
+
+1. `databricks apps validate --profile <PROFILE>`
+2. `databricks apps deploy -t <TARGET> --profile <PROFILE>`
+
+`databricks bundle deploy` alone uploads bundle assets but **does not** restart the app or apply all config changes. After `bundle deploy`, also run `databricks apps deploy` or `databricks bundle run <APP_RESOURCE_NAME>`.
+
+### When deploy-first is mandatory vs optional
+
+| App type | Deploy before local dev? |
+|----------|--------------------------|
+| **Lakebase OLTP CRUD** (app creates schema/tables) | **Yes** — SP must create and own the schema |
+| **Lakebase synced-table reads only** | No — synced tables already exist; grant SP `SELECT` after deploy |
+| **Analytics-only** | No — warehouse queries work locally with profile auth |
+| **Hybrid** (analytics + Lakebase CRUD) | **Yes** — because of the CRUD side |
 
 ### Post-Deploy Verification
 

--- a/skills/databricks-apps/references/appkit/custom-endpoints.md
+++ b/skills/databricks-apps/references/appkit/custom-endpoints.md
@@ -1,14 +1,20 @@
 # Custom API Endpoints
 
-**CRITICAL**: Do NOT add custom endpoints for SQL queries or warehouse data retrieval. Use `config/queries/` + `useAnalyticsQuery` instead.
+**CRITICAL**: Do NOT add custom endpoints for warehouse **SELECT** queries or read-only data retrieval. Use `config/queries/` + `useAnalyticsQuery` instead.
 
 **CRITICAL**: Do NOT add custom endpoints for Unity Catalog file operations. Use the Files plugin instead.
 
 When you need server-side logic that no plugin covers, extend the AppKit server in `onPluginsReady` and register Express routes with `appkit.server.extend()`.
 
+**Writes are allowed via custom endpoints** — but pick the right backend first (see parent SKILL.md *Pick your write path first*):
+
+- **Postgres app state** (forms, CRUD, session data) → `appkit.lakebase.query()` — [Lakebase Guide](lakebase.md)
+- **Delta / Unity Catalog DML** (small scoped `INSERT`/`UPDATE`/`DELETE`/`MERGE`) → `appkit.analytics.query()` — [Warehouse Mutations](warehouse-mutations.md)
+- **Large or async lakehouse writes** → [Jobs](jobs.md) plugin
+
 Use custom endpoints ONLY for:
 
-- **Mutations**: Creating, updating, or deleting data (INSERT, UPDATE, DELETE)
+- **Data mutations** — Express routes in `onPluginsReady` using Lakebase or warehouse DML as above (not `useAnalyticsQuery`)
 - **External APIs**: Calling Databricks APIs not covered by a dedicated plugin (MLflow, Workspace API, etc.)
 - **Complex business logic**: Multi-step operations that cannot be expressed in SQL
 - **File processing**: Uploads, processing, transformations (when not covered by the Files plugin)
@@ -44,7 +50,7 @@ databricks apps manifest --profile <PROFILE>
 
 **Key plugins to check for:**
 
-- **analytics** — provides SQL warehouse query execution (do NOT reimplement with custom endpoints)
+- **analytics** — provides SQL warehouse execution: **reads** via `config/queries/` + `useAnalyticsQuery`; **writes** via `appkit.analytics.query()` inside custom mutation routes (see [Warehouse Mutations](warehouse-mutations.md)). Do NOT reimplement SELECT retrieval with custom endpoints.
 - **lakebase** — provides Lakebase plugin for PostgreSQL CRUD (use plugin in routes, don't create raw connections)
 - **genie** — provides Genie AI-powered data exploration (check before building custom natural-language-to-SQL routes)
 - **files** — provides file storage and retrieval helpers (check before writing custom file upload/download routes)
@@ -61,13 +67,23 @@ Read `server/server.ts` to see what routes already exist. Add new handlers insid
 
 ## Server-side Pattern
 
-Register routes inside `onPluginsReady` so plugins are initialized before the server accepts requests:
+Register routes inside `onPluginsReady` so plugins are initialized before the server accepts requests.
+
+**Include the plugins your routes need** — `server()` alone is not enough for warehouse or Lakebase mutations:
+
+| Route purpose | Plugins (minimum) |
+|---------------|-------------------|
+| External Databricks APIs (MLflow, Workspace) | `[server()]` |
+| Delta / UC DML | `[server(), analytics({})]` — see [Warehouse Mutations](warehouse-mutations.md) |
+| Postgres CRUD | `[server(), lakebase()]` — see [Lakebase](lakebase.md) |
+| Trigger Lakeflow Jobs | `[server(), jobs()]` — see [Jobs](jobs.md) |
+
+### Example: external API (no warehouse or Lakebase)
 
 ```typescript
 // server/server.ts
 import { createApp, server } from "@databricks/appkit";
 import { getExecutionContext } from "@databricks/appkit";
-import { z } from "zod";
 
 await createApp({
   plugins: [server()],
@@ -82,23 +98,16 @@ await createApp({
         });
         res.json(response);
       });
-
-      // Example: Mutation
-      app.post("/api/records", async (req, res) => {
-        const parsed = z.object({ name: z.string() }).safeParse(req.body);
-        if (!parsed.success) {
-          res.status(400).json({ error: "Invalid input" });
-          return;
-        }
-        // Custom logic here
-        res.status(201).json({ success: true, id: 123 });
-      });
     });
   },
 });
 ```
 
+Do **not** copy a placeholder mutation that returns fake IDs — real writes must use `appkit.lakebase.query()` or `appkit.analytics.query()` as in [Lakebase Guide](lakebase.md) and [Warehouse Mutations Guide](warehouse-mutations.md).
+
 For Lakebase CRUD routes, schema initialization, and chat persistence, see [Lakebase Guide](lakebase.md).
+
+For Delta / Unity Catalog writes (`INSERT`, `UPDATE`, `DELETE`, `MERGE`), see [Warehouse Mutations Guide](warehouse-mutations.md).
 
 ## Client-side Pattern
 
@@ -119,10 +128,11 @@ function MyComponent() {
   }, []);
 
   const handleCreate = async () => {
-    await fetch("/api/records", {
+    // POST to your mutation route — see Lakebase or Warehouse Mutations guides for server handlers
+    await fetch("/api/books", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: "test" }),
+      body: JSON.stringify({ title: "Example" }),
     });
   };
 
@@ -143,9 +153,10 @@ function MyComponent() {
    - MLflow, Workspace API, other APIs → custom endpoint via `onPluginsReady`
 
 3. **Need to modify data?** → Custom endpoint in `onPluginsReady`
-   - INSERT, UPDATE, DELETE operations
-   - Multi-step transactions
-   - Business logic with side effects
+   - **Delta / UC table (SQL warehouse)** → `appkit.analytics.query()` with fixed SQL + Zod validation — see [Warehouse Mutations](warehouse-mutations.md)
+   - **Postgres app state** → `appkit.lakebase.query()` — see [Lakebase](lakebase.md)
+   - **Large / async lakehouse writes** → `jobs()` plugin — see [Jobs](jobs.md)
+   - Multi-step transactions or business logic with side effects
 
 4. **Need non-SQL custom logic?** → Custom endpoint in `onPluginsReady`
    - File processing
@@ -154,8 +165,9 @@ function MyComponent() {
 
 **Summary:**
 
-- ✅ SQL queries → Visualization components or `useAnalyticsQuery`
+- ✅ SQL **reads** → Visualization components or `useAnalyticsQuery`
+- ✅ Delta / UC **writes** → custom endpoint + `appkit.analytics.query()` — see [Warehouse Mutations](warehouse-mutations.md)
 - ✅ Databricks APIs without a plugin → custom endpoint via `onPluginsReady`
-- ✅ Data mutations → custom endpoint via `onPluginsReady`
-- ❌ SQL warehouse queries → custom endpoints (NEVER do this)
+- ✅ Postgres app mutations → Lakebase routes — see [Lakebase](lakebase.md)
+- ❌ SQL warehouse **SELECT** in custom endpoints (NEVER — use `config/queries/`)
 - ❌ Files operations → custom endpoints (NEVER do this — use Files plugin)

--- a/skills/databricks-apps/references/appkit/lakebase.md
+++ b/skills/databricks-apps/references/appkit/lakebase.md
@@ -16,9 +16,28 @@ Use Lakebase when your app needs **persistent read/write storage** — forms, CR
 
 **Scaffolding is the fastest way to get started.** If you already have an app, see *Adding Lakebase to an Existing App* below.
 
+**Always derive `--set` keys from the manifest** — do not guess field names:
+
+```bash
+databricks apps manifest --profile <PROFILE>
+```
+
+For the `lakebase` plugin, the required `postgres` resource has **three** user-supplied fields: `project`, `branch`, and `database`. All three must appear as `--set` flags — omitting `lakebase.postgres.project` causes init to fail.
+
+Discover values (after creating a project via the `databricks-lakebase` skill):
+
+```bash
+databricks postgres list-projects --profile <PROFILE>                    # → lakebase.postgres.project
+databricks postgres list-branches projects/<PROJECT_ID> --profile <PROFILE>   # → lakebase.postgres.branch
+databricks postgres list-databases projects/<PROJECT_ID>/branches/<BRANCH_ID> --profile <PROFILE>  # → lakebase.postgres.database
+```
+
+Use the `.name` field from each list command as the `--set` value.
+
 **Lakebase only** (no analytics SQL warehouse):
 ```bash
 databricks apps init --name <NAME> --features lakebase \
+  --set "lakebase.postgres.project=<PROJECT_NAME>" \
   --set "lakebase.postgres.branch=<BRANCH_NAME>" \
   --set "lakebase.postgres.database=<DATABASE_NAME>" \
   --run none --profile <PROFILE>
@@ -28,14 +47,13 @@ databricks apps init --name <NAME> --features lakebase \
 ```bash
 databricks apps init --name <NAME> --features analytics,lakebase \
   --set "analytics.sql-warehouse.id=<WAREHOUSE_ID>" \
+  --set "lakebase.postgres.project=<PROJECT_NAME>" \
   --set "lakebase.postgres.branch=<BRANCH_NAME>" \
   --set "lakebase.postgres.database=<DATABASE_NAME>" \
   --run none --profile <PROFILE>
 ```
 
-Where `<BRANCH_NAME>` and `<DATABASE_NAME>` are full resource names (e.g. `projects/<PROJECT_ID>/branches/<BRANCH_ID>` and `projects/<PROJECT_ID>/branches/<BRANCH_ID>/databases/<DB_ID>`).
-
-Use the `databricks-lakebase` skill to create a Lakebase project and discover branch/database resource names before running this command.
+Where `<PROJECT_NAME>`, `<BRANCH_NAME>`, and `<DATABASE_NAME>` are full resource paths (e.g. `projects/<PROJECT_ID>`, `projects/<PROJECT_ID>/branches/<BRANCH_ID>`, `projects/<PROJECT_ID>/branches/<BRANCH_ID>/databases/<DB_ID>`).
 
 > For multi-environment deployments (dev/prod), use `variables:` and `targets:` blocks in `databricks.yml` — see the **`databricks-dabs`** skill for patterns.
 
@@ -43,6 +61,8 @@ Use the `databricks-lakebase` skill to create a Lakebase project and discover br
 
 **Get resource names** (if you have an existing project):
 ```bash
+# List projects → use the name field
+databricks postgres list-projects --profile <PROFILE>
 # List branches → use the name field of a READY branch
 databricks postgres list-branches projects/<PROJECT_ID> --profile <PROFILE>
 # List databases → use the name field
@@ -123,15 +143,116 @@ Deploy the app before local development — see *Local Development > Prerequisit
 ```
 my-app/
 ├── server/
-│   └── server.ts       # Backend with Lakebase plugin + Express routes
-├── client/
-│   └── src/
-│       └── App.tsx     # React frontend
-├── app.yaml            # Manifest with database resource declaration
-└── package.json        # Includes @databricks/lakebase dependency
+│   ├── server.ts                          # Entry — calls setup from onPluginsReady
+│   └── routes/lakebase/
+│       └── todo-routes.ts                 # ⚠️ Starter CRUD — replace for your domain
+├── client/src/
+│   ├── App.tsx                            # Layout + nav (may include /lakebase route)
+│   └── pages/lakebase/
+│       └── LakebasePage.tsx               # ⚠️ Starter todo UI — replace for your domain
+├── tests/smoke.spec.ts                    # ⚠️ Asserts "Todo List" — update for your UI
+├── databricks.yml                         # Lakebase postgres resource wiring
+├── app.yaml                               # Manifest with database resource declaration
+└── package.json                           # Includes @databricks/lakebase dependency
 ```
 
 Note: **No `config/queries/` directory** — Lakebase apps use server-side `appkit.lakebase.query()` calls, not SQL files.
+
+## What the scaffold gives you (replace, don't keep)
+
+`databricks apps init --features lakebase` generates a **working todo list demo**, not your final app. Treat every file below as **starter code to replace** once you know your domain (reading log, inventory, registrations, etc.).
+
+| Scaffold artifact | What it is | What to do |
+|-------------------|------------|------------|
+| `server/routes/lakebase/todo-routes.ts` | Sample CRUD for `app.todos` + hand-written `AppKitWithLakebase` | Rename/replace (e.g. `book-routes.ts`), change table/schema/API paths to your domain |
+| `client/src/pages/lakebase/LakebasePage.tsx` | Todo list UI wired to `/api/lakebase/todos` | Replace with your page (e.g. `ReadingLogPage.tsx`) and your API paths |
+| `client/src/App.tsx` | Generic home page + nav link to `/lakebase` | Simplify or rewire — many CRUD apps use the domain page as `/` |
+| `tests/smoke.spec.ts` | Expects headings like "Todo List" and todo-specific selectors | Update **every** assertion to match your UI before `databricks apps validate` |
+| `AppKitWithLakebase` interface | Local typing workaround in `*-routes.ts` | **Not official AppKit API** — see *Lakebase route modules — typing* below |
+
+**Agent checklist after init:**
+
+1. **Decide your domain** (table name, API prefix, page title) — use domain names in routes and UI (`/api/books`, `BooksPage.tsx`), not "todo" or generic "lakebase" labels in user-facing code.
+2. **Replace backend** — schema (`app.<your_table>`), Zod validators, Express routes under a domain path (e.g. `/api/books`, not `/api/lakebase/todos`).
+3. **Replace frontend** — form, list, filters; point `fetch()` at your new API routes.
+4. **Update smoke tests** — assert your headings, buttons, and stable empty-state copy. Avoid asserting dynamic Lakebase content (e.g. "Your shelf is empty") if validate runs without a live database.
+5. **Remove dead scaffold files** — delete `todo-routes.ts` / `LakebasePage.tsx` after replacement so agents don't copy leftover patterns.
+
+Do **not** ship a custom app that still exposes "Todo List" in the UI or `/api/lakebase/todos` unless the user explicitly asked for a todo app.
+
+## Lakebase route modules — typing
+
+Inside `server.ts`, `onPluginsReady(appkit)` is already fully typed via AppKit's internal `PluginMap<T>` — no manual interface needed:
+
+```typescript
+createApp({
+  plugins: [lakebase(), server()],
+  async onPluginsReady(appkit) {
+    // appkit.lakebase.query(...) and appkit.server.extend(...) are typed here
+    await setupBookRoutes(appkit);
+  },
+});
+```
+
+The scaffold's `AppKitWithLakebase` in `todo-routes.ts` is **not** exported by `@databricks/appkit`. It exists because route setup was split into a separate file and `PluginMap` is not part of the public package exports. Agents often copy it and treat it as required AppKit surface area — **don't**.
+
+### Recommended patterns
+
+**Option A — Inline in `server.ts` (simplest)**
+
+Register schema init and routes directly in `onPluginsReady`. No shared type, no duplicate interface.
+
+**Option B — Extract routes with generic inference (recommended for larger apps)**
+
+Pass `appkit` from `onPluginsReady` into a setup function. TypeScript infers `T` from the call site — no `appkit-types.ts`, no duplicated plugin tuple, no hand-trimmed interface:
+
+```typescript
+// server/routes/lakebase/book-routes.ts
+import type { Application } from "express";
+
+export async function setupBookRoutes<
+  T extends {
+    lakebase: {
+      query(text: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
+    };
+    server: { extend(fn: (app: Application) => void): void };
+  },
+>(appkit: T) {
+  await appkit.lakebase.query("CREATE SCHEMA IF NOT EXISTS app");
+  appkit.server.extend((app) => { /* ... */ });
+}
+```
+
+```typescript
+// server/server.ts — plugins inline; T inferred at the call site
+createApp({
+  plugins: [lakebase(), server()],
+  async onPluginsReady(appkit) {
+    await setupBookRoutes(appkit); // appkit is fully typed here
+  },
+});
+```
+
+Keep `plugins: [lakebase(), server()]` inline in `server.ts` (same array as production). If AppKit later exports `PluginMap` / `AppKitHandle`, prefer that over widening the generic constraint.
+
+**Option C — Minimal local interface (fallback only)**
+
+If generics are not viable, a narrow app-local type is acceptable — rename it (e.g. `RouteSetupContext`) and comment that it is **not** AppKit API. Do **not** add a separate `appkit-types.ts` that re-declares the plugin list.
+
+### Anti-patterns
+
+```typescript
+// ❌ Copy scaffold's AppKitWithLakebase — looks like official API
+interface AppKitWithLakebase { /* ... */ }
+
+// ❌ appkit-types.ts + exported appPlugins tuple — duplicates server.ts, drifts when plugins change
+export const appPlugins = [lakebase(), server()] as const;
+
+// ❌ Double-assert to satisfy a local interface — appkit lint forbids this
+setupBookRoutes(appkit as unknown as AppKitWithLakebase);
+```
+
+Prefer Option A or B. When replacing scaffold routes, **rename** any local interface if you keep Option C — do not leave `AppKitWithLakebase` in a non-todo app.
 
 ## Lakebase Plugin API
 
@@ -213,7 +334,7 @@ await createApp({
 });
 ```
 
-> **Deploy first (App + Lakebase only)!** When your Databricks App uses Lakebase, the Service Principal must create and own the schema. Run `databricks apps deploy` before any local development. See **`databricks-lakebase`** skill's **Schema Permissions for Deployed Apps** for details.
+> **Deploy first (Lakebase OLTP CRUD)!** The Service Principal must create and own the schema before local development. Follow the parent **`databricks-apps`** skill *Deployment Workflow* — first deploy requires `bundle deploy` then `apps deploy`; see **`databricks-lakebase`** skill's **Schema Permissions for Deployed Apps** for the permission model.
 
 ## Schema Initialization
 
@@ -395,8 +516,10 @@ databricks apps get <APP_NAME> --profile <PROFILE>
 
 Check the response for the `active_deployment` field. If it exists with `status.state` of `SUCCEEDED`, the app has been deployed. If `active_deployment` is missing, the app has never been deployed:
 1. **STOP** — do not proceed with local development
-2. Deploy first: `databricks apps deploy <APP_NAME> --profile <PROFILE>`
+2. **First deploy** (app not in workspace): `databricks bundle deploy -t <TARGET> --profile <PROFILE>`, then `databricks apps deploy -t <TARGET> --profile <PROFILE>`
 3. Wait for deployment to complete, then continue
+
+For apps that already have `active_deployment`, use `databricks apps deploy` only. See parent **`databricks-apps`** skill *Deployment Workflow*.
 
 If you skip this step, the Service Principal won't own the database schema. You'll create schemas under your credentials that the SP **cannot access** after deployment. See **`databricks-lakebase`** skill's **Schema Permissions for Deployed Apps** for the full workflow and recovery steps.
 

--- a/skills/databricks-apps/references/appkit/overview.md
+++ b/skills/databricks-apps/references/appkit/overview.md
@@ -9,8 +9,8 @@ Before scaffolding, decide which data pattern the app needs:
 | Pattern | When to use | Init command |
 |---------|-------------|-------------|
 | **Analytics** (read-only) | Dashboards, charts, KPIs from warehouse | `--features analytics --set analytics.sql-warehouse.id=<ID>` |
-| **Lakebase synced tables** (low-latency reads) | Point lookups, entity search, catalogs from lakehouse data | `--features lakebase` (no `--set` flags needed) + sync Delta table via `databricks-lakebase` skill |
-| **Lakebase (OLTP)** (read/write) | CRUD forms, persistent state, user data | `--features lakebase --set lakebase.postgres.branch=<BRANCH> --set lakebase.postgres.database=<DB>` |
+| **Lakebase synced tables** (low-latency reads) | Point lookups, entity search, catalogs from lakehouse data | `--features lakebase` + all three `--set lakebase.postgres.{project,branch,database}=...` (derive from manifest) + sync Delta table via `databricks-lakebase` skill |
+| **Lakebase (OLTP)** (read/write) | CRUD forms, persistent state, user data | `--features lakebase` + `--set lakebase.postgres.project=<PROJECT> --set lakebase.postgres.branch=<BRANCH> --set lakebase.postgres.database=<DB>` (derive from `databricks apps manifest`) |
 | **Genie** (NL queries) | Chat interface over Unity Catalog tables | `--features genie --set genie.<resourceKey>.<field>=<value>` (check manifest) |
 | **Model Serving** (ML inference) | Chat, AI features, model predictions | `--features serving --set serving.serving-endpoint.name=<NAME>` (check manifest) |
 | **Jobs** (trigger Lakeflow Jobs) | Kick off and monitor pre-existing notebooks / Python / SQL / dbt jobs | `--features jobs --set jobs.<resourceKey>.<field>=<JOB_ID>` (check manifest) |
@@ -22,9 +22,9 @@ See [Genie Guide](genie.md) for space creation, plugin setup, and frontend compo
 ## Workflow
 
 1. **Scaffold**: Run `databricks apps manifest`, then `databricks apps init` with `--features` and `--set` as in parent SKILL.md (App Manifest and Scaffolding)
-2. **Develop**: `cd <NAME> && npm install && npm run dev`
-3. **Validate**: `databricks apps validate`
-4. **Deploy**: `databricks apps deploy --profile <PROFILE>` (⚠️ USER CONSENT REQUIRED)
+2. **Validate**: `databricks apps validate --profile <PROFILE>`
+3. **Deploy**: follow parent SKILL.md *Deployment Workflow* — first deploy: `bundle deploy` then `apps deploy`; updates: `apps deploy` (⚠️ USER CONSENT REQUIRED)
+4. **Develop**: `cd <NAME> && npm install && npm run dev` — **Lakebase OLTP CRUD apps**: deploy (step 3) before local dev so the SP owns the schema
 
 ## Data Discovery (Before Writing SQL)
 
@@ -32,15 +32,35 @@ See [Genie Guide](genie.md) for space creation, plugin setup, and frontend compo
 
 ## Pre-Implementation Checklist
 
-Before writing App.tsx, complete these steps:
+Use the checklist that matches your scaffolded `--features`. See parent SKILL.md *Pick your write path first* if you have not chosen read vs write paths yet.
 
-1. ✅ Create SQL files in `config/queries/`
+### Analytics apps (`--features analytics`)
+
+Before writing `App.tsx`:
+
+1. ✅ Create SQL files in `config/queries/` (SELECT only — not DML)
 2. ✅ Run `npm run typegen` to generate query types
 3. ✅ Read `client/src/appKitTypes.d.ts` to see available query result types
-4. ✅ Verify component props via `npx @databricks/appkit docs` (check the relevant component page)
+4. ✅ Verify component props via `npx @databricks/appkit docs`
 5. ✅ Plan smoke test updates (default expects "Minimal Databricks App")
 
 **DO NOT** write UI code until types are generated and verified.
+
+If the app also **writes to Delta/UC**, read [Warehouse Mutations](warehouse-mutations.md) before adding mutation routes.
+
+### Lakebase apps (`--features lakebase`)
+
+Before writing `App.tsx`:
+
+1. ✅ Read [Lakebase Guide](lakebase.md) — *What the scaffold gives you* and *Lakebase route modules — typing*
+2. ✅ Replace scaffold todo boilerplate with your domain routes and UI
+3. ✅ Plan schema init and CRUD routes in `onPluginsReady` (no `config/queries/`, no typegen)
+4. ✅ Plan smoke test updates — do not assert Lakebase-backed dynamic content during validate
+5. ✅ **Lakebase OLTP CRUD**: deploy before local dev so the SP owns the schema (see parent SKILL.md *Deployment Workflow*)
+
+### Hybrid apps (`analytics,lakebase` or similar)
+
+Complete both checklists above: SQL files + typegen for warehouse **reads**; Lakebase routes for Postgres **writes**. Do not use `useAnalyticsQuery` for Lakebase data.
 
 ## Post-Implementation Checklist
 
@@ -48,7 +68,7 @@ Before running `databricks apps validate`:
 
 1. ✅ Update `tests/smoke.spec.ts` heading selector to match your app title
 2. ✅ Update or remove the 'hello world' text assertion
-3. ✅ Verify `npm run typegen` has been run after all SQL files are finalized
+3. ✅ **Analytics reads**: verify `npm run typegen` ran after all SQL files are finalized
 4. ✅ Ensure all numeric SQL values use `Number()` conversion in display code
 
 ## Project Structure
@@ -125,8 +145,8 @@ Do not guess paths — run without args first, then pick from the index.
 | Write SQL files | [SQL Queries](sql-queries.md) — parameterization, dialect, sql.* helpers |
 | Use `useAnalyticsQuery` | [AppKit SDK](appkit-sdk.md) — memoization, conditional queries |
 | Add chart/table components | [Frontend](frontend.md) — component quick reference, anti-patterns |
-| Add API mutation endpoints | [Custom Endpoints](custom-endpoints.md) — only if you need server-side logic |
-| Use Lakebase for CRUD / persistent state | [Lakebase](lakebase.md) — Lakebase plugin API, `onPluginsReady` patterns, schema init |
+| Add API mutation endpoints | [Custom Endpoints](custom-endpoints.md) + [Warehouse Mutations](warehouse-mutations.md) for Delta/UC DML |
+| Use Lakebase for CRUD / persistent state | [Lakebase](lakebase.md) — replace scaffold todo boilerplate, route typing, `onPluginsReady` patterns, schema init |
 | Add Genie chat | [Genie](genie.md) — space creation, plugin setup, frontend components |
 | Call ML model serving endpoints | [Model Serving](model-serving.md) — serving plugin, frontend hooks |
 | Trigger / monitor Lakeflow Jobs from the app | [Jobs](jobs.md) — env discovery, JobHandle API, SSE streaming |
@@ -142,8 +162,17 @@ Do not guess paths — run without args first, then pick from the index.
 
 ## Decision Tree
 
-- **Display data from SQL?**
+- **Display data from SQL warehouse?**
   - Chart/Table → `BarChart`, `LineChart`, `DataTable` components
   - Custom layout (KPIs, cards) → `useAnalyticsQuery` hook
-- **Call Databricks API?** → Dedicated plugin (serving, jobs, files) or custom endpoint via `onPluginsReady`
-- **Modify data?** → Express routes in `onPluginsReady`
+  - **Never** custom endpoints for warehouse SELECT — use [SQL Queries](sql-queries.md)
+- **Call Databricks API?**
+  - Model inference → `serving()` plugin — [Model Serving](model-serving.md)
+  - Trigger/monitor jobs → `jobs()` plugin — [Jobs](jobs.md)
+  - Files in UC Volumes → `files()` plugin — [Files](files.md)
+  - MLflow, Workspace API, other APIs → custom endpoint via `onPluginsReady` — [Custom Endpoints](custom-endpoints.md)
+- **Modify / persist data?** → Custom endpoint in `onPluginsReady` (see parent SKILL.md *Pick your write path first*)
+  - Postgres app state (forms, CRUD) → `appkit.lakebase.query()` — [Lakebase](lakebase.md)
+  - Small scoped Delta/UC DML now → `appkit.analytics.query()` — [Warehouse Mutations](warehouse-mutations.md)
+  - Large / async lakehouse write → validate input, then `jobs()` — [Jobs](jobs.md)
+- **Non-SQL server logic?** → Custom endpoint via `onPluginsReady` — [Custom Endpoints](custom-endpoints.md)

--- a/skills/databricks-apps/references/appkit/overview.md
+++ b/skills/databricks-apps/references/appkit/overview.md
@@ -22,9 +22,11 @@ See [Genie Guide](genie.md) for space creation, plugin setup, and frontend compo
 ## Workflow
 
 1. **Scaffold**: Run `databricks apps manifest`, then `databricks apps init` with `--features` and `--set` as in parent SKILL.md (App Manifest and Scaffolding)
-2. **Validate**: `databricks apps validate --profile <PROFILE>`
-3. **Deploy**: follow parent SKILL.md *Deployment Workflow* — first deploy: `bundle deploy` then `apps deploy`; updates: `apps deploy` (⚠️ USER CONSENT REQUIRED)
-4. **Develop**: `cd <NAME> && npm install && npm run dev` — **Lakebase OLTP CRUD apps**: deploy (step 3) before local dev so the SP owns the schema
+2. **Develop**: `cd <NAME> && npm install`, implement SQL/routes/UI, update `tests/smoke.spec.ts` — use `npm run dev` to iterate (analytics, Genie, serving, etc.)
+3. **Validate**: `databricks apps validate --profile <PROFILE>` — after smoke tests match your UI
+4. **Deploy**: follow parent SKILL.md *Deployment Workflow* — first deploy: `bundle deploy` then `apps deploy`; updates: `apps deploy` (⚠️ USER CONSENT REQUIRED)
+
+**Lakebase OLTP CRUD exception:** Write routes and UI in step 2, but do **not** run `npm run dev` against Lakebase until after the first successful deploy (step 4) — the Service Principal must own the schema first. See [Lakebase Guide](lakebase.md) *Local Development*.
 
 ## Data Discovery (Before Writing SQL)
 
@@ -41,7 +43,7 @@ Before writing `App.tsx`:
 1. ✅ Create SQL files in `config/queries/` (SELECT only — not DML)
 2. ✅ Run `npm run typegen` to generate query types
 3. ✅ Read `client/src/appKitTypes.d.ts` to see available query result types
-4. ✅ Verify component props via `npx @databricks/appkit docs`
+4. ✅ Verify component props via `npx @databricks/appkit docs` (check the relevant component page)
 5. ✅ Plan smoke test updates (default expects "Minimal Databricks App")
 
 **DO NOT** write UI code until types are generated and verified.

--- a/skills/databricks-apps/references/appkit/sql-queries.md
+++ b/skills/databricks-apps/references/appkit/sql-queries.md
@@ -1,8 +1,10 @@
 # SQL Query Files
 
-**IMPORTANT**: ALWAYS use SQL files in `config/queries/` for data retrieval. NEVER add custom endpoints for warehouse SQL queries.
+**IMPORTANT**: ALWAYS use SQL files in `config/queries/` for **data retrieval (SELECT)**. NEVER add custom endpoints for warehouse SELECT queries.
 
-- Store ALL SQL queries in `config/queries/` directory
+For **writes** to Delta / Unity Catalog (`INSERT`, `UPDATE`, `DELETE`, `MERGE`), use custom mutation routes with `appkit.analytics.query()` — see [Warehouse Mutations](warehouse-mutations.md). Do not put DML in `config/queries/` for client-side execution.
+
+- Store all **read** (SELECT) queries in `config/queries/` directory
 - Name files descriptively: `trip_statistics.sql`, `user_metrics.sql`, `sales_by_region.sql`
 - Reference by filename (without extension) in `useAnalyticsQuery` or directly in a visualization component passing it as `queryKey`
 - App Kit automatically executes queries against configured Databricks warehouse

--- a/skills/databricks-apps/references/appkit/warehouse-mutations.md
+++ b/skills/databricks-apps/references/appkit/warehouse-mutations.md
@@ -1,0 +1,208 @@
+# Warehouse Mutations (Delta / Unity Catalog)
+
+Use this guide when an AppKit app must **write to Unity Catalog Delta tables** via the SQL warehouse — `INSERT`, `UPDATE`, `DELETE`, or `MERGE` — in response to a user action.
+
+For **reads** from the warehouse, use [SQL Queries](sql-queries.md) (`config/queries/` + `useAnalyticsQuery`). **Never** add custom endpoints for SELECT.
+
+For **app-owned operational state** (forms, CRUD, session data), prefer [Lakebase](lakebase.md) instead of writing Delta directly from the app.
+
+## Decision gate
+
+Before implementing warehouse DML, confirm this is the right layer:
+
+| Need | Use |
+|------|-----|
+| User form / CRUD / low-latency app state | [Lakebase](lakebase.md) — `appkit.lakebase.query()` |
+| App data must appear in Delta later (async OK) | Lakebase write + [Lakehouse Sync](../../../databricks-lakebase/references/lakehouse-sync.md) (UI-only) |
+| Large / batch / multi-step lakehouse write | [Jobs](jobs.md) — `jobs()` plugin triggers a Lakeflow Job |
+| User action must land in Delta **now**, small scoped DML | **This guide** — custom endpoint + `appkit.analytics.query()` |
+| Read lakehouse data in the UI | [SQL Queries](sql-queries.md) or Lakebase synced tables (read-only) |
+
+**Never write to Lakebase synced tables** — they are read-only replicas of Delta; app writes corrupt sync. See [Lakebase Guide](lakebase.md) *Reading from Synced Tables*.
+
+## How it works
+
+The analytics plugin exposes **server-side** SQL execution via `appkit.analytics.query()` (and `appkit.analytics.asUser(req).query(...)` for on-behalf-of-user). This is separate from the client hook `useAnalyticsQuery`, which is for **read-only** display.
+
+```
+Browser  →  POST /api/your-mutation  →  Express route (Zod validate)
+                                      →  appkit.analytics.query(fixed SQL, params)
+                                      →  SQL warehouse  →  Delta table
+```
+
+**Scaffold with analytics** so the warehouse resource is wired:
+
+```bash
+databricks apps init --name <NAME> --features analytics \
+  --set "analytics.sql-warehouse.id=<WAREHOUSE_ID>" \
+  --run none --profile <PROFILE>
+```
+
+Hybrid apps (read warehouse + write Lakebase, or read SQL files + write Delta) use `--features analytics,lakebase` with all required `--set` flags from `databricks apps manifest`.
+
+## Canonical pattern
+
+Register **one named route per mutation**. Use **fixed SQL** with `:param` placeholders and `sql.*` helpers. Validate input with Zod. **Never** accept arbitrary SQL from the client.
+
+Before writing code, run `npx @databricks/appkit docs ./docs/plugins/analytics.md` on the installed AppKit version and verify `query()` signature and parameter types.
+
+```typescript
+// server/routes/warehouse/feedback-routes.ts
+import { sql } from "@databricks/appkit";
+import { z } from "zod";
+import type { Application, Request } from "express";
+
+const FeedbackBody = z.object({
+  userId: z.string().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().max(2000).optional(),
+});
+
+export function setupFeedbackRoutes<
+  T extends {
+    analytics: {
+      query(
+        statement: string,
+        parameters?: Record<string, ReturnType<typeof sql.string>>,
+      ): Promise<unknown>;
+      asUser: (req: Request) => { query: T["analytics"]["query"] };
+    };
+    server: { extend(fn: (app: Application) => void): void };
+  },
+>(appkit: T) {
+  appkit.server.extend((app) => {
+    app.post("/api/feedback", async (req, res) => {
+      const parsed = FeedbackBody.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ error: "Invalid input" });
+        return;
+      }
+
+      try {
+        await appkit.analytics.query(
+          `INSERT INTO catalog.schema.feedback (user_id, rating, comment, created_at)
+           VALUES (:user_id, :rating, :comment, current_timestamp())`,
+          {
+            user_id: sql.string(parsed.data.userId),
+            rating: sql.int(parsed.data.rating),
+            comment: sql.string(parsed.data.comment ?? ""),
+          },
+        );
+        res.status(201).json({ ok: true });
+      } catch (err) {
+        console.error("Failed to insert feedback:", err);
+        res.status(500).json({ error: "Failed to save feedback" });
+      }
+    });
+  });
+}
+```
+
+```typescript
+// server/server.ts
+import { createApp, analytics, server } from "@databricks/appkit";
+import { setupFeedbackRoutes } from "./routes/warehouse/feedback-routes";
+
+createApp({
+  plugins: [server(), analytics({})],
+  async onPluginsReady(appkit) {
+    setupFeedbackRoutes(appkit);
+  },
+}).catch(console.error);
+```
+
+For typing extracted route modules, see [Lakebase Guide](lakebase.md) *Lakebase route modules — typing* — use the same generic `setupXRoutes<T>(appkit: T)` pattern when `analytics()` is in the plugin list. Do not add `appkit-types.ts` or hand-written `AppKitWith*` interfaces.
+
+## Service principal vs on-behalf-of-user
+
+| Call | Credentials | When to use |
+|------|-------------|-------------|
+| `appkit.analytics.query(...)` | App service principal | System writes, batch ops, trusted server-side validation |
+| `appkit.analytics.asUser(req).query(...)` | End user's Databricks identity | UC row/column policies must apply; user-scoped audit |
+
+OBO requires the deployed app proxy headers (`x-forwarded-user`, `x-forwarded-access-token`). In local dev without those headers, OBO may fall back to SP — verify behavior with `npx @databricks/appkit docs` for your AppKit version.
+
+Grant UC privileges to whichever identity executes the statement (SP client ID from `databricks apps get <APP_NAME>` or the signed-in user).
+
+## Unity Catalog permissions
+
+The app SP (or user, for OBO) needs at minimum:
+
+- `USE CATALOG` on the target catalog
+- `USE SCHEMA` on the target schema
+- `MODIFY` (or table-appropriate write privilege) on the target table
+
+`CAN_USE` on the SQL warehouse is wired via the analytics plugin resource in `databricks.yml`. **Warehouse access does not imply table write access** — verify UC grants separately.
+
+Test with a one-off statement (as the app SP or your user) before wiring the route:
+
+```bash
+databricks experimental aitools tools query \
+  "INSERT INTO catalog.schema.feedback (user_id, rating, comment) VALUES ('test', 5, 'smoke')" \
+  --profile <PROFILE>
+```
+
+## Client-side pattern
+
+Mutations use `fetch` to your custom route — **not** `useAnalyticsQuery`:
+
+```typescript
+await fetch("/api/feedback", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ userId, rating, comment }),
+});
+```
+
+Keep reads on `useAnalyticsQuery` / visualization components; keep writes on POST/PUT/PATCH/DELETE to your mutation routes.
+
+## Anti-patterns
+
+```typescript
+// ❌ NEVER — arbitrary SQL from the client (injection, privilege escalation)
+app.post("/api/sql", async (req, res) => {
+  await appkit.analytics.query(req.body.sql);
+});
+
+// ❌ NEVER — SELECT in a custom endpoint (use config/queries/)
+app.get("/api/items", async (_req, res) => {
+  const rows = await appkit.analytics.query("SELECT * FROM catalog.schema.items");
+  res.json(rows);
+});
+
+// ❌ NEVER — string concatenation with user input
+await appkit.analytics.query(
+  `INSERT INTO t VALUES ('${req.body.name}')`,
+);
+
+// ❌ NEVER — heavy MERGE / large batch in a synchronous request handler
+// Use jobs() plugin instead
+```
+
+## When to use Jobs instead
+
+Prefer the [Jobs](jobs.md) plugin when the write:
+
+- Touches many rows or large partitions
+- Runs multi-statement ETL
+- Should be retried/monitored asynchronously
+- Must not block the HTTP response
+
+Pattern: custom endpoint validates input → `appkit.jobs.run(...)` with parameters → job notebook/SQL task writes Delta.
+
+## Agents plugin note
+
+If you enable the **agents** plugin, built-in `analytics.query` **agent tools** are **read-only** (SELECT-only classifier). That restriction applies to LLM-invoked tools, **not** to your own server routes calling `appkit.analytics.query()` directly. Do not confuse agent tool safety with app mutation routes.
+
+## Validation and testing
+
+- Update `tests/smoke.spec.ts` to assert mutation **UI** (buttons, forms) — not that a Delta row landed (validate runs without live warehouse writes in many setups).
+- `databricks apps validate` checks build/typecheck/lint/smoke — it does **not** prove UC write permissions. Verify grants after deploy.
+- After deploy, confirm with `databricks apps logs <APP_NAME> --follow` if mutations fail at runtime.
+
+## Related guides
+
+- [Custom Endpoints](custom-endpoints.md) — when to add routes vs use plugins
+- [SQL Queries](sql-queries.md) — read path only (`config/queries/`)
+- [Lakebase](lakebase.md) — Postgres CRUD and hybrid read/write patterns
+- [Jobs](jobs.md) — async lakehouse writes

--- a/skills/databricks-apps/references/platform-guide.md
+++ b/skills/databricks-apps/references/platform-guide.md
@@ -105,17 +105,25 @@ env:
 
 ⚠️ **USER CONSENT REQUIRED** — always confirm with the user before deploying.
 
+**Canonical flow** is documented in the parent **`databricks-apps`** skill *Deployment Workflow* (first deploy vs updates, Lakebase deploy-first rules). Summary:
+
 ```bash
-# Option A: single command (recommended) — validates, deploys, and runs
+# First deploy (app not in workspace yet) — bundle deploy registers the app resource
+databricks bundle deploy -t <TARGET> --profile <PROFILE>
 databricks apps deploy -t <TARGET> --profile <PROFILE>
 
-# Option B: step by step
+# Subsequent deploys (app already exists)
+databricks apps deploy -t <TARGET> --profile <PROFILE>
+
+# Alternative step-by-step (updates or first deploy after bundle deploy)
 databricks apps validate --profile <PROFILE>
 databricks bundle deploy -t <TARGET> --profile <PROFILE>
 databricks bundle run <APP_RESOURCE_NAME> -t <TARGET> --profile <PROFILE>
 ```
 
-❌ **Common mistake:** Running only `bundle deploy` and expecting the app to update. Deploy uploads code but does NOT apply config changes or restart the app. Use `databricks apps deploy` or add `bundle run` after `bundle deploy`.
+❌ **Common mistakes:**
+- Running `databricks apps deploy` on a freshly scaffolded app before `bundle deploy` → **app does not exist**
+- Running only `bundle deploy` and expecting the app to update → also run `databricks apps deploy` or `bundle run`
 
 ### ⚠️ Destructive Updates Warning
 

--- a/skills/databricks-lakebase/SKILL.md
+++ b/skills/databricks-lakebase/SKILL.md
@@ -99,9 +99,11 @@ databricks postgres list-databases projects/<PROJECT_ID>/branches/<BRANCH_ID> --
 
 | Value | JSON path | Used for |
 |-------|-----------|----------|
+| Project resource path | `name` (from `list-projects`) | `lakebase.postgres.project` |
+| Branch resource path | `name` (from `list-branches`) | `lakebase.postgres.branch` |
+| Database resource path | `name` (from `list-databases`) | `lakebase.postgres.database` |
 | Endpoint host | `status.hosts.host` | `PGHOST`, `lakebase.postgres.host` |
 | Endpoint resource path | `name` | `LAKEBASE_ENDPOINT`, `lakebase.postgres.endpointPath` |
-| Database resource path | `name` | `lakebase.postgres.database` |
 | PostgreSQL database name | `status.postgres_database` | `PGDATABASE`, `lakebase.postgres.databaseName` |
 
 ### Updating a Project
@@ -178,34 +180,43 @@ databricks postgres reset-branch projects/<PROJECT_ID>/branches/<BRANCH_ID> --pr
 
 ### Build a Databricks App
 
-After creating a project, scaffold a connected Databricks App:
+After creating a project, scaffold a connected Databricks App. **Derive all three `--set` fields from `databricks apps manifest`** — the `lakebase` plugin requires `project`, `branch`, and `database` (omitting `project` fails init):
 
 ```bash
-# 1. Get branch name
+# 0. Confirm required fields (do not guess keys)
+databricks apps manifest --profile <PROFILE>
+
+# 1. Project resource path
+databricks postgres list-projects --profile <PROFILE>
+
+# 2. Branch resource path (use production after create-project)
 databricks postgres list-branches projects/<PROJECT_ID> --profile <PROFILE>
 
-# 2. Get database name
+# 3. Database resource path
 databricks postgres list-databases projects/<PROJECT_ID>/branches/<BRANCH_ID> --profile <PROFILE>
 
-# 3. Scaffold with lakebase feature
+# 4. Scaffold — use .name from each list command
 databricks apps init --name <APP_NAME> --features lakebase \
+  --set "lakebase.postgres.project=<PROJECT_NAME>" \
   --set "lakebase.postgres.branch=<BRANCH_NAME>" \
   --set "lakebase.postgres.database=<DATABASE_NAME>" \
   --run none --profile <PROFILE>
 ```
 
-For the full app workflow, use the **`databricks-apps`** skill.
+For the full app workflow (deploy, local dev, CRUD patterns), use the **`databricks-apps`** skill.
 
 ### Schema Permissions for Deployed Apps
 
 The app's Service Principal has `CAN_CONNECT_AND_CREATE` -- it can create new objects but **cannot access existing schemas**. The SP must create the schema to become its owner.
 
-**ALWAYS deploy the app before running it locally.** This is the #1 source of Lakebase permission errors.
+**ALWAYS deploy the app before running it locally (Lakebase OLTP CRUD apps).** This is the #1 source of Lakebase permission errors.
 
-**Correct workflow:**
-1. **Deploy first**: `databricks apps deploy <APP_NAME> --profile <PROFILE>`
-2. **Grant local access** *(if needed)*: assign `databricks_superuser` via UI (project creators already have access)
-3. **Develop locally**: your credentials get DML access to SP-owned schemas
+**Correct workflow** — see **`databricks-apps`** skill *Deployment Workflow* for the full picture:
+
+1. **First deploy** (app never existed in workspace): `databricks bundle deploy -t <TARGET> --profile <PROFILE>`, then `databricks apps deploy -t <TARGET> --profile <PROFILE>`. `apps deploy` alone on a new scaffold often returns **app does not exist**.
+2. **Subsequent deploys**: `databricks apps deploy -t <TARGET> --profile <PROFILE>`
+3. **Grant local access** *(if needed)*: assign `databricks_superuser` via UI (project creators already have access)
+4. **Develop locally**: your credentials get DML access to SP-owned schemas
 
 **If you already ran locally first** and hit `permission denied`: the schema is owned by your credentials, not the SP. **Do NOT drop the schema without asking the user** -- dropping it deletes all data.
 

--- a/skills/databricks-lakebase/references/pgvector.md
+++ b/skills/databricks-lakebase/references/pgvector.md
@@ -47,21 +47,12 @@ If using a different model (768d or 1536d), change `VECTOR(1024)` to match.
 
 ## Vector Store Module
 
-Create `server/lib/vector-store.ts`:
+Create `server/lib/vector-store.ts`. For typing `appkit` in extracted modules, see the **`databricks-apps`** skill's [Lakebase Guide](../../databricks-apps/references/appkit/lakebase.md) section *Lakebase route modules — typing* — use generic `setupXRoutes<T>(appkit: T)` called from `onPluginsReady`; do not copy scaffold's `AppKitWithLakebase` or add `appkit-types.ts`.
 
 ```typescript
-import type { Application } from "express";
-
-interface AppKitWithLakebase {
-  lakebase: {
-    query(text: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
-  };
-  server: {
-    extend(fn: (app: Application) => void): void;
-  };
-}
-
-export async function setupVectorTables(appkit: AppKitWithLakebase) {
+export async function setupVectorTables<
+  T extends { lakebase: { query(text: string, params?: unknown[]): Promise<unknown> } },
+>(appkit: T) {
   try {
     await appkit.lakebase.query("CREATE EXTENSION IF NOT EXISTS vector");
   } catch (err: unknown) {
@@ -90,7 +81,7 @@ export async function setupVectorTables(appkit: AppKitWithLakebase) {
 }
 
 export async function insertDocument(
-  appkit: AppKitWithLakebase,
+  appkit: AppKit,
   input: { content: string; embedding: number[]; metadata?: Record<string, unknown> },
 ) {
   const result = await appkit.lakebase.query(
@@ -103,7 +94,7 @@ export async function insertDocument(
 }
 
 export async function retrieveSimilar(
-  appkit: AppKitWithLakebase,
+  appkit: AppKit,
   queryEmbedding: number[],
   limit = 5,
 ) {


### PR DESCRIPTION
## Summary

- Add `warehouse-mutations.md` for Delta/UC DML via `appkit.analytics.query()`
- Add "Pick your write path first" table and sharpen data-path guidance in `SKILL.md`
- Expand `lakebase.md` (OLTP vs synced reads, deploy-first, typing patterns)
- Update `custom-endpoints.md`, `overview.md`, `platform-guide.md`, and cross-skill links
- Restore correct workflow order: Scaffold → Develop → Validate → Deploy (Lakebase OLTP exception)

Stacks on `main` after #130 (tRPC → custom endpoints) merged.

## Test plan

- [x] `python3 scripts/skills.py validate`
- [ ] Spot-check: form/CRUD → Lakebase; Delta write → warehouse mutations; dashboard → SQL queries