### PR TITLE
skills(dabs): link official bundle-examples repo

### DIFF
--- a/skills/databricks-dabs/SKILL.md
+++ b/skills/databricks-dabs/SKILL.md
@@ -37,3 +37,8 @@ Load this skill for any request involving:
 4. **Path resolution is critical** - Paths differ based on file location (see Bundle Structure reference)
 5. **Preserve existing structure** - Keep user comments and structure when editing YAML files
 6. **Use variables** - Parameterize catalog, schema, and warehouse for multi-environment support
+
+## Documentation
+
+- [Declarative Automation Bundles](https://docs.databricks.com/dev-tools/bundles/)
+- [Bundle Examples Repository](https://github.com/databricks/bundle-examples) - official end-to-end example bundles (jobs, pipelines, dashboards, apps, and more); use as working references for patterns not covered by the reference files above


### PR DESCRIPTION
## Why

The official [bundle-examples](https://github.com/databricks/bundle-examples) repo is the canonical source of working DAB examples, but the `databricks-dabs` skill never mentions it. Today only `databricks-jobs` links it, which is the wrong home: agents working on bundle configuration load `databricks-dabs`.

## Changes

Adds a `## Documentation` section to `skills/databricks-dabs/SKILL.md` (same convention as `databricks-jobs` and `databricks-serverless-migration`) linking the bundles docs and the bundle-examples repo, with a short note on when to consult it.

## Test plan

- [x] `python3 scripts/skills.py validate` passes

This pull request and its description were written by Isaac.
