### PR TITLE
Bump plugin manifests to v0.2.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "databricks",
   "description": "Databricks skills for the CLI, Apps, Lakebase, Model Serving, Lakeflow Jobs, Spark Declarative Pipelines, Declarative Automation Bundles (DABs), and classic-to-serverless migration.",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "author": {
     "name": "Databricks",
     "url": "https://databricks.com"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "databricks-skills",
   "displayName": "Databricks Skills",
   "description": "Databricks skills for CLI, Apps, Unity Catalog, Model Serving, Declarative Automation Bundles (DABs), and more.",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "author": {
     "name": "Databricks"
   },


### PR DESCRIPTION
## Summary

Cuts release **v0.2.4** by bumping the plugin manifest `version` field (Claude Code's marketplace keys cache-busting on this field, so every release must bump it).

- `.claude-plugin/plugin.json`: `0.2.3` → `0.2.4`
- `.cursor-plugin/plugin.json`: `0.2.3` → `0.2.4`
- `manifest.json`: regenerated via `scripts/bump_version.py` (no skill-version changes this round, so it stays byte-identical)

Generated with `python3 scripts/bump_version.py v0.2.4` — the same script `.github/workflows/release.yml` runs.

## Unreleased changes since v0.2.3

- Add `data-app-design` skill (analytics/BI/AI app design) (#125)
- skills(dabs): link official bundle-examples repo (#142)
- Update agent skills to `9f7ff11` (#141)
- feat(plugin): add prompt-routing hooks and doctor/setup commands (#128)
- Update agent skills to `f7c2fb5` (#137)
- skills(pipelines): tighten databricks-pipelines for correctness and density (#102)

## Follow-up after merge

- Trigger the **Release** workflow (`.github/workflows/release.yml`, `workflow_dispatch`) with tag `v0.2.4` to create the annotated tag + GitHub release. Its bump step is a no-op since this PR already bumped.
- Update `cli-compat.json` in the CLI repo so `databricks aitools install` resolves to v0.2.4 (per CONTRIBUTING.md).

This pull request and its description were written by Isaac.