### PR TITLE
fix(routing): Cursor routing rule, Copilot hook doc fixes, CI hardening

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -8,5 +8,6 @@
   },
   "skills": "./skills/",
   "commands": "./commands-cursor/",
+  "rules": "./rules/",
   "hooks": "./hooks/cursor-hooks.json"
 }

--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ skill under [`./skills/`](./skills/)):
 ```
 
 The Cursor plugin ships the skills plus the `databricks-setup` /
-`databricks-doctor` commands and two of the three hooks (session context,
-auth-failure hints); see
+`databricks-doctor` commands, two of the three hooks (session context,
+auth-failure hints), and a routing rule that steers Databricks prompts into the
+skills; see
 [Commands and hooks](#commands-and-hooks-claude-code-cursor).
 
 **Via the GitHub Copilot plugin marketplace:**
@@ -58,8 +59,9 @@ copilot plugin install databricks@databricks-agent-skills
 
 Works in Copilot CLI (plugins are GA there) and VS Code (agent plugins,
 preview; also installable from the Extensions view). Ships the skills plus
-two hooks: the session context primer (effective in VS Code) and the
-auth-failure hinter. The Copilot cloud agent on github.com takes no plugins;
+two hooks: the session context primer and the auth-failure hinter (both run on
+Copilot CLI and the cloud agent; VS Code has its own hooks system). The Copilot
+cloud agent on github.com takes no plugins;
 for that surface, vendor the skills into the target repo (`.github/skills/`)
 and the auth-hint hook into `.github/hooks/`.
 
@@ -166,9 +168,12 @@ the same commands ship as `/databricks-setup` and `/databricks-doctor` from
 `.cursor-plugin/plugin.json`): the context primer (`sessionStart`) and the
 auth-failure hint (`postToolUse`), both invoked with `--platform cursor` so
 they emit Cursor's output shape and reference the Cursor command names. The
-prompt router does not port: Cursor's `beforeSubmitPrompt` hook cannot inject
-context, so routing rides on the primer's routing rule plus Cursor's native
-skill selection.
+prompt-router hook does not port (Cursor's `beforeSubmitPrompt` cannot inject
+context), so routing instead ships as a Cursor rule
+([`rules/databricks-routing.mdc`](./rules/databricks-routing.mdc)) that injects
+the routing table when a prompt is Databricks-related, independent of an open
+Cursor bug that currently drops hook `additional_context`. Native skill
+selection also helps.
 
 > **Distribution parity (follow-up).** The plugin marketplace ships the whole
 > repo (`marketplace.json` `source: "./"`), so commands and hooks come with it.

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -13,20 +13,30 @@ discovery would otherwise parse the Claude-format `hooks.json`. It runs the
 context primer (`sessionStart`) and the auth hinter (`postToolUse`, matcher
 `Shell`) with `--platform cursor`, which switches the scripts' output envelope
 to Cursor's `additional_context` and renders the Cursor command names
-(`/databricks-setup`, `/databricks-doctor`) in the injected text. The prompt
-router is not wired on Cursor: `beforeSubmitPrompt` can block a prompt but
-cannot inject context, so routing rides on the primer plus Cursor's native
-skill selection.
+(`/databricks-setup`, `/databricks-doctor`) in the injected text. The
+prompt-router hook is not wired on Cursor (`beforeSubmitPrompt` can block a
+prompt but cannot inject context). Routing instead ships as a Cursor **rule**
+(`rules/databricks-routing.mdc`, declared via `"rules"` in
+`.cursor-plugin/plugin.json`): an Apply-Intelligently rule whose description
+triggers it on Databricks-related prompts and injects the same product-skill
+table the Claude/Codex router uses. This is load-bearing because Cursor
+currently drops `additional_context` from `sessionStart`/`postToolUse` for
+non-MCP tools (open upstream bug, Cursor forum #155689 / #158452), so the primer
+and auth-hint hooks are effectively no-ops on Cursor today; the rule loads
+through the rules engine, not the hook-injection path, so it is unaffected.
+Native skill selection also helps.
 
 `copilot-hooks.json` wires the GitHub Copilot plugin (declared as `"hooks"` in
 `.github/plugin/plugin.json`). It uses PascalCase event names, which selects
 Copilot's Claude-compatible payload dialect, so the scripts run unchanged and
 emit the Claude output envelope. Only two hooks are wired: the context primer
-(`SessionStart`; its injected context is honored in VS Code, while Copilot CLI
-and the cloud agent ignore session-start stdout) and the auth hinter
-(`PostToolUse`, which injects `additionalContext` on every Copilot surface).
+(`SessionStart`) and the auth hinter (`PostToolUse`). Copilot's hooks run on the
+Copilot CLI and the cloud agent (VS Code ships its own separate hooks system);
+the CLI injects `SessionStart` / `PostToolUse` `additionalContext` as of Copilot
+CLI v1.0.11 (earlier versions dropped session-start output).
 The prompt router is not wired: no Copilot surface lets a prompt-submit hook
-inject context, so routing rides on skill descriptions and instruction files.
+inject context (`userPromptSubmitted` output is not processed), so routing rides
+on skill descriptions and instruction files.
 Each entry carries `bash` and `powershell` command variants per Copilot's hook
 format.
 
@@ -112,8 +122,9 @@ These ship with the Claude Code plugin (the whole repo is the plugin via
 auth hinter via `copilot-hooks.json`, catalogued in
 `.github/plugin/marketplace.json`), and with the Codex plugin (all three hooks
 via `codex-hooks.json`, catalogued in `.agents/plugins/marketplace.json`). The
-Cursor marketplace plugin (`databricks`) ships the context primer and
-auth hinter via `cursor-hooks.json`; the router stays Claude-only there. The
+Cursor marketplace plugin (`databricks`) ships the context primer and auth
+hinter via `cursor-hooks.json` plus the routing rule
+(`rules/databricks-routing.mdc`); the router hook stays Claude/Codex-only. The
 Copilot cloud agent takes no plugins; it only reads hooks vendored into the
 target repo's `.github/hooks/`. The Databricks CLI install path
 (`databricks aitools install`) currently packages **skills only**. See the repo

--- a/manifest.json
+++ b/manifest.json
@@ -108,7 +108,7 @@
       "version": "0.1.0"
     },
     "databricks-core": {
-      "description": "Databricks CLI operations: auth, profiles, data exploration, and bundles. Contains up-to-date guidelines for Databricks-related CLI tasks.",
+      "description": "Databricks CLI operations and the parent/entry-point skill for all Databricks work: authentication, profile selection, data exploration, bundles, and Genie natural-language data Q&A. Load this firs...",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",

--- a/rules/databricks-routing.mdc
+++ b/rules/databricks-routing.mdc
@@ -1,0 +1,22 @@
+---
+description: Routing for any Databricks task -- CLI, auth, profiles, data exploration, Jobs/Lakeflow, Spark Declarative Pipelines (formerly DLT), Apps/AppKit, Asset Bundles/DABs, Model Serving, Lakebase/Postgres, Vector Search/RAG, Genie, and classic-to-serverless migration. Apply when the request is Databricks-related so the Databricks skills are loaded instead of ad hoc commands.
+alwaysApply: false
+---
+
+This request is Databricks-related. Handle it through the Databricks skills
+rather than ad hoc commands. Load the `databricks-core` skill first (the parent:
+CLI, auth, profile selection, data exploration), then load the product skill
+that matches the request:
+
+- Jobs / Lakeflow / workflows -> databricks-jobs
+- Pipelines / Lakeflow Spark Declarative Pipelines (formerly DLT) -> databricks-pipelines
+- Apps / AppKit -> databricks-apps
+- Asset Bundles / DABs / databricks.yml -> databricks-dabs
+- Model Serving / endpoints -> databricks-model-serving
+- Lakebase / Postgres -> databricks-lakebase
+- Vector Search / RAG -> databricks-vector-search
+- Classic-to-serverless migration -> databricks-serverless-migration
+- Genie / natural-language data Q&A -> databricks-core (Genie CLI support is experimental)
+
+Then follow the skill's guidance (it drives the `databricks` CLI). If no product
+skill fits, databricks-core alone is enough.

--- a/scripts/skills.py
+++ b/scripts/skills.py
@@ -504,6 +504,54 @@ def _read_frontmatter(md_path: Path) -> str | None:
     return text[3:end]
 
 
+# Documented hook event names per platform. A config keyed on an event outside
+# its platform's set silently never fires, which the JSON-validity and
+# script-existence checks cannot catch. Verified against each platform's current
+# (mid-2026) hooks docs; extend these sets when a platform adds an event we wire.
+_CLAUDE_EVENTS = frozenset({
+    "PreToolUse", "PostToolUse", "UserPromptSubmit", "Notification",
+    "Stop", "SubagentStop", "SessionStart", "SessionEnd", "PreCompact",
+})
+_CODEX_EVENTS = frozenset({
+    "PreToolUse", "PermissionRequest", "PostToolUse", "PreCompact",
+    "PostCompact", "UserPromptSubmit", "SubagentStart", "SubagentStop",
+    "Stop", "SessionStart",
+})
+_CURSOR_EVENTS = frozenset({
+    "sessionStart", "sessionEnd", "preToolUse", "postToolUse",
+    "postToolUseFailure", "subagentStart", "subagentStop",
+    "beforeShellExecution", "afterShellExecution", "beforeMCPExecution",
+    "afterMCPExecution", "beforeReadFile", "afterFileEdit",
+    "beforeSubmitPrompt", "preCompact", "stop", "afterAgentResponse",
+    "afterAgentThought", "beforeTabFileRead", "afterTabFileEdit",
+    "workspaceOpen",
+})
+# Copilot accepts its native camelCase events and the PascalCase
+# (Claude / Open Plugins) dialect; both are valid.
+_COPILOT_EVENTS = frozenset({
+    "sessionStart", "sessionEnd", "userPromptSubmitted", "preToolUse",
+    "postToolUse", "agentStop", "subagentStop", "errorOccurred",
+    "SessionStart", "PreToolUse", "PostToolUse", "UserPromptSubmit",
+    "PreCompact", "SubagentStart", "SubagentStop", "Stop",
+})
+
+
+def _check_hook_event_names(rel: str, cfg: dict | None, valid: frozenset, errors: list[str]) -> None:
+    """Flag any hook event key in cfg that the platform does not actually fire."""
+    if not isinstance(cfg, dict):
+        return
+    hooks = cfg.get("hooks")
+    if not isinstance(hooks, dict):
+        return
+    for event in hooks:
+        if event not in valid:
+            errors.append(
+                f"{rel} wires hook event '{event}', not a documented event for "
+                "this platform (it would silently never fire). Valid events: "
+                f"{', '.join(sorted(valid))}."
+            )
+
+
 def check_plugin_components(repo_root: Path) -> list[str]:
     """Validate the non-skill plugin components: hooks/ and commands/.
 
@@ -587,6 +635,7 @@ def check_plugin_components(repo_root: Path) -> list[str]:
                     errors.append(
                         f"hooks/hooks.json references '{rel}' which does not exist."
                     )
+        _check_hook_event_names("hooks/hooks.json", hooks_cfg, _CLAUDE_EVENTS, errors)
 
     return errors
 
@@ -667,6 +716,7 @@ def check_cursor_plugin(repo_root: Path) -> list[str]:
         cfg = _check_hook_wiring(repo_root, "hooks/cursor-hooks.json", errors)
         if cfg is not None and cfg.get("version") != 1:
             errors.append('hooks/cursor-hooks.json must declare "version": 1.')
+        _check_hook_event_names("hooks/cursor-hooks.json", cfg, _CURSOR_EVENTS, errors)
 
     commands_rel = plugin.get("commands")
     if isinstance(commands_rel, str):
@@ -685,6 +735,25 @@ def check_cursor_plugin(repo_root: Path) -> list[str]:
                 errors.append(
                     f"Cursor command '{md.relative_to(repo_root)}' needs frontmatter "
                     "with a 'description'."
+                )
+
+    rules_rel = plugin.get("rules")
+    if isinstance(rules_rel, str):
+        rules_dir = repo_root / _norm_rel_path(rules_rel)
+        mdc_files = sorted(rules_dir.glob("*.mdc")) if rules_dir.is_dir() else []
+        if not mdc_files:
+            errors.append(
+                f'.cursor-plugin/plugin.json declares rules at "{rules_rel}" but no '
+                "*.mdc rule files exist there."
+            )
+        for mdc in mdc_files:
+            frontmatter = _read_frontmatter(mdc)
+            if frontmatter is None or not re.search(
+                r"^description:\s*\S", frontmatter, re.MULTILINE
+            ):
+                errors.append(
+                    f"Cursor rule '{mdc.relative_to(repo_root)}' needs frontmatter "
+                    "with a 'description' (Apply-Intelligently rules trigger on it)."
                 )
 
     return errors
@@ -756,6 +825,7 @@ def check_codex_plugin(repo_root: Path) -> list[str]:
                     errors.append(
                         f"hooks/codex-hooks.json references '{script}' which does not exist."
                     )
+        _check_hook_event_names("hooks/codex-hooks.json", cfg, _CODEX_EVENTS, errors)
 
     market_path = repo_root / ".agents" / "plugins" / "marketplace.json"
     if not market_path.exists():
@@ -848,6 +918,7 @@ def check_copilot_plugin(repo_root: Path) -> list[str]:
                     errors.append(
                         f"hooks/copilot-hooks.json references '{script}' which does not exist."
                     )
+        _check_hook_event_names("hooks/copilot-hooks.json", cfg, _COPILOT_EVENTS, errors)
 
     market_path = repo_root / ".github" / "plugin" / "marketplace.json"
     if not market_path.exists():
@@ -866,6 +937,80 @@ def check_copilot_plugin(repo_root: Path) -> list[str]:
                 f"'{plugin.get('name')}'."
             )
 
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Routing tables (prompt router + Cursor rule, kept in sync with the skills)
+# ---------------------------------------------------------------------------
+
+def _routing_skill_refs(text: str) -> set:
+    """The set of databricks-* skill names referenced in a routing table."""
+    return set(re.findall(r"databricks-[a-z][a-z0-9-]*", text))
+
+
+def _load_routing_instruction(repo_root: Path) -> str | None:
+    """ROUTING_INSTRUCTION from hooks/databricks-router.py (hyphenated -> load by path)."""
+    path = repo_root / "hooks" / "databricks-router.py"
+    if not path.exists():
+        return None
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("databricks_router", path)
+    if spec is None or spec.loader is None:
+        return None
+    try:
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    except Exception:
+        return None
+    return getattr(module, "ROUTING_INSTRUCTION", None)
+
+
+def check_routing_tables(repo_root: Path) -> list[str]:
+    """Keep the prompt router's and Cursor rule's product-skill tables honest.
+
+    - Every databricks-* skill the router names must exist as a shipped skill; a
+      rename or removal otherwise silently points routing at a dead skill.
+    - The Cursor routing rule (rules/databricks-routing.mdc), if present, must
+      name the same skill set as the router, so the two hand-maintained tables
+      cannot drift apart (the router runs on Claude/Codex, the rule on Cursor).
+    """
+    errors: list[str] = []
+    instruction = _load_routing_instruction(repo_root)
+    if not instruction:
+        # No router (or unreadable) -> nothing to cross-check here.
+        return errors
+
+    def _exists(name: str) -> bool:
+        return (repo_root / "skills" / name).is_dir() or (
+            repo_root / "experimental" / name
+        ).is_dir()
+
+    router_refs = _routing_skill_refs(instruction)
+    for name in sorted(router_refs):
+        if not _exists(name):
+            errors.append(
+                f"hooks/databricks-router.py routes to '{name}', which is not a "
+                "shipped skill under skills/ or experimental/."
+            )
+
+    rule_path = repo_root / "rules" / "databricks-routing.mdc"
+    if rule_path.exists():
+        rule_refs = _routing_skill_refs(rule_path.read_text())
+        missing = router_refs - rule_refs
+        extra = rule_refs - router_refs
+        if missing:
+            errors.append(
+                "rules/databricks-routing.mdc is missing skills the router routes "
+                f"to ({', '.join(sorted(missing))}); keep the Cursor rule's table "
+                "in sync with hooks/databricks-router.py."
+            )
+        if extra:
+            errors.append(
+                "rules/databricks-routing.mdc routes to skills the router does not "
+                f"({', '.join(sorted(extra))}); keep the two routing tables in sync."
+            )
     return errors
 
 
@@ -973,6 +1118,16 @@ def main() -> None:
                     file=sys.stderr,
                 )
                 for err in copilot_errors:
+                    print(f"  - {err}", file=sys.stderr)
+                ok = False
+
+            routing_errors = check_routing_tables(repo_root)
+            if routing_errors:
+                print(
+                    "ERROR: routing tables (router + Cursor rule) are out of sync:",
+                    file=sys.stderr,
+                )
+                for err in routing_errors:
                     print(f"  - {err}", file=sys.stderr)
                 ok = False
 

--- a/skills/databricks-core/SKILL.md
+++ b/skills/databricks-core/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "databricks-core"
-description: "Databricks CLI operations: auth, profiles, data exploration, and bundles. Contains up-to-date guidelines for Databricks-related CLI tasks."
+description: "Databricks CLI operations and the parent/entry-point skill for all Databricks work: authentication, profile selection, data exploration, bundles, and Genie natural-language data Q&A. Load this first for any Databricks task (CLI, auth, profiles, exploring catalogs/tables), then load the matching product skill. Contains up-to-date guidelines for Databricks-related CLI tasks."
 compatibility: Requires databricks CLI (>= v0.292.0)
 metadata:
   version: "0.1.0"


### PR DESCRIPTION
## Why

The prompt-router hook only injects context on Claude and Codex. On Cursor and Copilot, prompt-submit hooks are block/allow only, so routing relied on the SessionStart context primer plus native skill selection. Verifying against current platform docs surfaced that the primer is currently unreliable on Cursor: an open upstream bug drops `additional_context` from `sessionStart`/`postToolUse` for non-MCP tools (Cursor forum #155689 / #158452), so Cursor had no dependable proactive routing. Separately, this repo's Copilot hook docs were factually inverted.

This does not (and cannot) port the router hook to those platforms; it adds routing through the mechanisms they actually support and fixes the docs.

## Changes

**Cursor routing rule (the functional fix).** Ship `rules/databricks-routing.mdc`, an Apply-Intelligently rule carrying the same product-skill table as the router, and declare `"rules": "./rules/"` in `.cursor-plugin/plugin.json`. Rules load through Cursor's rules engine, not the broken `additional_context` hook path, so routing works today regardless of the upstream bug.

**Doc corrections** (`README.md`, `hooks/README.md`):
- Fix the inverted Copilot claim. Copilot hooks run on the CLI + cloud agent (VS Code has its own hooks system), and the CLI injects `additionalContext` as of Copilot CLI v1.0.11. The old text said VS Code honored it while the CLI/cloud ignored it, which is backwards.
- Document the live Cursor `additional_context` drop so contributors don't assume the primer/auth-hint hooks fire there.

**databricks-core description.** Reframe it as the parent/entry-point skill. Description-driven native skill auto-selection is the only in-plugin routing lever on Copilot and a key one on Cursor, so a stronger core description improves routing on every platform. Regenerated `manifest.json`.

**CI hardening** (`scripts/skills.py validate`):
- Validate each platform's hook event names against a documented allow-list. A wrong-cased or invented event (e.g. `UserPromptSubmit` in a Cursor config) passed before and silently never fired.
- Verify the router's and the Cursor rule's product-skill tables stay in sync with the shipped skills, closing the table-drift hazard.

## Test plan

- [x] `python3 scripts/skills.py validate` -> "Everything is up to date."
- [x] `python3 -m unittest discover -s tests -p '*_test.py'` -> 52 passed
- [x] Negative tests confirm the new checks catch bad event names, dead skill refs, and router/rule table drift

## Note

The `databricks-core` description lives under `skills/`, which syncs from the internal source. Mirror that one-line change there so it survives the next sync. The Cursor rule, docs, and CI changes are plugin infra authored in this repo and are unaffected.

This pull request and its description were written by Isaac.
