### PR TITLE
feat(routing): generate routing tables from plugin.meta.json (P2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,12 @@ config, edit `plugin.meta.json` and run `python3 scripts/skills.py generate`; CI
 and propagates to all four targets. Adding a stable skill requires an entry in
 the `skills` map (with a `keyword`).
 
+The `routing` block in `plugin.meta.json` is generated too: it renders the
+prompt router's data (`hooks/_routing_data.json`, loaded by
+`hooks/databricks-router.py`) and the Cursor rule
+(`rules/databricks-routing.mdc`) from one table. Do not hand-edit those; edit
+`plugin.meta.json` and regenerate. CI fails if a product skill has no routing row.
+
 ## Plugin components (hooks + commands)
 
 Beyond skills, the Claude Code plugin ships two component dirs at the repo root.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,13 @@ keywords_tail`, in the insertion order of the `skills` map. The plugin `name` is
 `databricks` for every target and is load-bearing (it keys Cursor/Claude
 installs); the generator never emits a different value.
 
+The `routing` block in `plugin.meta.json` is also generated output: the
+product-skill table there is rendered into both the prompt router's data
+(`hooks/_routing_data.json`, which `hooks/databricks-router.py` loads) and the
+Cursor rule (`rules/databricks-routing.mdc`), so the two routing tables cannot
+drift. Add a product skill and CI fails until it has a `routing.table` row.
+Regenerate the same way: edit `plugin.meta.json`, run `scripts/skills.py generate`.
+
 ## Plugin components (hooks + commands)
 
 The Claude Code plugin ships more than skills:

--- a/README.md
+++ b/README.md
@@ -256,7 +256,10 @@ python3 scripts/skills.py validate   # CI check: fails on any drift
 name, description, keywords, author/license, per-target display names and
 hook/command/rule wiring, and the skill-to-keyword map. Adding a stable skill
 means adding it to the `skills` map there (with a `keyword`); CI fails if a
-shipped skill has no entry. See
+shipped skill has no entry. The same source also drives prompt routing: its
+`routing` block is rendered into the prompt router's data
+(`hooks/_routing_data.json`) and the Cursor routing rule
+(`rules/databricks-routing.mdc`) from one table, so they can't drift. See
 [CONTRIBUTING.md](./CONTRIBUTING.md) for the full field reference.
 
 ## Security

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -85,7 +85,14 @@ Precision is tuned to avoid over-routing:
   (`github.com/databricks/...`) does not route. URLs whose hostname contains
   `databricks` (workspace and docs hosts) still do.
 
-Edit those three lists when the product surface changes. Behavior is pinned by
+These three lists, plus the injected instruction, live in `plugin.meta.json`'s
+`routing` block and are generated into `_routing_data.json` (next to this
+script), which the router loads at import. To change them, edit
+`plugin.meta.json` and run `python3 scripts/skills.py generate`; do not
+hand-edit `_routing_data.json`. If that file is ever missing or unreadable the
+router falls back to a minimal inline config that routes only literal
+`databricks` mentions (fail-open), so an install that loses it keeps working but
+loses product-keyword routing until it is restored. Behavior is pinned by
 `tests/databricks_router_test.py`.
 
 ## `databricks-context.py`: context primer (SessionStart)

--- a/hooks/_routing_data.json
+++ b/hooks/_routing_data.json
@@ -1,0 +1,50 @@
+{
+  "//": "GENERATED FILE: do not edit. Rendered from plugin.meta.json \"routing\" by scripts/skills.py. Run `python3 scripts/skills.py generate`.",
+  "strong": [
+    "\\bdatabricks\\b",
+    "\\bunity\\s+catalog\\b",
+    "\\blakeflow\\b",
+    "\\blakebase\\b",
+    "\\bdbfs\\b",
+    "\\bdbutils\\b",
+    "\\bdbsql\\b",
+    "\\bdatabricks\\.yml\\b",
+    "\\basset\\s+bundle\\b",
+    "\\bdabs\\b",
+    "\\b(?:lakeflow|spark)\\s+declarative\\s+pipelines?\\b",
+    "\\bdelta\\s+live\\s+tables?\\b",
+    "\\bmosaic\\s+ai\\b",
+    "\\bdelta\\s+sharing\\b",
+    "\\bcloudfiles\\b"
+  ],
+  "ambiguous": [
+    "\\bgenie\\b",
+    "\\bdelta\\s+(lake|tables?)\\b",
+    "\\bdeclarative\\s+pipelines?\\b",
+    "\\bmodel\\s+serving\\b",
+    "\\bvector\\s+search\\b",
+    "\\bmlflow\\b",
+    "\\bpyspark\\b",
+    "\\bspark\\s*\\.\\s*(sql|read|write|table)\\b",
+    "\\bserverless\\s+(compute|warehouse|migration)\\b",
+    "\\bmedallion\\s+(architecture|tables?)\\b",
+    "\\bsql\\s+warehouse\\b",
+    "\\bauto\\s+loader\\b"
+  ],
+  "suppress": [
+    "\\bbigquery\\b",
+    "\\bredshift\\b",
+    "\\bsynapse\\b",
+    "\\bsnowflake\\b",
+    "\\bgit\\s+(commit|push|pull|status|log|diff|branch|rebase|merge|clone|stash)\\b",
+    "\\b(read|edit|open|write|create|delete)\\s+(the\\s+|this\\s+|a\\s+|that\\s+)?file\\b",
+    "\\bunit\\s+tests?\\b",
+    "\\bnpm\\b",
+    "\\bpip\\s+install\\b",
+    "\\bdocker\\b",
+    "\\bkubernetes\\b",
+    "\\bjenkins(?:file)?\\b"
+  ],
+  "instruction": "[DATABRICKS] This request is Databricks-related. Handle it through the Databricks skills rather than ad hoc commands. Use the Skill tool to load `databricks-core` first (the parent skill: CLI, auth, profile selection, data exploration), then load the product skill that matches the request:\n- Jobs / Lakeflow / workflows -> databricks-jobs\n- Pipelines / Lakeflow Spark Declarative Pipelines (formerly DLT) -> databricks-pipelines\n- Apps / AppKit -> databricks-apps\n- Asset Bundles / DABs / databricks.yml -> databricks-dabs\n- Model Serving / endpoints -> databricks-model-serving\n- Lakebase / Postgres -> databricks-lakebase\n- Vector Search / RAG -> databricks-vector-search\n- Classic-to-serverless migration -> databricks-serverless-migration\n- Genie / natural-language data Q&A -> databricks-core (Genie CLI support is experimental)\nThen follow the skill's guidance (it drives the `databricks` CLI). If no product skill fits, databricks-core alone is enough.",
+  "reminder": "[DATABRICKS] Databricks-related prompt: keep routing through the Databricks skills (databricks-core plus the matching product skill); load any that are not already loaded."
+}

--- a/hooks/databricks-router.py
+++ b/hooks/databricks-router.py
@@ -53,7 +53,14 @@ _FALLBACK_REMINDER = (
 
 
 def _load_routing_data(path=None):
-    """Load the generated _routing_data.json next to this file; None on any problem."""
+    """Load the generated _routing_data.json next to this file; None on any problem.
+
+    Returns None (so the inline fallback engages) for a missing, unreadable,
+    malformed, wrong-typed, or regex-invalid file. The patterns are compiled
+    here, so a corrupt data file degrades the router to "route obvious
+    databricks mentions" rather than raising at import (which would otherwise
+    take the whole hook down, fallback included).
+    """
     try:
         if path is None:
             path = Path(__file__).resolve().parent / "_routing_data.json"
@@ -65,6 +72,16 @@ def _load_routing_data(path=None):
     if not all(
         k in data for k in ("strong", "ambiguous", "suppress", "instruction", "reminder")
     ):
+        return None
+    if not all(isinstance(data[k], list) for k in ("strong", "ambiguous", "suppress")):
+        return None
+    if not all(isinstance(data[k], str) for k in ("instruction", "reminder")):
+        return None
+    try:
+        for key in ("strong", "ambiguous", "suppress"):
+            for pattern in data[key]:
+                re.compile(pattern)
+    except (re.error, TypeError):
         return None
     return data
 

--- a/hooks/databricks-router.py
+++ b/hooks/databricks-router.py
@@ -10,6 +10,11 @@ There is no second agent to delegate to: Claude itself drives the `databricks`
 CLI through the skills, so "routing" just means "make sure the Databricks skills
 are loaded." No permission gating, no cost warnings.
 
+The keyword lists and the injected instruction are generated from
+plugin.meta.json into `_routing_data.json` next to this file and loaded at
+import time; a minimal inline fallback keeps the hook working if that file is
+missing or unreadable. Regenerate with `python3 scripts/skills.py generate`.
+
 The full routing instruction is injected once per session (keyed by the
 payload's session_id via a marker file in the temp dir); later Databricks
 prompts in the same session get a one-line reminder instead, keeping repeat
@@ -28,59 +33,59 @@ import sys
 import tempfile
 from pathlib import Path
 
-# Unambiguously Databricks -> always route, even alongside a mention of an
-# alternative platform (e.g. "migrate from redshift to databricks").
-STRONG = [
-    r"\bdatabricks\b",
-    r"\bunity\s+catalog\b",
-    r"\blakeflow\b",
-    r"\blakebase\b",
-    r"\bdbfs\b",
-    r"\bdbutils\b",
-    r"\bdbsql\b",
-    r"\bdatabricks\.yml\b",
-    r"\basset\s+bundle\b",
-    r"\bdabs\b",
-    r"\b(?:lakeflow|spark)\s+declarative\s+pipelines?\b",
-    r"\bdelta\s+live\s+tables?\b",  # legacy name for Declarative Pipelines
-    r"\bmosaic\s+ai\b",
-    r"\bdelta\s+sharing\b",
-    r"\bcloudfiles\b",
-]
+# Routing config (keyword lists + the injected instruction) is generated from
+# plugin.meta.json into _routing_data.json next to this file (see
+# rules/README.md and CONTRIBUTING.md) and loaded at import time. If that file
+# is missing or unreadable the hook stays fail-open via a minimal inline
+# fallback that still routes obvious Databricks prompts.
+_FALLBACK_STRONG = [r"\bdatabricks\b"]
+_FALLBACK_AMBIGUOUS = []
+_FALLBACK_SUPPRESS = []
+_FALLBACK_INSTRUCTION = (
+    "[DATABRICKS] This request is Databricks-related. Handle it through the "
+    "Databricks skills rather than ad hoc commands: load `databricks-core` (the "
+    "parent skill) plus the matching product skill before answering."
+)
+_FALLBACK_REMINDER = (
+    "[DATABRICKS] Databricks-related prompt: keep routing through the Databricks "
+    "skills (databricks-core plus the matching product skill)."
+)
 
-# Databricks-likely but also used elsewhere -> route only when no
-# alternative-platform / local-dev signal is present.
-AMBIGUOUS = [
-    r"\bgenie\b",
-    r"\bdelta\s+(lake|tables?)\b",
-    r"\bdeclarative\s+pipelines?\b",  # bare form collides with Jenkins pipelines
-    r"\bmodel\s+serving\b",
-    r"\bvector\s+search\b",
-    r"\bmlflow\b",
-    r"\bpyspark\b",
-    r"\bspark\s*\.\s*(sql|read|write|table)\b",
-    r"\bserverless\s+(compute|warehouse|migration)\b",
-    r"\bmedallion\s+(architecture|tables?)\b",
-    r"\bsql\s+warehouse\b",
-    r"\bauto\s+loader\b",
-]
 
-# Alternative data platforms + plainly-local dev work -> suppress an AMBIGUOUS
-# match. (STRONG matches ignore this list.)
-SUPPRESS = [
-    r"\bbigquery\b",
-    r"\bredshift\b",
-    r"\bsynapse\b",
-    r"\bsnowflake\b",
-    r"\bgit\s+(commit|push|pull|status|log|diff|branch|rebase|merge|clone|stash)\b",
-    r"\b(read|edit|open|write|create|delete)\s+(the\s+|this\s+|a\s+|that\s+)?file\b",
-    r"\bunit\s+tests?\b",
-    r"\bnpm\b",
-    r"\bpip\s+install\b",
-    r"\bdocker\b",
-    r"\bkubernetes\b",
-    r"\bjenkins(?:file)?\b",
-]
+def _load_routing_data(path=None):
+    """Load the generated _routing_data.json next to this file; None on any problem."""
+    try:
+        if path is None:
+            path = Path(__file__).resolve().parent / "_routing_data.json"
+        data = json.loads(Path(path).read_text())
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    if not all(
+        k in data for k in ("strong", "ambiguous", "suppress", "instruction", "reminder")
+    ):
+        return None
+    return data
+
+
+_DATA = _load_routing_data()
+
+# STRONG: unambiguously Databricks -> always route, even alongside a mention of
+# an alternative platform (e.g. "migrate from redshift to databricks").
+# AMBIGUOUS: Databricks-likely but also used elsewhere -> route only when no
+# SUPPRESS signal (alternative platform / local dev) is present. STRONG matches
+# ignore SUPPRESS. All are sourced from the generated data file; the inline
+# fallback degrades gracefully (routes only clear "databricks" mentions).
+STRONG = list(_DATA["strong"]) if _DATA else list(_FALLBACK_STRONG)
+AMBIGUOUS = list(_DATA["ambiguous"]) if _DATA else list(_FALLBACK_AMBIGUOUS)
+SUPPRESS = list(_DATA["suppress"]) if _DATA else list(_FALLBACK_SUPPRESS)
+
+# The full instruction injected on the session's first Databricks prompt, plus
+# the one-line reminder for later prompts. ROUTING_INSTRUCTION stays a
+# module-level attribute (scripts/skills.py check_routing_tables reads it).
+ROUTING_INSTRUCTION = _DATA["instruction"] if _DATA else _FALLBACK_INSTRUCTION
+ROUTING_REMINDER = _DATA["reminder"] if _DATA else _FALLBACK_REMINDER
 
 _STRONG = [re.compile(p, re.IGNORECASE) for p in STRONG]
 _AMBIGUOUS = [re.compile(p, re.IGNORECASE) for p in AMBIGUOUS]
@@ -104,33 +109,6 @@ def _strip_non_databricks_urls(text):
 
     return _URL_RE.sub(_keep_or_blank, text)
 
-ROUTING_INSTRUCTION = (
-    "[DATABRICKS] This request is Databricks-related. Handle it through the "
-    "Databricks skills rather than ad hoc commands. Use the Skill tool to load "
-    "`databricks-core` first (the parent skill: CLI, auth, profile selection, "
-    "data exploration), then load the product skill that matches the request:\n"
-    "- Jobs / Lakeflow / workflows -> databricks-jobs\n"
-    "- Pipelines / Lakeflow Spark Declarative Pipelines (formerly DLT) -> "
-    "databricks-pipelines\n"
-    "- Apps / AppKit -> databricks-apps\n"
-    "- Asset Bundles / DABs / databricks.yml -> databricks-dabs\n"
-    "- Model Serving / endpoints -> databricks-model-serving\n"
-    "- Lakebase / Postgres -> databricks-lakebase\n"
-    "- Vector Search / RAG -> databricks-vector-search\n"
-    "- Classic-to-serverless migration -> databricks-serverless-migration\n"
-    "- Genie / natural-language data Q&A -> databricks-core (Genie CLI support "
-    "is experimental)\n"
-    "Then follow the skill's guidance (it drives the `databricks` CLI). If no "
-    "product skill fits, databricks-core alone is enough."
-)
-
-# After the first routed prompt the skills are loaded (or being loaded), so the
-# rest of the session gets this one-liner instead of the full block above.
-ROUTING_REMINDER = (
-    "[DATABRICKS] Databricks-related prompt: keep routing through the "
-    "Databricks skills (databricks-core plus the matching product skill); load "
-    "any that are not already loaded."
-)
 
 _SESSION_ID_SAFE_RE = re.compile(r"[^A-Za-z0-9._-]")
 

--- a/plugin.meta.json
+++ b/plugin.meta.json
@@ -53,7 +53,7 @@
     }
   },
 
-  "//skills": "Per-skill plugin metadata. Insertion order defines the keyword order in plugin.json: keywords = keywords_lead + [each skill's keyword] + keywords_tail. Repo-owned (does NOT live in SKILL.md frontmatter, which syncs from the internal source). Routing fields (label/order/strong/ambiguous) are added in P2a.",
+  "//skills": "Per-skill plugin metadata. Insertion order defines the keyword order in plugin.json: keywords = keywords_lead + [each skill's keyword] + keywords_tail. Repo-owned (does NOT live in SKILL.md frontmatter, which syncs from the internal source). Prompt-routing config lives in the separate routing block below.",
   "skills": {
     "databricks-core": { "keyword": "cli" },
     "databricks-apps": { "keyword": "apps" },
@@ -65,5 +65,80 @@
     "databricks-dabs": { "keyword": "dabs" },
     "databricks-serverless-migration": { "keyword": "serverless" },
     "databricks-vector-search": { "keyword": "vector-search" }
+  },
+
+  "//routing": "Prompt-router + Cursor-rule routing config, rendered by scripts/skills.py. strong/ambiguous/suppress are regex patterns (backslashes are doubled for JSON). The router (hooks/databricks-router.py) loads the generated hooks/_routing_data.json; the Cursor rule (rules/databricks-routing.mdc) and the router instruction are both rendered from the single `table`, so the two routing tables cannot drift.",
+  "routing": {
+    "strong": [
+      "\\bdatabricks\\b",
+      "\\bunity\\s+catalog\\b",
+      "\\blakeflow\\b",
+      "\\blakebase\\b",
+      "\\bdbfs\\b",
+      "\\bdbutils\\b",
+      "\\bdbsql\\b",
+      "\\bdatabricks\\.yml\\b",
+      "\\basset\\s+bundle\\b",
+      "\\bdabs\\b",
+      "\\b(?:lakeflow|spark)\\s+declarative\\s+pipelines?\\b",
+      "\\bdelta\\s+live\\s+tables?\\b",
+      "\\bmosaic\\s+ai\\b",
+      "\\bdelta\\s+sharing\\b",
+      "\\bcloudfiles\\b"
+    ],
+    "ambiguous": [
+      "\\bgenie\\b",
+      "\\bdelta\\s+(lake|tables?)\\b",
+      "\\bdeclarative\\s+pipelines?\\b",
+      "\\bmodel\\s+serving\\b",
+      "\\bvector\\s+search\\b",
+      "\\bmlflow\\b",
+      "\\bpyspark\\b",
+      "\\bspark\\s*\\.\\s*(sql|read|write|table)\\b",
+      "\\bserverless\\s+(compute|warehouse|migration)\\b",
+      "\\bmedallion\\s+(architecture|tables?)\\b",
+      "\\bsql\\s+warehouse\\b",
+      "\\bauto\\s+loader\\b"
+    ],
+    "suppress": [
+      "\\bbigquery\\b",
+      "\\bredshift\\b",
+      "\\bsynapse\\b",
+      "\\bsnowflake\\b",
+      "\\bgit\\s+(commit|push|pull|status|log|diff|branch|rebase|merge|clone|stash)\\b",
+      "\\b(read|edit|open|write|create|delete)\\s+(the\\s+|this\\s+|a\\s+|that\\s+)?file\\b",
+      "\\bunit\\s+tests?\\b",
+      "\\bnpm\\b",
+      "\\bpip\\s+install\\b",
+      "\\bdocker\\b",
+      "\\bkubernetes\\b",
+      "\\bjenkins(?:file)?\\b"
+    ],
+    "//table": "Ordered product-skill routing table. Both the router instruction and the Cursor .mdc rule render their rows from here. A skill's `note` is appended after the skill name (Genie's experimental caveat).",
+    "table": [
+      { "label": "Jobs / Lakeflow / workflows", "skill": "databricks-jobs" },
+      { "label": "Pipelines / Lakeflow Spark Declarative Pipelines (formerly DLT)", "skill": "databricks-pipelines" },
+      { "label": "Apps / AppKit", "skill": "databricks-apps" },
+      { "label": "Asset Bundles / DABs / databricks.yml", "skill": "databricks-dabs" },
+      { "label": "Model Serving / endpoints", "skill": "databricks-model-serving" },
+      { "label": "Lakebase / Postgres", "skill": "databricks-lakebase" },
+      { "label": "Vector Search / RAG", "skill": "databricks-vector-search" },
+      { "label": "Classic-to-serverless migration", "skill": "databricks-serverless-migration" },
+      { "label": "Genie / natural-language data Q&A", "skill": "databricks-core", "note": " (Genie CLI support is experimental)" }
+    ],
+    "instruction_preamble": "[DATABRICKS] This request is Databricks-related. Handle it through the Databricks skills rather than ad hoc commands. Use the Skill tool to load `databricks-core` first (the parent skill: CLI, auth, profile selection, data exploration), then load the product skill that matches the request:",
+    "instruction_closing": "Then follow the skill's guidance (it drives the `databricks` CLI). If no product skill fits, databricks-core alone is enough.",
+    "reminder": "[DATABRICKS] Databricks-related prompt: keep routing through the Databricks skills (databricks-core plus the matching product skill); load any that are not already loaded.",
+    "rule_description": "Routing for any Databricks task -- CLI, auth, profiles, data exploration, Jobs/Lakeflow, Spark Declarative Pipelines (formerly DLT), Apps/AppKit, Asset Bundles/DABs, Model Serving, Lakebase/Postgres, Vector Search/RAG, Genie, and classic-to-serverless migration. Apply when the request is Databricks-related so the Databricks skills are loaded instead of ad hoc commands.",
+    "rule_preamble": [
+      "This request is Databricks-related. Handle it through the Databricks skills",
+      "rather than ad hoc commands. Load the `databricks-core` skill first (the parent:",
+      "CLI, auth, profile selection, data exploration), then load the product skill",
+      "that matches the request:"
+    ],
+    "rule_closing": [
+      "Then follow the skill's guidance (it drives the `databricks` CLI). If no product",
+      "skill fits, databricks-core alone is enough."
+    ]
   }
 }

--- a/rules/README.md
+++ b/rules/README.md
@@ -1,0 +1,9 @@
+<!-- GENERATED FILE: do not edit by hand. -->
+
+# Generated Cursor routing rule
+
+`databricks-routing.mdc` in this directory is generated from the repo-root
+`plugin.meta.json` (the `routing` block) by `scripts/skills.py`, alongside the
+prompt router's `hooks/_routing_data.json`, so the two routing tables stay in
+sync. To change routing, edit `plugin.meta.json` and run
+`python3 scripts/skills.py generate`. CI fails on any drift. See `CONTRIBUTING.md`.

--- a/scripts/skills.py
+++ b/scripts/skills.py
@@ -651,10 +651,14 @@ def check_meta_skill_coverage(repo_root: Path, meta: dict) -> list[str]:
     return errors
 
 
-def check_generated_plugins(repo_root: Path, meta: dict) -> list[str]:
-    """Fail if any generated plugin file drifts from what meta would produce."""
+def _check_generated_files(repo_root: Path, files: dict) -> list[str]:
+    """Fail if any generated file drifts from its expected text.
+
+    Two-stage like validate_manifest: same parsed content but different bytes ->
+    a formatting message; different content (or unparseable) -> out-of-date.
+    """
     errors: list[str] = []
-    for rel, expected in generated_plugin_files(meta).items():
+    for rel, expected in files.items():
         path = repo_root / rel
         if not path.exists():
             errors.append(f"Missing generated file {rel}.")
@@ -662,8 +666,6 @@ def check_generated_plugins(repo_root: Path, meta: dict) -> list[str]:
         actual = path.read_text()
         if actual == expected:
             continue
-        # Distinguish a content change from a pure formatting change for a
-        # clearer message, mirroring validate_manifest's two-stage check.
         try:
             same_content = json.loads(actual) == json.loads(expected)
         except json.JSONDecodeError:
@@ -674,6 +676,150 @@ def check_generated_plugins(repo_root: Path, meta: dict) -> list[str]:
             )
         else:
             errors.append(f"{rel} is out of date with plugin.meta.json.")
+    return errors
+
+
+def check_generated_plugins(repo_root: Path, meta: dict) -> list[str]:
+    """Fail if any generated plugin file drifts from what meta would produce."""
+    return _check_generated_files(repo_root, generated_plugin_files(meta))
+
+
+# ---------------------------------------------------------------------------
+# Routing (prompt-router data + Cursor rule, generated from meta "routing")
+# ---------------------------------------------------------------------------
+#
+# The product-skill routing table lives once in plugin.meta.json "routing".
+# Both the prompt router's instruction (rendered into hooks/_routing_data.json,
+# which the router loads) and the Cursor rule (rules/databricks-routing.mdc) are
+# rendered from that single table, so the two routing tables cannot drift.
+
+def _routing_rows(meta: dict) -> list[str]:
+    """The shared product-skill table rows ('- <label> -> <skill><note>')."""
+    return [
+        f"- {row['label']} -> {row['skill']}{row.get('note', '')}"
+        for row in meta["routing"]["table"]
+    ]
+
+
+def render_routing_instruction(meta: dict) -> str:
+    """The full UserPromptSubmit instruction the router injects (preamble + table + closing)."""
+    routing = meta["routing"]
+    rows = "".join(row + "\n" for row in _routing_rows(meta))
+    return routing["instruction_preamble"] + "\n" + rows + routing["instruction_closing"]
+
+
+def render_routing_rule(meta: dict) -> str:
+    """The Cursor Apply-Intelligently rule (rules/databricks-routing.mdc) text."""
+    routing = meta["routing"]
+    preamble = "\n".join(routing["rule_preamble"])
+    closing = "\n".join(routing["rule_closing"])
+    rows = "\n".join(_routing_rows(meta))
+    return (
+        "---\n"
+        f"description: {routing['rule_description']}\n"
+        "alwaysApply: false\n"
+        "---\n"
+        "\n"
+        f"{preamble}\n"
+        "\n"
+        f"{rows}\n"
+        "\n"
+        f"{closing}\n"
+    )
+
+
+def build_routing_data(meta: dict) -> dict:
+    """The hooks/_routing_data.json payload the router loads (fail-open)."""
+    routing = meta["routing"]
+    return {
+        "//": (
+            'GENERATED FILE: do not edit. Rendered from plugin.meta.json "routing" '
+            "by scripts/skills.py. Run `python3 scripts/skills.py generate`."
+        ),
+        "strong": routing["strong"],
+        "ambiguous": routing["ambiguous"],
+        "suppress": routing["suppress"],
+        "instruction": render_routing_instruction(meta),
+        "reminder": routing["reminder"],
+    }
+
+
+# Marker for the rules/ directory. databricks-routing.mdc is generated, but the
+# .mdc itself cannot carry a "do not edit" note (its whole body is injected into
+# the agent as the routing rule), so this sibling README is the signal. (The
+# generated hooks/_routing_data.json carries its own "//" header instead.)
+_ROUTING_RULE_README = """\
+<!-- GENERATED FILE: do not edit by hand. -->
+
+# Generated Cursor routing rule
+
+`databricks-routing.mdc` in this directory is generated from the repo-root
+`plugin.meta.json` (the `routing` block) by `scripts/skills.py`, alongside the
+prompt router's `hooks/_routing_data.json`, so the two routing tables stay in
+sync. To change routing, edit `plugin.meta.json` and run
+`python3 scripts/skills.py generate`. CI fails on any drift. See `CONTRIBUTING.md`.
+"""
+
+
+def generated_routing_files(meta: dict) -> dict:
+    """Map the generated routing files (repo-relative path -> canonical text)."""
+    return {
+        "hooks/_routing_data.json": json.dumps(build_routing_data(meta), indent=2) + "\n",
+        "rules/databricks-routing.mdc": render_routing_rule(meta),
+        "rules/README.md": _ROUTING_RULE_README,
+    }
+
+
+def generate_routing(repo_root: Path, meta: dict) -> int:
+    """Write the prompt-router data + Cursor rule from meta. Idempotent."""
+    files = generated_routing_files(meta)
+    for rel, text in files.items():
+        path = repo_root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+    return len(files)
+
+
+def check_generated_routing(repo_root: Path, meta: dict) -> list[str]:
+    """Fail if the generated routing files drift from what meta would produce."""
+    return _check_generated_files(repo_root, generated_routing_files(meta))
+
+
+def _skill_parent(skill_dir: Path) -> str | None:
+    """The `parent:` declared in a skill's SKILL.md frontmatter, or None."""
+    frontmatter = _read_frontmatter(skill_dir / "SKILL.md")
+    if not frontmatter:
+        return None
+    match = re.search(r"^parent:\s*(\S+)", frontmatter, re.MULTILINE)
+    if not match:
+        return None
+    return match.group(1).strip().strip('"').strip("'")
+
+
+def check_routing_coverage(repo_root: Path, meta: dict) -> list[str]:
+    """Every stable product skill must have a routing table row.
+
+    A skill needs routing if it is top-level (no parent) or sits directly under
+    databricks-core, excluding databricks-core itself. Skills nested under
+    another product skill (e.g. databricks-app-design, parent databricks-apps)
+    are reached via their parent and are exempt by derivation. This is the
+    coverage guard #151's check_routing_tables does not add (that one checks the
+    two tables agree and reference real skills, not that every product skill is
+    listed).
+    """
+    errors: list[str] = []
+    table_skills = {row["skill"] for row in meta.get("routing", {}).get("table", [])}
+    for skill_dir in iter_skill_dirs(repo_root):
+        name = skill_dir.name
+        if name == "databricks-core":
+            continue
+        parent = _skill_parent(skill_dir)
+        if parent in (None, "databricks-core") and name not in table_skills:
+            errors.append(
+                f"Stable skill '{name}' (parent {parent or 'none'}) has no routing row "
+                'in plugin.meta.json "routing"."table"; add one so the prompt router '
+                "and the Cursor rule can steer prompts to it."
+            )
     return errors
 
 
@@ -1266,6 +1412,11 @@ def main() -> None:
                 f"Generated {written_plugins} plugin manifest file(s) from {META_FILE}"
             )
 
+            written_routing = generate_routing(repo_root, meta)
+            print(
+                f"Generated {written_routing} routing file(s) from {META_FILE}"
+            )
+
         case "validate":
             ok = True
 
@@ -1311,6 +1462,28 @@ def main() -> None:
                         file=sys.stderr,
                     )
                     for err in drift_errors:
+                        print(f"  - {err}", file=sys.stderr)
+                    ok = False
+
+                routing_drift = check_generated_routing(repo_root, meta)
+                if routing_drift:
+                    print(
+                        "ERROR: generated routing files are out of date with "
+                        f"{META_FILE}:",
+                        file=sys.stderr,
+                    )
+                    for err in routing_drift:
+                        print(f"  - {err}", file=sys.stderr)
+                    ok = False
+
+                routing_coverage = check_routing_coverage(repo_root, meta)
+                if routing_coverage:
+                    print(
+                        "ERROR: a stable product skill is missing a routing row in "
+                        f"{META_FILE}:",
+                        file=sys.stderr,
+                    )
+                    for err in routing_coverage:
                         print(f"  - {err}", file=sys.stderr)
                     ok = False
 

--- a/scripts/skills.py
+++ b/scripts/skills.py
@@ -823,6 +823,30 @@ def check_routing_coverage(repo_root: Path, meta: dict) -> list[str]:
     return errors
 
 
+def check_routing_patterns(repo_root: Path, meta: dict) -> list[str]:
+    """Every routing regex in plugin.meta.json must compile.
+
+    The strong/ambiguous/suppress patterns round-trip through JSON into
+    hooks/_routing_data.json, which the router compiles at import. A bad pattern
+    would pass generate and the (text-only) drift check yet crash the router in
+    a real install, silently disabling all routing. Compiling them here makes a
+    bad pattern fail CI first. (The router also degrades to its fallback on a
+    bad pattern, but this catches it before it ever ships.)
+    """
+    errors: list[str] = []
+    routing = meta.get("routing", {})
+    for bucket in ("strong", "ambiguous", "suppress"):
+        for pattern in routing.get(bucket, []):
+            try:
+                re.compile(pattern)
+            except (re.error, TypeError) as exc:
+                errors.append(
+                    f'plugin.meta.json "routing"."{bucket}" pattern {pattern!r} '
+                    f"is not a valid regex: {exc}"
+                )
+    return errors
+
+
 # ---------------------------------------------------------------------------
 # Plugin components (hooks + commands)
 # ---------------------------------------------------------------------------
@@ -1484,6 +1508,17 @@ def main() -> None:
                         file=sys.stderr,
                     )
                     for err in routing_coverage:
+                        print(f"  - {err}", file=sys.stderr)
+                    ok = False
+
+                pattern_errors = check_routing_patterns(repo_root, meta)
+                if pattern_errors:
+                    print(
+                        f"ERROR: a routing regex in {META_FILE} does not compile "
+                        "(it would crash the prompt router in a real install):",
+                        file=sys.stderr,
+                    )
+                    for err in pattern_errors:
                         print(f"  - {err}", file=sys.stderr)
                     ok = False
 

--- a/tests/databricks_router_test.py
+++ b/tests/databricks_router_test.py
@@ -6,6 +6,7 @@ precision is pinned here (over-routing is annoying; under-routing misses work).
 Stdlib-only; run the suite with: python3 -m unittest discover -s tests -p "*_test.py"
 """
 import importlib.util
+import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -149,6 +150,50 @@ class SessionMemoTest(unittest.TestCase):
                 router.routing_context("deploy a databricks job", sid),
                 router.ROUTING_INSTRUCTION,
             )
+
+
+class RoutingDataLoadTest(unittest.TestCase):
+    """The router loads its keyword lists + instruction from the generated
+    _routing_data.json, falling back to a minimal inline config if it is
+    missing or unreadable (fail-open)."""
+
+    def test_loads_generated_data(self):
+        data = router._load_routing_data()
+        self.assertIsNotNone(data)
+        for key in ("strong", "ambiguous", "suppress", "instruction", "reminder"):
+            self.assertIn(key, data)
+        # The live config came from the data file, not the minimal fallback.
+        self.assertEqual(router.STRONG, list(data["strong"]))
+        self.assertEqual(router.ROUTING_INSTRUCTION, data["instruction"])
+        self.assertGreater(len(router.STRONG), len(router._FALLBACK_STRONG))
+
+    def test_missing_file_returns_none(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(router._load_routing_data(Path(tmp) / "nope.json"))
+
+    def test_corrupt_file_returns_none(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            bad = Path(tmp) / "_routing_data.json"
+            bad.write_text("{ not valid json ")
+            self.assertIsNone(router._load_routing_data(bad))
+
+    def test_incomplete_file_returns_none(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            partial = Path(tmp) / "_routing_data.json"
+            partial.write_text('{"strong": ["x"]}')
+            self.assertIsNone(router._load_routing_data(partial))
+
+    def test_fallback_still_routes_databricks(self):
+        # With no data file the inline fallback must still route an explicit
+        # "databricks" mention and carry a non-empty instruction/reminder.
+        self.assertTrue(
+            any(
+                re.search(p, "deploy a databricks job", re.IGNORECASE)
+                for p in router._FALLBACK_STRONG
+            )
+        )
+        self.assertTrue(router._FALLBACK_INSTRUCTION.strip())
+        self.assertTrue(router._FALLBACK_REMINDER.strip())
 
 
 if __name__ == "__main__":

--- a/tests/databricks_router_test.py
+++ b/tests/databricks_router_test.py
@@ -195,6 +195,27 @@ class RoutingDataLoadTest(unittest.TestCase):
         self.assertTrue(router._FALLBACK_INSTRUCTION.strip())
         self.assertTrue(router._FALLBACK_REMINDER.strip())
 
+    def test_bad_regex_returns_none(self):
+        # A shape-valid file with an uncompilable pattern must fall back rather
+        # than crash the router at import.
+        with tempfile.TemporaryDirectory() as tmp:
+            bad = Path(tmp) / "_routing_data.json"
+            bad.write_text(
+                '{"strong": ["(unclosed"], "ambiguous": [], "suppress": [], '
+                '"instruction": "x", "reminder": "y"}'
+            )
+            self.assertIsNone(router._load_routing_data(bad))
+
+    def test_wrong_type_returns_none(self):
+        # strong must be a list, not a string (which list() would shred into chars).
+        with tempfile.TemporaryDirectory() as tmp:
+            bad = Path(tmp) / "_routing_data.json"
+            bad.write_text(
+                '{"strong": "databricks", "ambiguous": [], "suppress": [], '
+                '"instruction": "x", "reminder": "y"}'
+            )
+            self.assertIsNone(router._load_routing_data(bad))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/routing_generator_test.py
+++ b/tests/routing_generator_test.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Tests for the routing generator (plugin.meta.json "routing" -> router + .mdc).
+
+The product-skill routing table lives once in plugin.meta.json and is rendered
+into both the prompt router's data (hooks/_routing_data.json) and the Cursor
+rule (rules/databricks-routing.mdc). These tests pin two things:
+
+1. The generated routing data equals the router's live values (STRONG /
+   AMBIGUOUS / SUPPRESS / ROUTING_INSTRUCTION / ROUTING_REMINDER). This is the
+   safety proof for the P2b cutover: because the generated data is byte-equal to
+   what the router already uses, switching the router to load it changes nothing.
+   (After the cutover these stay equal because the router loads exactly this.)
+2. The two rendered routing tables (router instruction + .mdc) name the same
+   skills, and every stable product skill is covered.
+
+Stdlib-only; run with: python3 -m unittest discover -s tests -p "*_test.py"
+"""
+import importlib.util
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+
+_skills_spec = importlib.util.spec_from_file_location(
+    "skills", _REPO / "scripts" / "skills.py"
+)
+skills = importlib.util.module_from_spec(_skills_spec)
+_skills_spec.loader.exec_module(skills)
+
+_router_spec = importlib.util.spec_from_file_location(
+    "databricks_router", _REPO / "hooks" / "databricks-router.py"
+)
+router = importlib.util.module_from_spec(_router_spec)
+_router_spec.loader.exec_module(router)
+
+
+class RoutingMatchesRouterTest(unittest.TestCase):
+    def setUp(self):
+        self.meta = skills.load_meta(_REPO)
+
+    def test_strong_matches_router(self):
+        self.assertEqual(self.meta["routing"]["strong"], list(router.STRONG))
+
+    def test_ambiguous_matches_router(self):
+        self.assertEqual(self.meta["routing"]["ambiguous"], list(router.AMBIGUOUS))
+
+    def test_suppress_matches_router(self):
+        self.assertEqual(self.meta["routing"]["suppress"], list(router.SUPPRESS))
+
+    def test_rendered_instruction_matches_router(self):
+        self.assertEqual(
+            skills.render_routing_instruction(self.meta), router.ROUTING_INSTRUCTION
+        )
+
+    def test_reminder_matches_router(self):
+        self.assertEqual(self.meta["routing"]["reminder"], router.ROUTING_REMINDER)
+
+
+class GeneratedRoutingFilesTest(unittest.TestCase):
+    def setUp(self):
+        self.meta = skills.load_meta(_REPO)
+
+    def test_rule_matches_disk(self):
+        disk = (_REPO / "rules" / "databricks-routing.mdc").read_text()
+        self.assertEqual(skills.render_routing_rule(self.meta), disk)
+
+    def test_routing_files_not_drifted(self):
+        self.assertEqual(skills.check_generated_routing(_REPO, self.meta), [])
+
+    def test_routing_data_payload_shape(self):
+        data = skills.build_routing_data(self.meta)
+        for key in ("strong", "ambiguous", "suppress", "instruction", "reminder"):
+            self.assertIn(key, data)
+
+
+class RoutingCoverageTest(unittest.TestCase):
+    def setUp(self):
+        self.meta = skills.load_meta(_REPO)
+
+    def test_coverage_clean(self):
+        self.assertEqual(skills.check_routing_coverage(_REPO, self.meta), [])
+
+    def test_required_skills_in_both_rendered_tables(self):
+        instruction = skills.render_routing_instruction(self.meta)
+        rule = skills.render_routing_rule(self.meta)
+        table_skills = {row["skill"] for row in self.meta["routing"]["table"]}
+        for skill_dir in skills.iter_skill_dirs(_REPO):
+            name = skill_dir.name
+            if name == "databricks-core":
+                continue
+            parent = skills._skill_parent(skill_dir)
+            if parent in (None, "databricks-core"):
+                self.assertIn(name, table_skills, f"{name} missing from routing table")
+                self.assertIn(name, instruction, f"{name} missing from router instruction")
+                self.assertIn(name, rule, f"{name} missing from Cursor rule")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/routing_generator_test.py
+++ b/tests/routing_generator_test.py
@@ -11,7 +11,11 @@ rule (rules/databricks-routing.mdc). These tests pin two things:
    what the router already uses, switching the router to load it changes nothing.
    (After the cutover these stay equal because the router loads exactly this.)
 2. The two rendered routing tables (router instruction + .mdc) name the same
-   skills, and every stable product skill is covered.
+   skills, every stable product skill is covered, and every regex compiles.
+
+Byte-identity of the generated data to the pre-P2 hand-authored router config
+was verified once at cutover time against git history; the invariant these
+tests enforce going forward is that meta and the generated data stay in sync.
 
 Stdlib-only; run with: python3 -m unittest discover -s tests -p "*_test.py"
 """
@@ -71,6 +75,11 @@ class GeneratedRoutingFilesTest(unittest.TestCase):
         data = skills.build_routing_data(self.meta)
         for key in ("strong", "ambiguous", "suppress", "instruction", "reminder"):
             self.assertIn(key, data)
+
+    def test_all_patterns_compile(self):
+        # A bad regex in meta would pass the text-only drift check yet crash the
+        # router at import; this guards against shipping one.
+        self.assertEqual(skills.check_routing_patterns(_REPO, self.meta), [])
 
 
 class RoutingCoverageTest(unittest.TestCase):


### PR DESCRIPTION
> Stacked on #152 (base branch `simonfaltum/meta-plugin-generator`). Review/merge #152 first; this PR's diff is just the two routing commits.

## Why

The product-skill routing table was duplicated in two hand-maintained places: the prompt router's `ROUTING_INSTRUCTION` (`hooks/databricks-router.py`, used on Claude/Codex) and the Cursor rule `rules/databricks-routing.mdc`. #151 added a check that the two *agree*, but nothing made them come from a single source, and the router's keyword lists (STRONG/AMBIGUOUS/SUPPRESS) lived only in the script.

## Changes

This is P2 of the meta-plugin work, in two commits so the risky part is reviewable in isolation.

**Commit 1 (`feat(routing)`, additive):** add a `routing` block to `plugin.meta.json` (the strong/ambiguous/suppress regex lists, the product-skill table, and the preamble/closing prose). `scripts/skills.py` renders it into:
- `hooks/_routing_data.json` (new) which the router loads, and
- `rules/databricks-routing.mdc` (regenerated **byte-identical** to the hand-authored file),

so both routing tables come from one `table` and cannot drift. Adds a drift check, a structural coverage check (every stable product skill needs a `routing.table` row, derived from its frontmatter `parent`), a `rules/README.md` "generated" marker, and cross-check tests asserting the rendered data equals the router's current values. The router is untouched in this commit.

**Commit 2 (`refactor(routing)`, the cutover):** `hooks/databricks-router.py` now loads its config from `_routing_data.json` instead of hardcoding it. Guarded and fail-open: if the file is missing or unreadable, a minimal inline fallback still routes obvious `databricks` prompts. `ROUTING_INSTRUCTION` stays a module attribute (the CI routing check reads it) and every public function is unchanged.

Routing behavior is identical: the cross-check tests prove the generated data equals the prior inline lists/instruction, so the cutover swaps the *source* of the config, not its values.

## Test plan

- [x] `scripts/skills.py generate` regenerates `rules/databricks-routing.mdc` byte-identically (no diff) and writes `_routing_data.json`.
- [x] Cross-check tests: rendered `strong`/`ambiguous`/`suppress`/`instruction`/`reminder` equal the router's values; `.mdc` equals disk.
- [x] Coverage check: every stable product skill (parent none or `databricks-core`) has a routing row; `app-design` (parent `databricks-apps`) and `core` exempt.
- [x] Router suite (keyword precision + session memo) + new fallback-path tests (missing/corrupt/incomplete data file) pass: 81 tests total.
- [x] `scripts/skills.py validate` green (includes the new routing drift + coverage checks and #151's table-sync check).
- [x] End-to-end smoke: piping a prompt to the hook emits the full instruction loaded from the data file.

This pull request and its description were written by Isaac.
