### PR TITLE
cursor: rename plugin to databricks for /add-plugin databricks

### DIFF
--- a/.cursor-plugin/NOTES.md
+++ b/.cursor-plugin/NOTES.md
@@ -1,29 +1,21 @@
-# Why `name` is `databricks-skills` here (and `databricks` next door)
+# The Cursor plugin `name` is the install identifier
 
-The `name` field in this `plugin.json` is intentionally **`databricks-skills`**, not `databricks`, even though the sibling [`../.claude-plugin/plugin.json`](../.claude-plugin/plugin.json) uses `databricks`. This is **not** a typo or stale value — please do not "fix" it.
+The `name` field in this `plugin.json` is **`databricks`**. It is the
+identifier Cursor uses for `/add-plugin databricks` and for tracking installed
+copies under `~/.cursor/plugins/databricks/`. The marketplace URL slugs
+(`cursor.com/marketplace/databricks`, `cursor.com/marketplace/databricks-apps`)
+are display-only and do not drive the install command.
 
-## Background
+It matches the Claude Code plugin
+([`../.claude-plugin/plugin.json`](../.claude-plugin/plugin.json)) so both
+agents install under the single brand word `databricks`, following the
+github/gitlab/terraform/linear convention.
 
-This plugin has been published on the Cursor marketplace since at least 2026-02-12 (see [cursor.com/marketplace/databricks](https://cursor.com/marketplace/databricks)). Cursor's marketplace assigned two URL slugs that *look* like they should drive the install identifier:
+## Don't change `name` casually
 
-- `cursor.com/marketplace/databricks` — the plugin landing page
-- `cursor.com/marketplace/databricks-apps` — the primary skill's page
-
-…but the **actual install command shown on those pages is `/add-plugin databricks-skills`**. Cursor uses the `name` field from this file as the canonical install identifier — the URL slugs are display-only.
-
-## Why we can't just rename it to `databricks`
-
-Renaming `name` here would change the install identifier Cursor uses to track existing installations under `~/.cursor/plugins/databricks-skills/`. Cursor's update mechanism is undocumented but appears to key on this identifier, so an in-place rename would likely orphan every existing user from auto-updates until they uninstall and reinstall under the new name. Multiple Databricks teams (Field Engineering, Auth Platform, Apps DevEx) have been pointing internal and external customers at the Cursor marketplace listing for months, so the user base is non-trivial.
-
-The Claude Code side has no such constraint — the plugin has never been published to the Anthropic marketplace under any name, so PR #77 freely set the Claude `name` to `databricks` to match the github/gitlab/terraform/linear single-brand-word convention.
-
-## No rename planned
-
-A rename to align the Cursor side with the Claude side (`databricks`) was explicitly closed as not planned ([issue #78](https://github.com/databricks/databricks-agent-skills/issues/78)). The breakage cost to existing installs outweighs the consistency win. The asymmetry is permanent; leave it alone.
-
-## TL;DR for future editors
-
-| File | `name` value | Why |
-|------|--------------|-----|
-| `.claude-plugin/plugin.json` | `databricks` | Fresh submission, no install-base constraint |
-| `.cursor-plugin/plugin.json` | `databricks-skills` | Matches the install ID Cursor users have been using since Feb 2026 |
+Cursor keys installs and auto-updates on this identifier. The plugin shipped as
+`databricks-skills` from its first publish (2026-02) until it was renamed to
+`databricks` alongside a coordinated Cursor-side migration, so existing installs
+kept receiving updates. Any future change carries the same risk and needs the
+same coordination; otherwise it orphans every existing install until users
+reinstall. `scripts/skills.py` enforces the current value.

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "databricks-skills",
+  "name": "databricks",
   "displayName": "Databricks Skills",
   "description": "Databricks skills for CLI, Apps, Unity Catalog, Model Serving, Declarative Automation Bundles (DABs), and more.",
   "version": "0.2.4",

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ skill under [`./skills/`](./skills/)):
 **Via the Cursor plugin marketplace:**
 
 ```text
-/add-plugin databricks-skills
+/add-plugin databricks
 ```
 
 The Cursor plugin ships the skills plus the `databricks-setup` /
@@ -127,7 +127,7 @@ originally imported from
 
 When installed as a Claude Code plugin, the `databricks` plugin adds slash
 commands and three hooks (prompt routing, session context, auth-failure hints)
-on top of the skills. The Cursor plugin (`databricks-skills`) ships the same
+on top of the skills. The Cursor plugin (`databricks`) ships the same
 commands and two of the hooks; see the Cursor note below.
 (These ship via the plugin marketplaces; the CLI `databricks aitools install`
 path installs skills only today; see the note at the end.)

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -112,7 +112,7 @@ These ship with the Claude Code plugin (the whole repo is the plugin via
 auth hinter via `copilot-hooks.json`, catalogued in
 `.github/plugin/marketplace.json`), and with the Codex plugin (all three hooks
 via `codex-hooks.json`, catalogued in `.agents/plugins/marketplace.json`). The
-Cursor marketplace plugin (`databricks-skills`) ships the context primer and
+Cursor marketplace plugin (`databricks`) ships the context primer and
 auth hinter via `cursor-hooks.json`; the router stays Claude-only there. The
 Copilot cloud agent takes no plugins; it only reads hooks vendored into the
 target repo's `.github/hooks/`. The Databricks CLI install path

--- a/scripts/skills.py
+++ b/scripts/skills.py
@@ -622,9 +622,10 @@ def check_cursor_plugin(repo_root: Path) -> list[str]:
 
     Two Cursor-specific traps this guards:
 
-    - The plugin `name` is the frozen Cursor install identifier. Cursor keys
-      installations and updates on it, so renaming orphans every existing
-      install from auto-updates (see .cursor-plugin/NOTES.md).
+    - The plugin `name` is the Cursor install identifier. Cursor keys
+      installations and updates on it, so changing it orphans every existing
+      install from auto-updates without a coordinated Cursor-side migration
+      (see .cursor-plugin/NOTES.md).
     - Cursor default-discovers `hooks/hooks.json` (the Claude-format wiring,
       whose event names Cursor cannot parse) when the manifest declares no
       hooks path, so the explicit "hooks" pointer is load-bearing.
@@ -639,11 +640,12 @@ def check_cursor_plugin(repo_root: Path) -> list[str]:
     except json.JSONDecodeError as exc:
         return [f".cursor-plugin/plugin.json is not valid JSON: {exc}"]
 
-    if plugin.get("name") != "databricks-skills":
+    if plugin.get("name") != "databricks":
         errors.append(
-            '.cursor-plugin/plugin.json "name" must stay "databricks-skills": it is '
-            "the frozen Cursor marketplace install identifier; renaming it orphans "
-            "every existing install (see .cursor-plugin/NOTES.md)."
+            '.cursor-plugin/plugin.json "name" must stay "databricks": it is the '
+            "Cursor marketplace install identifier; changing it orphans every "
+            "existing install without a coordinated Cursor-side migration "
+            "(see .cursor-plugin/NOTES.md)."
         )
 
     declared_hooks = plugin.get("hooks")


### PR DESCRIPTION
Renames the Cursor plugin's `name` to `databricks` so the Cursor install command is `/add-plugin databricks`, matching the Claude Code plugin and the single-word brand. The marketplace URL stays at https://cursor.com/marketplace/databricks.

## Changes
- `.cursor-plugin/plugin.json`: `name` `databricks-skills` -> `databricks`
- `scripts/skills.py`: name check and docstring now enforce `databricks`
- `README.md`, `hooks/README.md`: install command and references updated
- `.cursor-plugin/NOTES.md`: rewritten to document the install identifier

## Test plan
- [x] `python3 scripts/skills.py validate`
- [x] `python3 -m unittest discover -s tests -p '*_test.py'` (52 passed)

This pull request and its description were written by Isaac.
