### PR TITLE
Bump plugin manifests to v0.2.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "databricks",
   "description": "Databricks skills for the CLI, Apps, Lakebase, Model Serving, Lakeflow Jobs, Spark Declarative Pipelines, Declarative Automation Bundles (DABs), and classic-to-serverless migration.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": {
     "name": "Databricks",
     "url": "https://databricks.com"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "databricks-skills",
   "displayName": "Databricks Skills",
   "description": "Databricks skills for CLI, Apps, Unity Catalog, Model Serving, Declarative Automation Bundles (DABs), and more.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": {
     "name": "Databricks"
   },


### PR DESCRIPTION
## Summary

Cuts release **v0.2.3** by bumping the plugin manifest `version` field (Claude Code's marketplace keys cache-busting on this field, so every release must bump it).

- `.claude-plugin/plugin.json`: `0.2.2` → `0.2.3`
- `.cursor-plugin/plugin.json`: `0.2.2` → `0.2.3`
- `manifest.json`: regenerated via `scripts/bump_version.py` (no skill-version changes this round, so it stays byte-identical)

Generated with `python3 scripts/bump_version.py v0.2.3` — the same script `.github/workflows/release.yml` runs.

## Unreleased changes since v0.2.2

- Replace tRPC guidance with `onPluginsReady` custom endpoints (#130)
- Teach agent correct Unity Catalog identifier handling (#131)
- Update agent skills to `55d22d7` (#134)
- Update agent skills to `a07c1dc` (#129)

## Follow-up after merge

- Trigger the **Release** workflow (`.github/workflows/release.yml`, `workflow_dispatch`) with tag `v0.2.3` to create the annotated tag + GitHub release. Its bump step is a no-op since this PR already bumped.
- Update `cli-compat.json` in the CLI repo so `databricks aitools install` resolves to v0.2.3 (per CONTRIBUTING.md).

This pull request and its description were written by Isaac.