### PR TITLE
fix(skills): stop dashboard-intent leaking away from databricks-aibi-dashboards

### DIFF
--- a/experimental/databricks-aibi-dashboards/SKILL.md
+++ b/experimental/databricks-aibi-dashboards/SKILL.md
@@ -13,6 +13,8 @@ Create Databricks AI/BI dashboards (formerly Lakeview dashboards).
 A dashboard should be showing something relevant for a human, typically some KPI on the top, and based on the story, some graph (often temporal), and we see "something happens".
 **Follow these guidelines strictly.**
 
+> **When a custom app fits better:** A managed AI/BI dashboard is the right tool for read-only KPIs, charts, and filters over governed tables. If the user instead needs a *custom-code interactive app* — write-back / data entry, bespoke UI or interactions beyond the dashboard grid, embedded or auth-gated workflows, or a conversational Genie/chat assistant as the primary surface — build a Databricks App instead with the `databricks-apps` skill (which brings in `databricks-app-design` for the data-screen UX). Linking an "Ask Genie" space to *this* dashboard stays here (see Linking a Genie Space below).
+
 ## Quick Reference
 
 | Task | Command |
@@ -504,6 +506,7 @@ If the range is very small relative to the scale (e.g., 83-89% on a 0-100 scale)
 
 ## Related Skills
 
+- **[databricks-apps](../../skills/databricks-apps/SKILL.md)** - when the user needs a custom-code interactive app (write-back, bespoke UI, in-app chat / Genie) instead of a managed dashboard
 - **[databricks-unity-catalog](../databricks-unity-catalog/SKILL.md)** - for querying the underlying data and system tables
 - **[databricks-pipelines](../databricks-pipelines/SKILL.md)** - for building the data pipelines that feed dashboards
 - **[databricks-jobs](../databricks-jobs/SKILL.md)** - for scheduling dashboard data refreshes

--- a/manifest.json
+++ b/manifest.json
@@ -46,7 +46,7 @@
       "version": "0.2.0"
     },
     "databricks-app-design": {
-      "description": "Design the UX of Databricks data apps \u2014 dashboards, KPI pages, reports, charts, tables, and Genie/chat data assistants \u2014 mapped to concrete AppKit components.",
+      "description": "Design the UX of custom-code Databricks Apps (AppKit/React) data screens \u2014 KPI/overview pages, reports, charts, tables, and Genie/chat data assistants \u2014 mapped to concrete AppKit components.",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",

--- a/skills/databricks-app-design/SKILL.md
+++ b/skills/databricks-app-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: databricks-app-design
 parent: databricks-apps
-description: "Design the UX of Databricks data apps — dashboards, KPI pages, reports, charts, tables, and Genie/chat data assistants — mapped to concrete AppKit components. Use when BUILDING or reviewing any UI that displays data or answers data questions: choosing genre, layout, charts, KPIs, semantic color, required states (loading/empty/error), IBCS notation, and AI-result trust (showing generated SQL/sources for Genie/chat). NOT for authoring managed AI/BI (Lakeview) dashboards (→ databricks-aibi-dashboards), non-data frontend (forms, settings, auth, marketing), or scaffolding/build/deploy (→ databricks-apps). Complements databricks-apps; use it alongside whenever the app has a dashboard, chart, table, KPI, report, or Genie/chat/AI surface."
+description: 'Design the UX of custom-code Databricks Apps (AppKit/React) data screens — KPI/overview pages, reports, charts, tables, and Genie/chat data assistants — mapped to concrete AppKit components. Use when BUILDING or reviewing the UI of an AppKit/React app that displays data or answers data questions: choosing genre, layout, charts, KPIs, semantic color, required states (loading/empty/error), IBCS notation, and AI-result trust (showing generated SQL/sources for Genie/chat). A plain "create a dashboard" request means a managed AI/BI (Lakeview) dashboard → use databricks-aibi-dashboards, NOT this skill. Also NOT for non-data frontend (forms, settings, auth, marketing) or scaffolding/build/deploy (→ databricks-apps). Complements databricks-apps; use it alongside whenever a custom app has a chart, table, KPI, report, or Genie/chat/AI surface.'
 metadata:
   version: 0.1.0
 ---
@@ -18,8 +18,8 @@ skill merges two bodies of knowledge and binds them to implementation:
 Design advice that doesn't name a real component is incomplete. Always end at a component plan.
 
 ## When to use / when NOT
-- USE for: dashboard/overview/KPI pages, reports, metric/ontology pages, variance analysis, and Genie/NL data surfaces — design *or* critique.
-- Do NOT use for: authoring managed **AI/BI (Lakeview) dashboards** (→ `databricks-aibi-dashboards`), generic frontend (forms, auth, settings, marketing), or scaffolding/build/deploy (→ `databricks-apps`). If a request is "add a form", "deploy this", or "build a Lakeview / AI-BI dashboard", this skill should not fire.
+- USE for: the data screens of a custom-code Databricks App (AppKit/React) — overview/KPI pages, reports, metric/ontology pages, variance analysis, charts, tables, and Genie/NL data surfaces — design *or* critique.
+- Do NOT use for: authoring managed **AI/BI (Lakeview) dashboards** (→ `databricks-aibi-dashboards`), generic frontend (forms, auth, settings, marketing), or scaffolding/build/deploy (→ `databricks-apps`). **A plain "create a dashboard" / "build a dashboard" request (no app / AppKit / React / custom-code signal) means a managed AI/BI (Lakeview) dashboard → use `databricks-aibi-dashboards`, not this skill.** If a request is "add a form", "deploy this", or "build a Lakeview / AI-BI dashboard", this skill should not fire.
 - Relationship: `databricks-apps` builds/runs the app; this skill decides what the data screens should look like and which primitives realize them.
 
 ## Workflow

--- a/skills/databricks-app-design/agents/openai.yaml
+++ b/skills/databricks-app-design/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Databricks App Design"
-  short_description: "Design analytics/BI/AI data app UX, bound to AppKit"
+  short_description: "Design custom-code Databricks App (AppKit/React) data-screen UX"
   icon_small: "./assets/databricks.svg"
   icon_large: "./assets/databricks.png"
   brand_color: "#FF3621"

--- a/skills/databricks-app-design/agents/openai.yaml
+++ b/skills/databricks-app-design/agents/openai.yaml
@@ -4,4 +4,4 @@ interface:
   icon_small: "./assets/databricks.svg"
   icon_large: "./assets/databricks.png"
   brand_color: "#FF3621"
-  default_prompt: "Use $databricks-app-design to design or critique Databricks analytics/BI/AI data app UX (dashboards, KPI pages, reports, Genie surfaces)."
+  default_prompt: "Use $databricks-app-design to design or critique the data screens of a custom-code Databricks App (AppKit/React) — KPI/overview pages, reports, charts, tables, and Genie surfaces."

--- a/skills/databricks-apps/SKILL.md
+++ b/skills/databricks-apps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: databricks-apps
-description: "Build apps on Databricks Apps platform. Use when asked to create dashboards, data apps, analytics tools, or visualizations. Evaluates data access patterns (analytics vs Lakebase synced tables) before scaffolding. Invoke BEFORE starting implementation."
+description: "Build apps on Databricks Apps platform. Use when asked to create data apps, analytics tools, or custom interactive visualizations. A plain \"create a dashboard\" request means a managed AI/BI (Lakeview) dashboard → use databricks-aibi-dashboards, not this skill. Evaluates data access patterns (analytics vs Lakebase synced tables) before scaffolding. Invoke BEFORE starting implementation."
 compatibility: Requires databricks CLI (>= v0.294.0)
 metadata:
   version: "0.1.2"
@@ -11,7 +11,9 @@ parent: databricks-core
 
 **FIRST**: Use the parent `databricks-core` skill for CLI basics, authentication, and profile selection.
 
-**For data UI design (required for any data-displaying app)**: if the app shows ANY data — a dashboard, KPI/overview page, report, chart, table, query results, OR a **conversational / chat / Genie natural-language assistant** — you MUST use the `databricks-app-design` skill (alongside this one) to decide layout, charts, KPIs, semantic color, required states, and AI-result trust, and map them to AppKit components. This includes chat/Genie apps, not just dashboards — if in doubt, use it.
+**Is this even a Databricks App?** Don't assume an app is the only way to show data. For a simple "dashboard with a few charts" and no app-specific need, the managed **AI/BI (Lakeview) dashboard** is the simpler path → use the `databricks-aibi-dashboards` skill, not this one. Reach for a custom Databricks App only when the user needs something AI/BI can't give them — bespoke interactivity/components, write-back, embedded or auth-gated workflows, a Genie/chat surface inside the app — or explicitly asks for an app. If it's genuinely ambiguous, surface both options (managed AI/BI dashboard vs custom app) and let the user choose instead of defaulting to an app. Once an app is the right call, it's fine for this skill to favor an app-based dashboard, and `databricks-app-design` covers building it well.
+
+**For data UI design (required for any data-displaying app)**: once you've confirmed the user wants a custom-code app (not a managed AI/BI dashboard — see above), if the app shows ANY data — a KPI/overview page, report, chart, table, query results, OR a **conversational / chat / Genie natural-language assistant** — you MUST use the `databricks-app-design` skill (alongside this one) to decide layout, charts, KPIs, semantic color, required states, and AI-result trust, and map them to AppKit components. This includes chat/Genie apps, not just static data views — if in doubt, use it.
 
 Build apps that deploy to Databricks Apps platform.
 


### PR DESCRIPTION
## Problem

A routing A/B test (176 headless Claude Code sessions, 6 install conditions, 11 prompts × 3 trials) measured which skill is invoked when `databricks-aibi-dashboards`, `databricks-app-design` ([#125](https://github.com/databricks/databricks-agent-skills/pull/125)), and `databricks-apps` are all installed.

| Install condition | dashboard-intent → aibi |
|---|---|
| aibi alone (baseline) | 12/12 |
| aibi + app-design | 17/18 |
| **realistic bundle** (aibi + app-design + databricks-apps) | **14/18 (78%)** 🚨 |

The fear that `databricks-app-design` "steals" dashboard requests is mostly unfounded head-to-head — its "NOT for Lakeview" disclaimer holds, and explicit "AI/BI"/"Lakeview" phrasing routed correctly 100% of the time. **The real leak is `databricks-apps`**: its description lists "dashboards" as a trigger and its body hard-routes *any* data-displaying app to `databricks-app-design` → AppKit, never mentioning `databricks-aibi-dashboards`. So "sales dashboard with a region filter" went apps → app-design → AppKit in 3/3 trials, and aibi was never even in the consideration set (0 mentions across all funnel transcripts). Ambiguous prompts hit that funnel 8/9 times.

## Fix

- **`databricks-app-design`** — lead the description with "custom-code Databricks Apps (AppKit/React) screens" instead of bare "dashboards, KPI pages…", and add an explicit rule: a plain "create a dashboard" means a managed AI/BI (Lakeview) dashboard → `databricks-aibi-dashboards`. Mirrored in the "When to use / when NOT" section.
- **`databricks-apps`** — drop "dashboards" from the trigger list; add the same deference rule to the description and an "Is this even a Databricks App?" paragraph at the top of the body.
- **Codex metadata** — reword `databricks-app-design/agents/openai.yaml` `default_prompt` so it no longer leads with dashboards (same leak on the OpenAI side).
- Regenerate `manifest.json`.

## Result (validated empirically, not just proposed)

With both edits: dashboard-intent routing → **18/18 (100%)** aibi in the bundle, ambiguous prompts now go to aibi or a clarifying question, and `databricks-app-design` keeps **6/6** of its legitimate app-UX traffic — zero over-correction.

This pull request and its description were written by Isaac.