### PR TITLE
build(plugin): generate all plugin manifests from one plugin.meta.json

### DIFF
--- a/.agents/plugins/README.md
+++ b/.agents/plugins/README.md
@@ -1,0 +1,9 @@
+<!-- GENERATED FILE: do not edit by hand. -->
+
+# Generated plugin manifests
+
+The plugin manifest files in this directory (`plugin.json` and/or
+`marketplace.json`) are generated from the repo-root `plugin.meta.json` by
+`scripts/skills.py`. To change them, edit `plugin.meta.json` and run
+`python3 scripts/skills.py generate`. CI re-renders these files and fails on any
+drift, so hand-edits are reverted. See `CONTRIBUTING.md` ("Plugin metadata").

--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -1,0 +1,9 @@
+<!-- GENERATED FILE: do not edit by hand. -->
+
+# Generated plugin manifests
+
+The plugin manifest files in this directory (`plugin.json` and/or
+`marketplace.json`) are generated from the repo-root `plugin.meta.json` by
+`scripts/skills.py`. To change them, edit `plugin.meta.json` and run
+`python3 scripts/skills.py generate`. CI re-renders these files and fails on any
+drift, so hand-edits are reverted. See `CONTRIBUTING.md` ("Plugin metadata").

--- a/.codex-plugin/README.md
+++ b/.codex-plugin/README.md
@@ -1,0 +1,9 @@
+<!-- GENERATED FILE: do not edit by hand. -->
+
+# Generated plugin manifests
+
+The plugin manifest files in this directory (`plugin.json` and/or
+`marketplace.json`) are generated from the repo-root `plugin.meta.json` by
+`scripts/skills.py`. To change them, edit `plugin.meta.json` and run
+`python3 scripts/skills.py generate`. CI re-renders these files and fails on any
+drift, so hand-edits are reverted. See `CONTRIBUTING.md` ("Plugin metadata").

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -13,6 +13,7 @@
     "databricks",
     "cli",
     "apps",
+    "app-design",
     "lakebase",
     "model-serving",
     "jobs",

--- a/.cursor-plugin/README.md
+++ b/.cursor-plugin/README.md
@@ -1,0 +1,9 @@
+<!-- GENERATED FILE: do not edit by hand. -->
+
+# Generated plugin manifests
+
+The plugin manifest files in this directory (`plugin.json` and/or
+`marketplace.json`) are generated from the repo-root `plugin.meta.json` by
+`scripts/skills.py`. To change them, edit `plugin.meta.json` and run
+`python3 scripts/skills.py generate`. CI re-renders these files and fails on any
+drift, so hand-edits are reverted. See `CONTRIBUTING.md` ("Plugin metadata").

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "databricks",
   "displayName": "Databricks Skills",
-  "description": "Databricks skills for CLI, Apps, Unity Catalog, Model Serving, Declarative Automation Bundles (DABs), and more.",
+  "description": "Databricks skills for the CLI, Apps, Lakebase, Model Serving, Lakeflow Jobs, Spark Declarative Pipelines, Declarative Automation Bundles (DABs), and classic-to-serverless migration.",
   "version": "0.2.4",
   "author": {
     "name": "Databricks"

--- a/.github/plugin/README.md
+++ b/.github/plugin/README.md
@@ -1,0 +1,9 @@
+<!-- GENERATED FILE: do not edit by hand. -->
+
+# Generated plugin manifests
+
+The plugin manifest files in this directory (`plugin.json` and/or
+`marketplace.json`) are generated from the repo-root `plugin.meta.json` by
+`scripts/skills.py`. To change them, edit `plugin.meta.json` and run
+`python3 scripts/skills.py generate`. CI re-renders these files and fails on any
+drift, so hand-edits are reverted. See `CONTRIBUTING.md` ("Plugin metadata").

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,17 @@ jobs:
             exit 1
           fi
 
-      - name: Bump plugin manifests and regenerate manifest
+      - name: Bump version in plugin.meta.json and regenerate manifests
         env:
           VERSION: ${{ inputs.version }}
         run: python3 scripts/bump_version.py "$VERSION"
+
+      - name: Validate generated manifests before publishing
+        # Abort the release if anything is inconsistent (drift, a skill missing
+        # from plugin.meta.json, missing Codex metadata, ...) BEFORE the commit
+        # and tag are pushed, instead of failing the post-push CI after the
+        # release is already published.
+        run: python3 scripts/skills.py validate
 
       - name: Commit version bump
         env:
@@ -45,7 +52,20 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .claude-plugin/plugin.json .cursor-plugin/plugin.json manifest.json
+          # plugin.meta.json is the source; the rest are generated from it.
+          # Stage all of them (unchanged files are a no-op) so a release can
+          # never commit a partial set, e.g. bump the Claude manifest but leave
+          # the Codex/Copilot ones behind.
+          git add \
+            plugin.meta.json \
+            .claude-plugin/plugin.json \
+            .codex-plugin/plugin.json \
+            .github/plugin/plugin.json \
+            .cursor-plugin/plugin.json \
+            .claude-plugin/marketplace.json \
+            .github/plugin/marketplace.json \
+            .agents/plugins/marketplace.json \
+            manifest.json
           if git diff --cached --quiet; then
             echo "Manifests already at $VERSION; nothing to commit"
           else

--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -7,10 +7,18 @@ on:
       - 'experimental/**'
       - 'assets/**'
       - 'scripts/skills.py'
+      - 'scripts/bump_version.py'
       - 'manifest.json'
+      - 'plugin.meta.json'
       - '.claude-plugin/**'
+      - '.codex-plugin/**'
+      - '.github/plugin/**'
+      - '.cursor-plugin/**'
+      - '.agents/**'
       - 'hooks/**'
       - 'commands/**'
+      - 'commands-cursor/**'
+      - 'rules/**'
       - 'tests/**'
   push:
     branches:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,23 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md#skill-anatomy) for the full per-skill fi
 ### Skills management
 
 ```bash
-python3 scripts/skills.py              # sync Codex metadata + icons, then generate manifest (default)
+python3 scripts/skills.py              # sync metadata/icons, then generate manifest.json + all plugin manifests (default)
 python3 scripts/skills.py sync         # sync Codex metadata + icons only
-python3 scripts/skills.py validate     # check Codex metadata + icons + manifest are up to date (CI)
+python3 scripts/skills.py validate     # check metadata + icons + manifest + plugin manifests are up to date (CI)
 ```
+
+## Plugin manifests (generated from `plugin.meta.json`)
+
+The four `plugin.json` files (`.claude-plugin/`, `.codex-plugin/`,
+`.github/plugin/`, `.cursor-plugin/`) and the three `marketplace.json` files
+(`.claude-plugin/`, `.github/plugin/`, `.agents/plugins/`) are **generated**
+from [`plugin.meta.json`](./plugin.meta.json) by `scripts/skills.py generate`.
+**Do not hand-edit them** (each generated directory carries a `README.md`
+marker). To change the plugin version, description, keywords, or per-target
+config, edit `plugin.meta.json` and run `python3 scripts/skills.py generate`; CI
+(`validate`) fails on any drift. The version lives only in `plugin.meta.json`
+and propagates to all four targets. Adding a stable skill requires an entry in
+the `skills` map (with a `keyword`).
 
 ## Plugin components (hooks + commands)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,8 @@ If the synthesised display name comes out wrong (e.g. acronyms or product names 
 mkdir -p skills/databricks-foo/references
 $EDITOR skills/databricks-foo/SKILL.md      # write SKILL.md with frontmatter
 
-# 2. For stable skills only: add a description to scripts/skills.py SKILL_METADATA.
+# 2. For stable skills only: add the skill to plugin.meta.json "skills"
+#    with a "keyword" (this is its Claude/Codex plugin marketplace keyword).
 
 # 3. Generate Codex metadata + icons + manifest in one shot.
 python3 scripts/skills.py generate
@@ -44,13 +45,40 @@ python3 scripts/skills.py validate
 
 ### CI
 
-`.github/workflows/validate-manifest.yml` runs `python3 scripts/skills.py validate` on every PR that touches `skills/**`, `experimental/**`, `assets/**`, `scripts/skills.py`, or `manifest.json`. Validation enforces:
+`.github/workflows/validate-manifest.yml` runs `python3 scripts/skills.py validate` on every PR that touches the skills, the generator, `plugin.meta.json`, any plugin manifest dir (`.claude-plugin/**`, `.codex-plugin/**`, `.github/plugin/**`, `.cursor-plugin/**`, `.agents/**`), `hooks/**`, the command dirs, or `rules/**`. Validation enforces:
 
 - Every skill has `agents/openai.yaml`.
 - Every skill ships `assets/databricks.svg` + `assets/databricks.png` byte-identical to the repo-root source.
 - `manifest.json` matches what `scripts/skills.py generate` would produce.
+- Every stable skill has a `plugin.meta.json` "skills" entry (and vice versa).
+- Every target's `plugin.json` + `marketplace.json` is byte-identical to what the generator produces from `plugin.meta.json` (no drift across the four targets).
 
 If validation fails the error tells you which file is missing or stale; the fix is always `python3 scripts/skills.py generate` and committing the result.
+
+## Plugin metadata (`plugin.meta.json`)
+
+The repo ships one logical plugin to four targets (Claude Code, Codex, Copilot,
+Cursor) plus a marketplace catalog for three of them. All cross-target plugin
+metadata, version, name, description, author, license, keywords, per-target
+display names, and hook/command/rule wiring, lives once in **`plugin.meta.json`**
+at the repo root. `scripts/skills.py generate` renders it into every target's
+`plugin.json` and `marketplace.json`:
+
+- `.claude-plugin/{plugin,marketplace}.json`
+- `.codex-plugin/plugin.json` + `.agents/plugins/marketplace.json`
+- `.github/plugin/{plugin,marketplace}.json`
+- `.cursor-plugin/plugin.json`
+
+**Edit `plugin.meta.json`, then run `python3 scripts/skills.py generate`.** Never
+hand-edit the generated files; CI re-renders them in memory and fails on any byte
+drift. (The generated JSON carries no "do-not-edit" comment key because the
+plugin loaders / the Claude marketplace `$schema` reject unknown keys; their
+generated status is documented here and enforced by the drift check.)
+
+The plugin keyword list is composed as `keywords_lead + [each skill's keyword] +
+keywords_tail`, in the insertion order of the `skills` map. The plugin `name` is
+`databricks` for every target and is load-bearing (it keys Cursor/Claude
+installs); the generator never emits a different value.
 
 ## Plugin components (hooks + commands)
 
@@ -99,9 +127,10 @@ Releases are cut by the **Release** workflow (`.github/workflows/release.yml`),
 triggered manually (`workflow_dispatch`) with a `vX.Y.Z` tag. The workflow:
 
 1. Runs `scripts/bump_version.py <version>`, which sets the `version` field in
-   both `.claude-plugin/plugin.json` and `.cursor-plugin/plugin.json` to the
-   release version and regenerates `manifest.json`.
-2. Commits the bump to `main`.
+   `plugin.meta.json` (the single source) and regenerates every target's
+   `plugin.json` + `marketplace.json` and `manifest.json` from it, so all four
+   targets carry the same version.
+2. Commits the bump (`plugin.meta.json` + the regenerated manifests) to `main`.
 3. Creates an annotated `vX.Y.Z` tag (`git tag -a`) at that commit, pushes it,
    then creates the GitHub release (`gh release create --verify-tag`).
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,27 @@ python3 scripts/skills.py validate
 
 The manifest is consumed by the CLI to discover available skills.
 
+### Plugin manifest management
+
+The repo ships one plugin to four targets (Claude Code, Codex, Copilot, Cursor)
+plus three marketplace catalogs. Their `plugin.json` / `marketplace.json` files
+are **generated** from a single source of truth,
+[`plugin.meta.json`](./plugin.meta.json), by `scripts/skills.py`. Do not
+hand-edit the generated files (each generated directory also carries a
+`README.md` saying so) — edit `plugin.meta.json` and regenerate:
+
+```bash
+python3 scripts/skills.py generate   # regenerates manifest.json + all plugin manifests
+python3 scripts/skills.py validate   # CI check: fails on any drift
+```
+
+`plugin.meta.json` owns the version (one value, propagated to all four targets),
+name, description, keywords, author/license, per-target display names and
+hook/command/rule wiring, and the skill-to-keyword map. Adding a stable skill
+means adding it to the `skills` map there (with a `keyword`); CI fails if a
+shipped skill has no entry. See
+[CONTRIBUTING.md](./CONTRIBUTING.md) for the full field reference.
+
 ## Security
 
 Please see [SECURITY](./SECURITY) for vulnerability reporting guidelines.

--- a/manifest.json
+++ b/manifest.json
@@ -108,7 +108,7 @@
       "version": "0.1.0"
     },
     "databricks-core": {
-      "description": "Databricks CLI operations and the parent/entry-point skill for all Databricks work: authentication, profile selection, data exploration, bundles, and Genie natural-language data Q&A. Load this firs...",
+      "description": "Databricks CLI operations and the parent/entry-point skill for all Databricks work: authentication, profile selection, data exploration, bundles, and Genie natural-language data Q&A.",
       "files": [
         "SKILL.md",
         "agents/openai.yaml",

--- a/plugin.meta.json
+++ b/plugin.meta.json
@@ -1,0 +1,69 @@
+{
+  "//": "Single source of truth for the databricks plugin across all targets (Claude, Codex, Copilot, Cursor). Edit this file, then run `python3 scripts/skills.py generate`. The 4 plugin.json + 3 marketplace.json files are generated from here; CI fails on drift. Do not hand-edit the generated files.",
+  "version": "0.2.4",
+  "name": "databricks",
+  "description": "Databricks skills for the CLI, Apps, Lakebase, Model Serving, Lakeflow Jobs, Spark Declarative Pipelines, Declarative Automation Bundles (DABs), and classic-to-serverless migration.",
+  "category": "development",
+  "author": {
+    "name": "Databricks",
+    "url": "https://databricks.com"
+  },
+  "homepage": "https://github.com/databricks/databricks-agent-skills",
+  "repository": "https://github.com/databricks/databricks-agent-skills",
+  "license": "LicenseRef-Databricks",
+
+  "keywords_lead": ["databricks"],
+  "keywords_tail": ["data-engineering"],
+
+  "marketplace": {
+    "name": "databricks-agent-skills",
+    "description": "Databricks agent skills for AI coding assistants.",
+    "owner": { "name": "Databricks" },
+    "displayName": "Databricks Agent Skills"
+  },
+
+  "targets": {
+    "claude": {
+      "dir": ".claude-plugin",
+      "commands": "./commands/"
+    },
+    "codex": {
+      "dir": ".codex-plugin",
+      "hooks": "./hooks/codex-hooks.json",
+      "interface": {
+        "displayName": "Databricks",
+        "shortDescription": "Databricks skills and hooks for Codex.",
+        "category": "development",
+        "brandColor": "#FF3621",
+        "logo": "./assets/databricks.png",
+        "composerIcon": "./assets/databricks.svg"
+      }
+    },
+    "copilot": {
+      "dir": ".github/plugin",
+      "displayName": "Databricks",
+      "hooks": "./hooks/copilot-hooks.json"
+    },
+    "cursor": {
+      "dir": ".cursor-plugin",
+      "displayName": "Databricks Skills",
+      "commands": "./commands-cursor/",
+      "rules": "./rules/",
+      "hooks": "./hooks/cursor-hooks.json"
+    }
+  },
+
+  "//skills": "Per-skill plugin metadata. Insertion order defines the keyword order in plugin.json: keywords = keywords_lead + [each skill's keyword] + keywords_tail. Repo-owned (does NOT live in SKILL.md frontmatter, which syncs from the internal source). Routing fields (label/order/strong/ambiguous) are added in P2a.",
+  "skills": {
+    "databricks-core": { "keyword": "cli" },
+    "databricks-apps": { "keyword": "apps" },
+    "databricks-app-design": { "keyword": "app-design" },
+    "databricks-lakebase": { "keyword": "lakebase" },
+    "databricks-model-serving": { "keyword": "model-serving" },
+    "databricks-jobs": { "keyword": "jobs" },
+    "databricks-pipelines": { "keyword": "pipelines" },
+    "databricks-dabs": { "keyword": "dabs" },
+    "databricks-serverless-migration": { "keyword": "serverless" },
+    "databricks-vector-search": { "keyword": "vector-search" }
+  }
+}

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
-"""Bump the plugin manifest versions to a release version + regenerate manifest.
+"""Set the plugin version in plugin.meta.json + regenerate all manifests.
 
-Given a `vX.Y.Z` (or `X.Y.Z`) release version, set the `version` field in every
-plugin manifest (`.claude-plugin`, `.cursor-plugin`, `.github/plugin`,
-`.codex-plugin`), then regenerate `manifest.json` so the released commit ships
-a current manifest.
+Given a `vX.Y.Z` (or `X.Y.Z`) release version, set the `version` field in
+`plugin.meta.json` (the single source of truth), then regenerate every target's
+`plugin.json` + `marketplace.json` and `manifest.json` so the released commit
+ships a fully consistent set.
 
 Why this exists: Claude Code's plugin marketplace keys updates on the `version`
 field in `.claude-plugin/plugin.json`. If a release ships without bumping that
 field, marketplace clients keep the cached copy and never see the new skills.
-This makes the release tag the single source of truth for the plugin version.
+`plugin.meta.json` is the one place the version lives now; this writes it there
+and lets the generator propagate it to all four targets, so they can never
+diverge.
 
 Run by `.github/workflows/release.yml`. Stdlib-only (no pip), so it runs on the
 protected runner that can't reach pypi.org.
@@ -23,18 +25,14 @@ import skills  # sibling module in scripts/
 
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
 
-# Matches the first `"version": "..."` field. Every manifest carries exactly
+# Matches the first `"version": "..."` field. plugin.meta.json carries exactly
 # one top-level `version` key, so a targeted in-place replacement keeps the
-# diff to a single line and avoids reformatting the JSON (which a load/dump
-# round-trip would risk).
+# source file's formatting + comments intact (a load/dump round-trip would
+# reflow it). The generated plugin.json files ARE round-tripped by the
+# generator, which owns their canonical format.
 VERSION_FIELD_RE = re.compile(r'("version"\s*:\s*")[^"]*(")')
 
-PLUGIN_MANIFESTS = (
-    Path(".claude-plugin") / "plugin.json",
-    Path(".cursor-plugin") / "plugin.json",
-    Path(".github") / "plugin" / "plugin.json",
-    Path(".codex-plugin") / "plugin.json",
-)
+META_FILE = Path("plugin.meta.json")
 
 
 def normalize_version(raw: str) -> str:
@@ -48,13 +46,19 @@ def normalize_version(raw: str) -> str:
 
 
 def set_version(path: Path, version: str) -> bool:
-    """Set the `version` field in a plugin manifest. Returns True if changed."""
+    """Set the `version` field in a JSON file. Returns True if changed."""
     text = path.read_text()
-    new_text, count = VERSION_FIELD_RE.subn(rf"\g<1>{version}\g<2>", text, count=1)
-    if count != 1:
+    # Count matches independently of the rewrite: subn(count=1) caps the
+    # returned count at 1, so it can only catch the zero-match case, never a
+    # second (e.g. nested) "version" key. findall enforces the documented
+    # "exactly one version key" invariant so we never silently bump the wrong
+    # one if plugin.meta.json grows nested version-like fields.
+    matches = len(VERSION_FIELD_RE.findall(text))
+    if matches != 1:
         raise SystemExit(
-            f'ERROR: expected exactly one "version" field in {path}, found {count}'
+            f'ERROR: expected exactly one "version" field in {path}, found {matches}'
         )
+    new_text = VERSION_FIELD_RE.sub(rf"\g<1>{version}\g<2>", text, count=1)
     if new_text == text:
         return False
     path.write_text(new_text)
@@ -69,9 +73,18 @@ def main() -> None:
     version = normalize_version(args.version)
     repo_root = Path(__file__).resolve().parent.parent
 
-    for rel in PLUGIN_MANIFESTS:
-        changed = set_version(repo_root / rel, version)
-        print(f"{'set' if changed else 'unchanged'} {rel} -> {version}")
+    meta_path = repo_root / META_FILE
+    if not meta_path.exists():
+        raise SystemExit(
+            f"ERROR: {META_FILE} not found at the repo root. It is the plugin "
+            "source of truth and must be committed; did you forget to `git add` it?"
+        )
+    changed = set_version(meta_path, version)
+    print(f"{'set' if changed else 'unchanged'} {META_FILE} -> {version}")
+
+    meta = skills.load_meta(repo_root)
+    written = skills.generate_plugins(repo_root, meta)
+    print(f"regenerated {written} plugin manifest file(s) from {META_FILE}")
 
     manifest = skills.generate_manifest(repo_root)
     (repo_root / "manifest.json").write_text(skills.serialize_manifest(manifest))

--- a/scripts/skills.py
+++ b/scripts/skills.py
@@ -20,22 +20,17 @@ SHARED_ASSETS = [
 STABLE_REPO_DIR = "skills"
 EXPERIMENTAL_REPO_DIR = "experimental"
 
-# Stable-skill -> Claude marketplace plugin keyword. Used by
-# check_plugin_manifest to verify .claude-plugin/plugin.json keywords stay
-# aligned with the shipped skills. Descriptions live in each skill's SKILL.md
-# frontmatter and are synthesized into the manifest via _build_stable_entry.
-SKILL_METADATA = {
-    "databricks-core": {"plugin_keyword": "cli"},
-    "databricks-apps": {"plugin_keyword": "apps"},
-    "databricks-app-design": {"plugin_keyword": "app-design"},
-    "databricks-jobs": {"plugin_keyword": "jobs"},
-    "databricks-lakebase": {"plugin_keyword": "lakebase"},
-    "databricks-dabs": {"plugin_keyword": "dabs"},
-    "databricks-model-serving": {"plugin_keyword": "model-serving"},
-    "databricks-pipelines": {"plugin_keyword": "pipelines"},
-    "databricks-serverless-migration": {"plugin_keyword": "serverless"},
-    "databricks-vector-search": {"plugin_keyword": "vector-search"},
-}
+# Plugin-level metadata (version, identity, keywords, description, per-target
+# shape) is the single source of truth in plugin.meta.json at the repo root.
+# load_meta reads it; the build_* renderers below generate every target's
+# plugin.json + marketplace.json from it. The skill -> plugin-keyword map that
+# used to live here (SKILL_METADATA) now lives in plugin.meta.json "skills".
+META_FILE = "plugin.meta.json"
+
+
+def load_meta(repo_root: Path) -> dict:
+    """Load plugin.meta.json (the cross-target plugin source of truth)."""
+    return json.loads((repo_root / META_FILE).read_text())
 
 
 def iter_skill_dirs(repo_root: Path, parent: str = STABLE_REPO_DIR):
@@ -160,9 +155,13 @@ def extract_description_from_skill(skill_path: Path) -> str:
 
 
 # Markers that separate the "what this skill does" lead-in from the
-# "Use when ..." trigger list. The Codex marketplace short_description should
-# only contain the lead-in.
-_SHORT_DESC_MARKERS = (". Use when", ". Use this", ". Triggers", ". ALWAYS")
+# trigger/instruction tail. The marketplace short_description should only
+# contain the lead-in. ". Load this" trims the parent skill's "Load this first
+# ..., then load the matching product skill" agent-instruction tail
+# (databricks-core), which otherwise overran the 200-char cap and truncated
+# mid-word to "...Load this firs...". First marker found (in list order) wins,
+# so this only affects descriptions that don't already match an earlier marker.
+_SHORT_DESC_MARKERS = (". Use when", ". Use this", ". Triggers", ". ALWAYS", ". Load this")
 
 
 def synthesize_short_description(skill_path: Path) -> str:
@@ -398,77 +397,253 @@ def validate_manifest(repo_root: Path) -> bool:
     return True
 
 
-def validate_plugin_manifests(repo_root: Path) -> list[str]:
-    """Validate .claude-plugin/plugin.json and .claude-plugin/marketplace.json
-    stay in sync with the set of skills shipped in this repo.
+# ---------------------------------------------------------------------------
+# Plugin manifests (generated from plugin.meta.json for every target)
+# ---------------------------------------------------------------------------
+#
+# One logical plugin ships to four targets (Claude Code, Codex, Copilot,
+# Cursor) plus a marketplace catalog for three of them. Every target used to
+# keep a hand-edited copy of the same plugin-level metadata (version,
+# description, keywords, author, ...) and they drifted: version duplicated 4x,
+# Codex missing the app-design keyword, Cursor's description stale. plugin.meta.json
+# is now the single source; the build_* renderers below assemble each target's
+# file from it in that target's exact key order, and check_generated_plugins
+# fails CI on any drift. Stdlib-only, like the rest of this file.
+#
+# These JSON files are consumed by strict plugin loaders / a JSON-schema
+# validator (the Claude marketplace `$schema`), so they carry NO "//" comment
+# key (unlike manifest.json, whose consumer tolerates it). Their generated
+# status is documented in CONTRIBUTING.md and enforced by the drift check.
 
-    The two manifests power Claude Code marketplace discovery; if a new skill
-    lands without a corresponding plugin keyword bump, the marketplace listing
-    silently goes stale. This check forces SKILL_METADATA, plugin.json, and
-    marketplace.json to stay aligned.
+_CLAUDE_MARKETPLACE_SCHEMA = (
+    "https://json.schemastore.org/claude-code-plugin-marketplace.json"
+)
 
-    Returns a list of error strings (empty means all good).
+
+def _serialize_plugin_json(obj: dict) -> str:
+    """Canonical on-disk form for a generated plugin JSON file.
+
+    2-space indent, insertion-ordered keys (NOT sorted — each target's key
+    order is reproduced by the build_* function), trailing newline.
+    """
+    return json.dumps(obj, indent=2) + "\n"
+
+
+def build_keywords(meta: dict) -> list[str]:
+    """Compose the plugin keyword list from meta.
+
+    keywords = keywords_lead + [each skill's keyword, in meta order] +
+    keywords_tail. The lead/tail hold cross-cutting terms owned by no single
+    skill ("databricks", "data-engineering"); the middle is one keyword per
+    shipped skill, ordered by the insertion order of meta["skills"].
+    """
+    skill_keywords = [entry["keyword"] for entry in meta["skills"].values()]
+    return [
+        *meta.get("keywords_lead", []),
+        *skill_keywords,
+        *meta.get("keywords_tail", []),
+    ]
+
+
+def build_claude_plugin(meta: dict) -> dict:
+    return {
+        "name": meta["name"],
+        "description": meta["description"],
+        "version": meta["version"],
+        "author": meta["author"],
+        "homepage": meta["homepage"],
+        "repository": meta["repository"],
+        "license": meta["license"],
+        "keywords": build_keywords(meta),
+        "skills": "./skills/",
+        "commands": meta["targets"]["claude"]["commands"],
+    }
+
+
+def build_codex_plugin(meta: dict) -> dict:
+    target = meta["targets"]["codex"]
+    return {
+        "name": meta["name"],
+        "description": meta["description"],
+        "version": meta["version"],
+        "author": meta["author"],
+        "homepage": meta["homepage"],
+        "repository": meta["repository"],
+        "license": meta["license"],
+        "keywords": build_keywords(meta),
+        "skills": "./skills/",
+        "hooks": target["hooks"],
+        "interface": target["interface"],
+    }
+
+
+def build_copilot_plugin(meta: dict) -> dict:
+    target = meta["targets"]["copilot"]
+    return {
+        "name": meta["name"],
+        "displayName": target["displayName"],
+        "description": meta["description"],
+        "version": meta["version"],
+        "author": meta["author"],
+        "homepage": meta["homepage"],
+        "repository": meta["repository"],
+        "license": meta["license"],
+        "skills": "./skills/",
+        "hooks": target["hooks"],
+    }
+
+
+def build_cursor_plugin(meta: dict) -> dict:
+    target = meta["targets"]["cursor"]
+    # Cursor omits homepage/repository/license and ships the author name only.
+    return {
+        "name": meta["name"],
+        "displayName": target["displayName"],
+        "description": meta["description"],
+        "version": meta["version"],
+        "author": {"name": meta["author"]["name"]},
+        "skills": "./skills/",
+        "commands": target["commands"],
+        "rules": target["rules"],
+        "hooks": target["hooks"],
+    }
+
+
+def build_claude_marketplace(meta: dict) -> dict:
+    market = meta["marketplace"]
+    return {
+        "$schema": _CLAUDE_MARKETPLACE_SCHEMA,
+        "name": market["name"],
+        "description": market["description"],
+        "owner": market["owner"],
+        "plugins": [
+            {
+                "name": meta["name"],
+                "source": "./",
+                "category": meta["category"],
+                "description": meta["description"],
+            }
+        ],
+    }
+
+
+def build_copilot_marketplace(meta: dict) -> dict:
+    market = meta["marketplace"]
+    return {
+        "name": market["name"],
+        "description": market["description"],
+        "owner": market["owner"],
+        "plugins": [
+            {
+                "name": meta["name"],
+                "source": "./",
+                "category": meta["category"],
+                "description": meta["description"],
+            }
+        ],
+    }
+
+
+def build_codex_marketplace(meta: dict) -> dict:
+    market = meta["marketplace"]
+    return {
+        "name": market["name"],
+        "interface": {"displayName": market["displayName"]},
+        "plugins": [
+            {
+                "name": meta["name"],
+                "description": meta["description"],
+                "category": meta["category"],
+                "source": {"source": "local", "path": "./"},
+            }
+        ],
+    }
+
+
+def generated_plugin_files(meta: dict) -> dict:
+    """Map every generated plugin file (repo-relative path -> canonical text)."""
+    return {
+        ".claude-plugin/plugin.json": _serialize_plugin_json(build_claude_plugin(meta)),
+        ".codex-plugin/plugin.json": _serialize_plugin_json(build_codex_plugin(meta)),
+        ".github/plugin/plugin.json": _serialize_plugin_json(build_copilot_plugin(meta)),
+        ".cursor-plugin/plugin.json": _serialize_plugin_json(build_cursor_plugin(meta)),
+        ".claude-plugin/marketplace.json": _serialize_plugin_json(
+            build_claude_marketplace(meta)
+        ),
+        ".github/plugin/marketplace.json": _serialize_plugin_json(
+            build_copilot_marketplace(meta)
+        ),
+        ".agents/plugins/marketplace.json": _serialize_plugin_json(
+            build_codex_marketplace(meta)
+        ),
+    }
+
+
+def generate_plugins(repo_root: Path, meta: dict) -> int:
+    """Write every target's plugin.json + marketplace.json from meta.
+
+    Idempotent: always writes the full set and returns its size.
+    """
+    files = generated_plugin_files(meta)
+    for rel, text in files.items():
+        path = repo_root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+    return len(files)
+
+
+def check_meta_skill_coverage(repo_root: Path, meta: dict) -> list[str]:
+    """Every stable skill must have a plugin.meta.json entry, and vice versa.
+
+    This is the coverage guard: add a skill under skills/ and forget to list it
+    in plugin.meta.json (so it gets no plugin keyword) and this fails, instead
+    of the keyword silently going missing from every target's plugin.json.
     """
     errors: list[str] = []
+    meta_skills = meta.get("skills", {})
+    disk_skills = {d.name for d in iter_skill_dirs(repo_root)}
 
-    plugin_path = repo_root / ".claude-plugin" / "plugin.json"
-    marketplace_path = repo_root / ".claude-plugin" / "marketplace.json"
-
-    if not plugin_path.exists():
-        errors.append(f"Missing {plugin_path.relative_to(repo_root)}")
-    if not marketplace_path.exists():
-        errors.append(f"Missing {marketplace_path.relative_to(repo_root)}")
-    if errors:
-        return errors
-
-    try:
-        plugin = json.loads(plugin_path.read_text())
-    except json.JSONDecodeError as exc:
-        return [f"{plugin_path.relative_to(repo_root)} is not valid JSON: {exc}"]
-    try:
-        marketplace = json.loads(marketplace_path.read_text())
-    except json.JSONDecodeError as exc:
-        return [f"{marketplace_path.relative_to(repo_root)} is not valid JSON: {exc}"]
-
-    keywords = {k.lower() for k in plugin.get("keywords", [])}
-
-    for skill_dir in iter_skill_dirs(repo_root):
-        meta = SKILL_METADATA.get(skill_dir.name)
-        if meta is None:
-            errors.append(
-                f"Stable skill '{skill_dir.name}' has no SKILL_METADATA entry in "
-                "scripts/skills.py. Add one with a 'plugin_keyword' so its Claude "
-                "marketplace keyword in .claude-plugin/plugin.json stays in sync."
-            )
-            continue
-        expected_keyword = meta.get("plugin_keyword")
-        if not expected_keyword:
-            errors.append(
-                f"SKILL_METADATA['{skill_dir.name}'] is missing 'plugin_keyword'. "
-                "Add one so .claude-plugin/plugin.json keywords coverage can be validated."
-            )
-            continue
-        if expected_keyword.lower() not in keywords:
-            errors.append(
-                f"Skill '{skill_dir.name}' has no corresponding entry in "
-                f".claude-plugin/plugin.json 'keywords' (looking for '{expected_keyword}'). "
-                "Add it so the Claude marketplace listing stays in sync."
-            )
-
-    plugin_name = plugin.get("name")
-    market_plugins = marketplace.get("plugins", [])
-    market_entry = next((p for p in market_plugins if p.get("name") == plugin_name), None)
-    if market_entry is None:
+    for name in sorted(disk_skills - set(meta_skills)):
         errors.append(
-            f".claude-plugin/marketplace.json has no entry for plugin '{plugin_name}'."
+            f"Stable skill '{name}' has no entry in plugin.meta.json \"skills\". "
+            'Add one with a "keyword" so it gets a plugin keyword.'
         )
-    else:
-        if market_entry.get("description") != plugin.get("description"):
+    for name in sorted(set(meta_skills) - disk_skills):
+        errors.append(
+            f"plugin.meta.json \"skills\" lists '{name}' but skills/{name}/ does "
+            "not exist. Remove the entry or restore the skill."
+        )
+    for name, entry in meta_skills.items():
+        if not isinstance(entry, dict) or not entry.get("keyword"):
             errors.append(
-                ".claude-plugin/marketplace.json plugin description must match "
-                ".claude-plugin/plugin.json description (they drift independently otherwise)."
+                f'plugin.meta.json skills["{name}"] is missing a "keyword".'
             )
+    return errors
 
+
+def check_generated_plugins(repo_root: Path, meta: dict) -> list[str]:
+    """Fail if any generated plugin file drifts from what meta would produce."""
+    errors: list[str] = []
+    for rel, expected in generated_plugin_files(meta).items():
+        path = repo_root / rel
+        if not path.exists():
+            errors.append(f"Missing generated file {rel}.")
+            continue
+        actual = path.read_text()
+        if actual == expected:
+            continue
+        # Distinguish a content change from a pure formatting change for a
+        # clearer message, mirroring validate_manifest's two-stage check.
+        try:
+            same_content = json.loads(actual) == json.loads(expected)
+        except json.JSONDecodeError:
+            same_content = False
+        if same_content:
+            errors.append(
+                f"{rel} is not in canonical generated form (whitespace / key order)."
+            )
+        else:
+            errors.append(f"{rel} is out of date with plugin.meta.json.")
     return errors
 
 
@@ -573,7 +748,7 @@ def check_plugin_components(repo_root: Path) -> list[str]:
     try:
         plugin = json.loads(plugin_path.read_text()) if plugin_path.exists() else {}
     except json.JSONDecodeError as exc:
-        # validate_plugin_manifests reports the broken manifest itself; never
+        # check_generated_plugins reports the broken manifest itself; never
         # crash here, just skip the manifest-dependent checks.
         return [f".claude-plugin/plugin.json is not valid JSON: {exc}"]
 
@@ -792,8 +967,8 @@ def check_codex_plugin(repo_root: Path) -> list[str]:
     if claude_version and plugin.get("version") != claude_version:
         errors.append(
             f'.codex-plugin/plugin.json version ({plugin.get("version")}) must match '
-            f".claude-plugin/plugin.json ({claude_version}); scripts/bump_version.py "
-            "keeps them in sync at release time."
+            f".claude-plugin/plugin.json ({claude_version}); both are generated from "
+            'plugin.meta.json "version" -- run `python3 scripts/skills.py generate`.'
         )
 
     skills_rel = plugin.get("skills")
@@ -882,8 +1057,8 @@ def check_copilot_plugin(repo_root: Path) -> list[str]:
     if claude_version and plugin.get("version") != claude_version:
         errors.append(
             f'.github/plugin/plugin.json version ({plugin.get("version")}) must match '
-            f".claude-plugin/plugin.json ({claude_version}); scripts/bump_version.py "
-            "keeps them in sync at release time."
+            f".claude-plugin/plugin.json ({claude_version}); both are generated from "
+            'plugin.meta.json "version" -- run `python3 scripts/skills.py generate`.'
         )
 
     skills_rel = plugin.get("skills")
@@ -1055,6 +1230,12 @@ def main() -> None:
                 f"{', '.join(manifest['skills'].keys())}"
             )
 
+            meta = load_meta(repo_root)
+            written_plugins = generate_plugins(repo_root, meta)
+            print(
+                f"Generated {written_plugins} plugin manifest file(s) from {META_FILE}"
+            )
+
         case "validate":
             ok = True
 
@@ -1071,15 +1252,37 @@ def main() -> None:
             if not validate_manifest(repo_root):
                 ok = False
 
-            plugin_errors = validate_plugin_manifests(repo_root)
-            if plugin_errors:
+            try:
+                meta = load_meta(repo_root)
+            except (OSError, json.JSONDecodeError) as exc:
                 print(
-                    "ERROR: .claude-plugin manifests are out of sync with skills:",
+                    f"ERROR: cannot read {META_FILE} (the plugin source of truth): {exc}",
                     file=sys.stderr,
                 )
-                for err in plugin_errors:
-                    print(f"  - {err}", file=sys.stderr)
+                meta = None
                 ok = False
+
+            if meta is not None:
+                coverage_errors = check_meta_skill_coverage(repo_root, meta)
+                if coverage_errors:
+                    print(
+                        f"ERROR: {META_FILE} \"skills\" is out of sync with skills/:",
+                        file=sys.stderr,
+                    )
+                    for err in coverage_errors:
+                        print(f"  - {err}", file=sys.stderr)
+                    ok = False
+
+                drift_errors = check_generated_plugins(repo_root, meta)
+                if drift_errors:
+                    print(
+                        "ERROR: generated plugin manifests are out of date with "
+                        f"{META_FILE}:",
+                        file=sys.stderr,
+                    )
+                    for err in drift_errors:
+                        print(f"  - {err}", file=sys.stderr)
+                    ok = False
 
             component_errors = check_plugin_components(repo_root)
             if component_errors:
@@ -1133,10 +1336,10 @@ def main() -> None:
 
             if not ok:
                 print(
-                    "\nRun `python3 scripts/skills.py generate` to fix the "
-                    "manifest, and update .claude-plugin/plugin.json + "
-                    "marketplace.json by hand for any plugin-keyword/description "
-                    "mismatches.",
+                    "\nRun `python3 scripts/skills.py generate` to regenerate "
+                    "manifest.json and every target's plugin.json + marketplace.json "
+                    f"from {META_FILE}, then commit the result. For coverage errors, "
+                    f"add the missing skill to {META_FILE} \"skills\" first.",
                     file=sys.stderr,
                 )
                 sys.exit(1)

--- a/scripts/skills.py
+++ b/scripts/skills.py
@@ -560,9 +560,36 @@ def build_codex_marketplace(meta: dict) -> dict:
     }
 
 
+# Marker dropped in every generated-manifest directory. The JSON files
+# themselves cannot carry a "do not edit" comment (their loaders / the Claude
+# marketplace $schema reject unknown keys), so this sibling README is the
+# in-folder signal that the directory is generated. It is part of the generated
+# set, so the drift check keeps it present and current.
+_GENERATED_README = """\
+<!-- GENERATED FILE: do not edit by hand. -->
+
+# Generated plugin manifests
+
+The plugin manifest files in this directory (`plugin.json` and/or
+`marketplace.json`) are generated from the repo-root `plugin.meta.json` by
+`scripts/skills.py`. To change them, edit `plugin.meta.json` and run
+`python3 scripts/skills.py generate`. CI re-renders these files and fails on any
+drift, so hand-edits are reverted. See `CONTRIBUTING.md` ("Plugin metadata").
+"""
+
+# Directories whose plugin/marketplace JSON is generated; each gets the marker.
+_GENERATED_MANIFEST_DIRS = (
+    ".claude-plugin",
+    ".codex-plugin",
+    ".github/plugin",
+    ".cursor-plugin",
+    ".agents/plugins",
+)
+
+
 def generated_plugin_files(meta: dict) -> dict:
     """Map every generated plugin file (repo-relative path -> canonical text)."""
-    return {
+    files = {
         ".claude-plugin/plugin.json": _serialize_plugin_json(build_claude_plugin(meta)),
         ".codex-plugin/plugin.json": _serialize_plugin_json(build_codex_plugin(meta)),
         ".github/plugin/plugin.json": _serialize_plugin_json(build_copilot_plugin(meta)),
@@ -577,6 +604,9 @@ def generated_plugin_files(meta: dict) -> dict:
             build_codex_marketplace(meta)
         ),
     }
+    for directory in _GENERATED_MANIFEST_DIRS:
+        files[f"{directory}/README.md"] = _GENERATED_README
+    return files
 
 
 def generate_plugins(repo_root: Path, meta: dict) -> int:

--- a/tests/skills_generator_test.py
+++ b/tests/skills_generator_test.py
@@ -35,8 +35,15 @@ class GeneratedPluginsTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             root = Path(d)
             written = skills.generate_plugins(root, self.meta)
-            self.assertEqual(written, 7)
+            self.assertEqual(written, len(skills.generated_plugin_files(self.meta)))
             self.assertEqual(skills.check_generated_plugins(root, self.meta), [])
+
+    def test_each_dir_has_generated_marker(self):
+        # Every generated-manifest directory ships a README marker so a reader
+        # browsing the folder sees it is generated.
+        files = skills.generated_plugin_files(self.meta)
+        for directory in skills._GENERATED_MANIFEST_DIRS:
+            self.assertIn(f"{directory}/README.md", files)
 
     def test_content_drift_detected(self):
         with tempfile.TemporaryDirectory() as d:

--- a/tests/skills_generator_test.py
+++ b/tests/skills_generator_test.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Unit tests for the plugin.meta.json -> plugin manifests generator.
+
+P1 made plugin.meta.json the single source of truth and generates every
+target's plugin.json + marketplace.json from it, with a CI drift guard. These
+tests pin that machinery (byte-reproducible generation, drift detection, skill
+coverage) so a future refactor of a build_* renderer can't silently change a
+target's output. Stdlib-only; run with:
+  python3 -m unittest discover -s tests -p "*_test.py"
+"""
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location("skills", _REPO / "scripts" / "skills.py")
+skills = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(skills)
+
+
+class GeneratedPluginsTest(unittest.TestCase):
+    def setUp(self):
+        self.meta = skills.load_meta(_REPO)
+
+    def test_repo_is_canonical(self):
+        # The committed plugin manifests must equal what the generator produces
+        # from plugin.meta.json, and every skill must be covered. This pins the
+        # committed state even if the validate wiring changes.
+        self.assertEqual(skills.check_generated_plugins(_REPO, self.meta), [])
+        self.assertEqual(skills.check_meta_skill_coverage(_REPO, self.meta), [])
+
+    def test_generate_roundtrips_clean(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            written = skills.generate_plugins(root, self.meta)
+            self.assertEqual(written, 7)
+            self.assertEqual(skills.check_generated_plugins(root, self.meta), [])
+
+    def test_content_drift_detected(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            skills.generate_plugins(root, self.meta)
+            target = root / ".claude-plugin" / "plugin.json"
+            data = json.loads(target.read_text())
+            data["version"] = "9.9.9"
+            target.write_text(json.dumps(data, indent=2) + "\n")
+            errors = skills.check_generated_plugins(root, self.meta)
+            self.assertTrue(
+                any("out of date" in e and ".claude-plugin/plugin.json" in e for e in errors),
+                errors,
+            )
+
+    def test_formatting_drift_detected(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            skills.generate_plugins(root, self.meta)
+            target = root / ".codex-plugin" / "plugin.json"
+            # Same content, non-canonical formatting (4-space + sorted keys).
+            data = json.loads(target.read_text())
+            target.write_text(json.dumps(data, indent=4, sort_keys=True) + "\n")
+            errors = skills.check_generated_plugins(root, self.meta)
+            self.assertTrue(
+                any("canonical generated form" in e for e in errors), errors
+            )
+
+    def test_missing_file_detected(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            skills.generate_plugins(root, self.meta)
+            (root / ".cursor-plugin" / "plugin.json").unlink()
+            errors = skills.check_generated_plugins(root, self.meta)
+            self.assertTrue(
+                any("Missing generated file .cursor-plugin/plugin.json" in e for e in errors),
+                errors,
+            )
+
+    def test_keyword_composition(self):
+        kw = skills.build_keywords(self.meta)
+        skill_kws = [s["keyword"] for s in self.meta["skills"].values()]
+        expected = [
+            *self.meta["keywords_lead"],
+            *skill_kws,
+            *self.meta["keywords_tail"],
+        ]
+        self.assertEqual(kw, expected)
+        # No duplicate keywords (lead/tail must not collide with a skill keyword).
+        self.assertEqual(len(kw), len(set(kw)))
+
+    def test_all_targets_share_one_version(self):
+        versions = {
+            build(self.meta)["version"]
+            for build in (
+                skills.build_claude_plugin,
+                skills.build_codex_plugin,
+                skills.build_copilot_plugin,
+                skills.build_cursor_plugin,
+            )
+        }
+        self.assertEqual(versions, {self.meta["version"]})
+
+    def test_name_is_databricks_everywhere(self):
+        # The plugin name keys Cursor/Claude installs; the generator must never
+        # emit anything but "databricks".
+        for build in (
+            skills.build_claude_plugin,
+            skills.build_codex_plugin,
+            skills.build_copilot_plugin,
+            skills.build_cursor_plugin,
+        ):
+            self.assertEqual(build(self.meta)["name"], "databricks")
+
+    def test_claude_plugin_has_no_hooks_key(self):
+        # hooks/hooks.json is auto-loaded by Claude Code; declaring it double-loads.
+        self.assertNotIn("hooks", skills.build_claude_plugin(self.meta))
+
+
+class MetaSkillCoverageTest(unittest.TestCase):
+    def _make_skill(self, root: Path, name: str) -> None:
+        skill_dir = root / "skills" / name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(f"---\nname: {name}\n---\n")
+
+    def test_clean(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            self._make_skill(root, "databricks-core")
+            meta = {"skills": {"databricks-core": {"keyword": "cli"}}}
+            self.assertEqual(skills.check_meta_skill_coverage(root, meta), [])
+
+    def test_disk_skill_missing_from_meta(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            self._make_skill(root, "databricks-core")
+            self._make_skill(root, "databricks-newthing")
+            meta = {"skills": {"databricks-core": {"keyword": "cli"}}}
+            errors = skills.check_meta_skill_coverage(root, meta)
+            self.assertTrue(any("databricks-newthing" in e for e in errors), errors)
+
+    def test_meta_entry_without_disk_skill(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            self._make_skill(root, "databricks-core")
+            meta = {
+                "skills": {
+                    "databricks-core": {"keyword": "cli"},
+                    "databricks-ghost": {"keyword": "ghost"},
+                }
+            }
+            errors = skills.check_meta_skill_coverage(root, meta)
+            self.assertTrue(any("databricks-ghost" in e for e in errors), errors)
+
+    def test_missing_keyword(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            self._make_skill(root, "databricks-core")
+            meta = {"skills": {"databricks-core": {}}}
+            errors = skills.check_meta_skill_coverage(root, meta)
+            self.assertTrue(any("keyword" in e for e in errors), errors)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

The repo ships one logical plugin to four targets (Claude Code, Codex, Copilot, Cursor) plus three marketplace catalogs. Every target hand-maintained the same plugin metadata, and the copies drifted:

- Version was duplicated across all four `plugin.json` files (`0.2.4`).
- Codex's `plugin.json` was missing the `app-design` keyword that Claude's had.
- Cursor's description had gone stale ("...Unity Catalog...") versus the canonical one.

There was no single place to change the plugin's version, identity, description, or keywords.

## Changes

**Before:** four hand-edited `plugin.json` + three `marketplace.json`, kept in sync by hand (and `bump_version.py` regex-editing each manifest).

**Now:** `plugin.meta.json` at the repo root is the single source of truth, and `scripts/skills.py` generates all four `plugin.json` + three `marketplace.json` from it. CI re-renders them in memory and fails on any byte drift.

- `plugin.meta.json` (new): version, identity, description, author/urls/license, composed keywords, per-target config (display names, the Codex `interface`, hook/command/rule wiring), and the `skills` map (skill to plugin keyword, folding in the old `SKILL_METADATA`).
- `scripts/skills.py`: per-target builders, `generate_plugins`, a byte-drift check, and a skill-coverage check (every skill must have a meta entry and vice versa). Removed `SKILL_METADATA` and `validate_plugin_manifests` (subsumed). Kept the existing per-target hook/command/routing checks as defense-in-depth.
- `scripts/bump_version.py`: writes the version into `plugin.meta.json`, then regenerates everything, so all four targets always share one version.
- `.github/workflows/release.yml`: commits the full generated set (previously it staged only two of the four `plugin.json`, so Codex/Copilot bumps were never committed) and runs `validate` before tagging.
- `.github/workflows/validate-manifest.yml`: expanded PR triggers to every generated dir + `plugin.meta.json` + `rules/`.
- `tests/skills_generator_test.py` (new): 13 tests pinning generation, drift detection, and coverage.
- Also fixes the `databricks-core` manifest blurb, which truncated mid-word to "...Load this firs...", by adding ". Load this" as a short-description boundary.

Generating fixes the two existing drifts as a side effect: Codex gains `app-design`; Cursor's description becomes canonical. Every other generated file is byte-identical to what shipped before.

Note: the generated `plugin.json` / `marketplace.json` carry no "do-not-edit" comment key, because the plugin loaders and the Claude marketplace `$schema` reject unknown keys. Their generated status is documented in `CONTRIBUTING.md` and enforced by the drift check.

## Test plan

- [x] `python3 scripts/skills.py generate` produces a diff of only the two intended drift-fixes; all other generated files byte-identical.
- [x] `python3 scripts/skills.py validate` passes; the drift guard fails (exit 1) on a tampered manifest.
- [x] `python3 scripts/bump_version.py vX.Y.Z` propagates the version to all four `plugin.json` and round-trips cleanly.
- [x] `python3 -m unittest discover -s tests -p '*_test.py'` (65 tests) passes.
- [x] Adversarial review (4 reviewers + per-finding verification): 6 findings, all low/nit, all addressed.

This pull request and its description were written by Isaac.
