### PR TITLE
feat(codex): add Codex plugin manifest, marketplace, and hook wiring

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "databricks-agent-skills",
+  "interface": {
+    "displayName": "Databricks Agent Skills"
+  },
+  "plugins": [
+    {
+      "name": "databricks",
+      "description": "Databricks skills for the CLI, Apps, Lakebase, Model Serving, Lakeflow Jobs, Spark Declarative Pipelines, Declarative Automation Bundles (DABs), and classic-to-serverless migration.",
+      "category": "development",
+      "source": {
+        "source": "local",
+        "path": "./"
+      }
+    }
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "databricks",
+  "description": "Databricks skills for the CLI, Apps, Lakebase, Model Serving, Lakeflow Jobs, Spark Declarative Pipelines, Declarative Automation Bundles (DABs), and classic-to-serverless migration.",
+  "version": "0.2.3",
+  "author": {
+    "name": "Databricks",
+    "url": "https://databricks.com"
+  },
+  "homepage": "https://github.com/databricks/databricks-agent-skills",
+  "repository": "https://github.com/databricks/databricks-agent-skills",
+  "license": "LicenseRef-Databricks",
+  "keywords": [
+    "databricks",
+    "cli",
+    "apps",
+    "lakebase",
+    "model-serving",
+    "jobs",
+    "pipelines",
+    "dabs",
+    "serverless",
+    "vector-search",
+    "data-engineering"
+  ],
+  "skills": "./skills/",
+  "hooks": "./hooks/codex-hooks.json",
+  "interface": {
+    "displayName": "Databricks",
+    "shortDescription": "Databricks skills and hooks for Codex.",
+    "category": "development",
+    "brandColor": "#FF3621",
+    "logo": "./assets/databricks.png",
+    "composerIcon": "./assets/databricks.svg"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ skill under [`./skills/`](./skills/)):
 /add-plugin databricks-skills
 ```
 
+**Via the Codex plugin marketplace:**
+
+```text
+codex plugin marketplace add databricks/databricks-agent-skills
+codex plugin add databricks
+```
+
+The Codex plugin ships the skills plus all three hooks (prompt routing,
+session context, auth-failure hints). Codex hash-pins plugin hooks: run
+`/hooks` once after install (and after each update) to review and enable
+them. Codex has no distributable slash commands, so the setup/doctor
+workflows are reachable through the skills there.
+
 ### CLI vs plugin marketplace
 
 | | CLI | Plugin marketplace |

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -7,6 +7,15 @@ exits 0, so a broken hook never blocks a prompt, session start, or tool call).
 Code auto-loads `hooks/hooks.json`, so it is **not** declared in `plugin.json`
 (declaring the standard path double-loads it and fails the plugin).
 
+`codex-hooks.json` wires the Codex plugin and **is** declared explicitly (as
+`"hooks"` in `.codex-plugin/plugin.json`), because Codex's default plugin hook
+file is `hooks/hooks.json`, the Claude wiring. Codex uses Claude's event names
+and payload/output schema, so all three scripts run unchanged. Script paths
+resolve via the `PLUGIN_ROOT` env var Codex exports to hook processes (with
+`CLAUDE_PLUGIN_ROOT` as fallback; Codex exports both). Codex hash-pins plugin
+hooks: users approve them via `/hooks` after install and after every update,
+and enterprises can pre-trust them through managed `requirements.toml` hooks.
+
 Each hook is pinned by a test file in `tests/` at the repo root; run the whole
 suite with `python3 -m unittest discover -s tests -p '*_test.py'`.
 
@@ -76,6 +85,7 @@ Covered by `tests/databricks_auth_helper_test.py`.
 ## Distribution note
 
 These ship with the Claude Code plugin (the whole repo is the plugin via
-`marketplace.json` `source: "./"`). The Databricks CLI install path
-(`databricks aitools install`) currently packages **skills only**. See the repo
-README for the parity follow-up.
+`marketplace.json` `source: "./"`) and with the Codex plugin (all three hooks
+via `codex-hooks.json`, catalogued in `.agents/plugins/marketplace.json`). The
+Databricks CLI install path (`databricks aitools install`) currently packages
+**skills only**. See the repo README for the parity follow-up.

--- a/hooks/codex-hooks.json
+++ b/hooks/codex-hooks.json
@@ -1,0 +1,36 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/hooks/databricks-router.py\" || python \"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/hooks/databricks-router.py\" || true"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/hooks/databricks-context.py\" || python \"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/hooks/databricks-context.py\" || true"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "(?i)bash|shell|exec",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/hooks/databricks-auth-helper.py\" || python \"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/hooks/databricks-auth-helper.py\" || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Bump the plugin manifest versions to a release version + regenerate manifest.
 
-Given a `vX.Y.Z` (or `X.Y.Z`) release version, set the `version` field in both
-`.claude-plugin/plugin.json` and `.cursor-plugin/plugin.json`, then regenerate
-`manifest.json` so the released commit ships a current manifest.
+Given a `vX.Y.Z` (or `X.Y.Z`) release version, set the `version` field in every
+plugin manifest (`.claude-plugin`, `.cursor-plugin`, `.codex-plugin`), then
+regenerate `manifest.json` so the released commit ships a current manifest.
 
 Why this exists: Claude Code's plugin marketplace keys updates on the `version`
 field in `.claude-plugin/plugin.json`. If a release ships without bumping that
@@ -22,15 +22,16 @@ import skills  # sibling module in scripts/
 
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
 
-# Matches the first `"version": "..."` field. Both manifests carry exactly one
-# top-level `version` key, so a targeted in-place replacement keeps the diff to
-# a single line and avoids reformatting the JSON (which a load/dump round-trip
-# would risk).
+# Matches the first `"version": "..."` field. Every manifest carries exactly
+# one top-level `version` key, so a targeted in-place replacement keeps the
+# diff to a single line and avoids reformatting the JSON (which a load/dump
+# round-trip would risk).
 VERSION_FIELD_RE = re.compile(r'("version"\s*:\s*")[^"]*(")')
 
 PLUGIN_MANIFESTS = (
     Path(".claude-plugin") / "plugin.json",
     Path(".cursor-plugin") / "plugin.json",
+    Path(".codex-plugin") / "plugin.json",
 )
 
 

--- a/scripts/skills.py
+++ b/scripts/skills.py
@@ -585,6 +585,93 @@ def check_plugin_components(repo_root: Path) -> list[str]:
     return errors
 
 
+def check_codex_plugin(repo_root: Path) -> list[str]:
+    """Validate the Codex plugin manifest, marketplace catalog, and hook wiring.
+
+    Codex's default plugin hook file is `hooks/hooks.json`, which is this
+    repo's Claude Code wiring, so `.codex-plugin/plugin.json` must point
+    "hooks" at `hooks/codex-hooks.json` explicitly. The marketplace entry in
+    `.agents/plugins/marketplace.json` becomes load-bearing once users install
+    from it (same never-remove rule as the Claude marketplace).
+    """
+    errors: list[str] = []
+
+    plugin_path = repo_root / ".codex-plugin" / "plugin.json"
+    if not plugin_path.exists():
+        return [f"Missing {plugin_path.relative_to(repo_root)}"]
+    try:
+        plugin = json.loads(plugin_path.read_text())
+    except json.JSONDecodeError as exc:
+        return [f".codex-plugin/plugin.json is not valid JSON: {exc}"]
+
+    if plugin.get("name") != "databricks":
+        errors.append(
+            '.codex-plugin/plugin.json "name" must be "databricks" (the install '
+            "identifier; the marketplace entry and install docs key on it)."
+        )
+
+    claude_path = repo_root / ".claude-plugin" / "plugin.json"
+    try:
+        claude_version = json.loads(claude_path.read_text()).get("version")
+    except Exception:
+        claude_version = None
+    if claude_version and plugin.get("version") != claude_version:
+        errors.append(
+            f'.codex-plugin/plugin.json version ({plugin.get("version")}) must match '
+            f".claude-plugin/plugin.json ({claude_version}); scripts/bump_version.py "
+            "keeps them in sync at release time."
+        )
+
+    skills_rel = plugin.get("skills")
+    if not isinstance(skills_rel, str) or not (repo_root / _norm_rel_path(skills_rel)).is_dir():
+        errors.append(
+            '.codex-plugin/plugin.json "skills" must point at an existing directory.'
+        )
+
+    hooks_rel = plugin.get("hooks")
+    declared = _norm_rel_path(hooks_rel) if isinstance(hooks_rel, str) else ""
+    if declared != "hooks/codex-hooks.json":
+        errors.append(
+            '.codex-plugin/plugin.json must declare "hooks": "./hooks/codex-hooks.json". '
+            "Without it Codex defaults to hooks/hooks.json, the Claude Code wiring."
+        )
+    codex_hooks = repo_root / "hooks" / "codex-hooks.json"
+    if not codex_hooks.exists():
+        errors.append("Missing hooks/codex-hooks.json.")
+    else:
+        try:
+            cfg = json.loads(codex_hooks.read_text())
+        except json.JSONDecodeError as exc:
+            errors.append(f"hooks/codex-hooks.json is not valid JSON: {exc}")
+            cfg = None
+        if cfg is not None:
+            blob = json.dumps(cfg)
+            for script in sorted(set(re.findall(r"hooks/[\w.-]+\.py", blob))):
+                if not (repo_root / script).exists():
+                    errors.append(
+                        f"hooks/codex-hooks.json references '{script}' which does not exist."
+                    )
+
+    market_path = repo_root / ".agents" / "plugins" / "marketplace.json"
+    if not market_path.exists():
+        errors.append(f"Missing {market_path.relative_to(repo_root)}")
+    else:
+        try:
+            market = json.loads(market_path.read_text())
+        except json.JSONDecodeError as exc:
+            errors.append(f".agents/plugins/marketplace.json is not valid JSON: {exc}")
+            market = None
+        if market is not None and not any(
+            p.get("name") == plugin.get("name") for p in market.get("plugins", [])
+        ):
+            errors.append(
+                ".agents/plugins/marketplace.json has no entry for plugin "
+                f"'{plugin.get('name')}'."
+            )
+
+    return errors
+
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -659,6 +746,16 @@ def main() -> None:
                     file=sys.stderr,
                 )
                 for err in component_errors:
+                    print(f"  - {err}", file=sys.stderr)
+                ok = False
+
+            codex_errors = check_codex_plugin(repo_root)
+            if codex_errors:
+                print(
+                    "ERROR: Codex plugin manifests / hooks are misconfigured:",
+                    file=sys.stderr,
+                )
+                for err in codex_errors:
                     print(f"  - {err}", file=sys.stderr)
                 ok = False
 


### PR DESCRIPTION
## Why

Codex now supports the full extension surface this plugin uses on Claude Code: native Agent Skills (same SKILL.md standard, and our per-skill `agents/openai.yaml` files are exactly Codex's skill metadata format), a Claude-compatible hooks system (same event names and payload/output schema), and a plugin + marketplace mechanism. Nothing is published for Codex yet; this PR adds a net-new Codex plugin so Codex users get the skills and all three hooks from this same repo.

## Changes

Before: Codex users could only get skills via `databricks aitools install` file drops. Now: the repo doubles as a Codex marketplace; `codex plugin marketplace add databricks/databricks-agent-skills` + `codex plugin add databricks` installs the 9 skills plus the prompt router, session context primer, and auth-failure hinter.

- `.codex-plugin/plugin.json`: Codex plugin manifest (name `databricks`, matching the Claude plugin), pointing at the shared `skills/` and at `hooks/codex-hooks.json`, with marketplace interface metadata (display name, brand color, icons from `assets/`).
- `.agents/plugins/marketplace.json`: Codex marketplace catalog with the one local-source plugin. Like the Claude marketplace entry, this becomes load-bearing once anyone installs from it: never remove or rename it.
- `hooks/codex-hooks.json`: wires all three existing hook scripts unchanged. Codex hooks use Claude's event names and schemas, so no script changes are needed. The explicit `"hooks"` pointer in plugin.json is load-bearing: Codex's default plugin hook file is `hooks/hooks.json`, which is the Claude Code wiring (auto-loaded there and intentionally not declared). Script paths resolve through the `PLUGIN_ROOT` env var Codex exports to hook processes, with `CLAUDE_PLUGIN_ROOT` as fallback.
- `scripts/bump_version.py`: release bumps now cover the Codex manifest too.
- `scripts/skills.py` validate: new `check_codex_plugin` (manifest valid and named `databricks`, version in sync with the Claude manifest, hooks pointer correct, referenced scripts exist, marketplace entry present).
- `README.md` + `hooks/README.md`: install and trust-flow docs. Codex hash-pins plugin hooks, so users run `/hooks` once after install (and after updates) to enable them.

Codex has no distributable slash commands (custom prompts are deprecated and user-local), so `/databricks:setup` and `/databricks:doctor` have no Codex equivalent in this PR; the skills cover those workflows, and porting them as invocable skills is a follow-up.

## Test plan

- [x] `python3 scripts/skills.py validate` (includes the new Codex checks)
- [x] `python3 -m unittest discover -s tests -p '*_test.py'`
- [ ] Manual verification on Codex CLI (>= 0.137) before announcing: marketplace add + plugin add from a git checkout, `/hooks` trust flow, and that `$PLUGIN_ROOT` resolves in hook command strings (Codex documents the env vars for hook processes; shell-side resolution is the expected execution model but is not explicitly documented).

Notes: the PostToolUse matcher is `(?i)bash|shell|exec` to tolerate tool-name variants; the auth-hinter script itself currently gates on `Bash`, and #138 broadens that gate to the other shell tool names. Trivial adjacent-line conflicts with #138 in `scripts/skills.py` (both add a validate block); resolution is keep both.

This pull request and its description were written by Isaac.
