### PR TITLE
feat(hooks): generate the four hook-wiring dialects from plugin.meta.json (P3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,11 @@ prompt router's data (`hooks/_routing_data.json`, loaded by
 (`rules/databricks-routing.mdc`) from one table. Do not hand-edit those; edit
 `plugin.meta.json` and regenerate. CI fails if a product skill has no routing row.
 
+The four hook-wiring files (`hooks/hooks.json`, `codex-hooks.json`,
+`copilot-hooks.json`, `cursor-hooks.json`) are also generated, from the `hooks`
+block + each target's `hooks_render`. Edit `plugin.meta.json` and regenerate;
+the hook `*.py` scripts stay hand-written, only the wiring JSON is generated.
+
 ## Plugin components (hooks + commands)
 
 Beyond skills, the Claude Code plugin ships two component dirs at the repo root.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,12 @@ Cursor rule (`rules/databricks-routing.mdc`), so the two routing tables cannot
 drift. Add a product skill and CI fails until it has a `routing.table` row.
 Regenerate the same way: edit `plugin.meta.json`, run `scripts/skills.py generate`.
 
+The four hook-wiring files (`hooks/hooks.json`, `codex-hooks.json`,
+`copilot-hooks.json`, `cursor-hooks.json`) are generated from the `hooks` block
++ each target's `hooks_render` (the same three logical hooks rendered into each
+runtime's dialect). Edit `plugin.meta.json` and regenerate; only the wiring JSON
+is generated, the hook `*.py` scripts are hand-written.
+
 ## Plugin components (hooks + commands)
 
 The Claude Code plugin ships more than skills:

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -7,6 +7,16 @@ exits 0, so a broken hook never blocks a prompt, session start, or tool call).
 Code auto-loads `hooks/hooks.json`, so it is **not** declared in `plugin.json`
 (declaring the standard path double-loads it and fails the plugin).
 
+**The four hook-wiring files (`hooks.json`, `codex-hooks.json`,
+`copilot-hooks.json`, `cursor-hooks.json`) are generated** from
+`plugin.meta.json` (the `hooks` block + each target's `hooks_render`) by
+`scripts/skills.py`. They are the same three logical hooks rendered into each
+runtime's dialect (schema shape, event-name casing, env var, command form, tool
+matcher, and whether the router is wired). To change hook wiring, edit
+`plugin.meta.json` and run `python3 scripts/skills.py generate`; do not
+hand-edit these JSON files (CI fails on drift). The hook *scripts* (`*.py`) are
+hand-written; only the wiring JSON is generated.
+
 `cursor-hooks.json` wires the Cursor plugin and **is** declared explicitly (as
 `"hooks"` in `.cursor-plugin/plugin.json`), because Cursor's default plugin
 discovery would otherwise parse the Claude-format `hooks.json`. It runs the

--- a/plugin.meta.json
+++ b/plugin.meta.json
@@ -25,11 +25,25 @@
   "targets": {
     "claude": {
       "dir": ".claude-plugin",
-      "commands": "./commands/"
+      "commands": "./commands/",
+      "hooks_render": {
+        "out": "hooks/hooks.json",
+        "dialect": "nested",
+        "env_root": "${CLAUDE_PLUGIN_ROOT}",
+        "tool_matcher": "Bash",
+        "description": true
+      }
     },
     "codex": {
       "dir": ".codex-plugin",
       "hooks": "./hooks/codex-hooks.json",
+      "hooks_render": {
+        "out": "hooks/codex-hooks.json",
+        "dialect": "nested",
+        "env_root": "${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}",
+        "tool_matcher": "(?i)bash|shell|exec",
+        "description": false
+      },
       "interface": {
         "displayName": "Databricks",
         "shortDescription": "Databricks skills and hooks for Codex.",
@@ -42,14 +56,25 @@
     "copilot": {
       "dir": ".github/plugin",
       "displayName": "Databricks",
-      "hooks": "./hooks/copilot-hooks.json"
+      "hooks": "./hooks/copilot-hooks.json",
+      "hooks_render": {
+        "out": "hooks/copilot-hooks.json",
+        "dialect": "copilot",
+        "tool_matcher": "(?i)bash|shell|terminal"
+      }
     },
     "cursor": {
       "dir": ".cursor-plugin",
       "displayName": "Databricks Skills",
       "commands": "./commands-cursor/",
       "rules": "./rules/",
-      "hooks": "./hooks/cursor-hooks.json"
+      "hooks": "./hooks/cursor-hooks.json",
+      "hooks_render": {
+        "out": "hooks/cursor-hooks.json",
+        "dialect": "cursor",
+        "tool_matcher": "Shell",
+        "platform_flag": "--platform cursor"
+      }
     }
   },
 
@@ -139,6 +164,17 @@
     "rule_closing": [
       "Then follow the skill's guidance (it drives the `databricks` CLI). If no product",
       "skill fits, databricks-core alone is enough."
+    ]
+  },
+
+  "//hooks": "Canonical hook wiring, rendered into each target's dialect by scripts/skills.py: hooks/hooks.json (Claude, auto-loaded), codex-hooks.json, copilot-hooks.json, cursor-hooks.json. The shared content (the scripts, their events, the description, the session-start matcher) lives here once; per-target dialect knobs (schema shape, event casing, env var, command form, tool matcher, whether the router is wired) live under targets.*.hooks_render. The router is wired only on Claude + Codex (the other two cannot inject context from a prompt-submit hook).",
+  "hooks": {
+    "description": "Databricks plugin hooks: route Databricks prompts into the skills, prime session context, and hint on auth failures.",
+    "session_start_matcher": "startup|clear|compact",
+    "entries": [
+      { "id": "router", "event": "prompt_submit", "script": "databricks-router.py" },
+      { "id": "context", "event": "session_start", "script": "databricks-context.py" },
+      { "id": "auth", "event": "post_tool", "script": "databricks-auth-helper.py" }
     ]
   }
 }

--- a/scripts/skills.py
+++ b/scripts/skills.py
@@ -785,6 +785,150 @@ def check_generated_routing(repo_root: Path, meta: dict) -> list[str]:
     return _check_generated_files(repo_root, generated_routing_files(meta))
 
 
+# ---------------------------------------------------------------------------
+# Hooks (the four hook-wiring dialects, generated from meta "hooks")
+# ---------------------------------------------------------------------------
+#
+# Three logical hooks (router, context, auth) ship to four runtimes whose hook
+# wiring formats differ in schema shape, event-name casing, env-var convention,
+# command form, and which hooks are wired. The shared content lives once in
+# plugin.meta.json "hooks"; the build_* functions below render each target's
+# dialect. The router is wired only on Claude + Codex (Copilot/Cursor cannot
+# inject context from a prompt-submit hook). Generated event names land in the
+# per-platform allow-lists checked by _check_hook_event_names.
+
+def _hook_scripts(meta: dict) -> dict:
+    """Map hook id -> script filename from meta."""
+    return {entry["id"]: entry["script"] for entry in meta["hooks"]["entries"]}
+
+
+def _nested_command(env_root: str, script: str) -> str:
+    """The 'python3 X || python X || true' fallback chain for Claude/Codex."""
+    target = f'"{env_root}/hooks/{script}"'
+    return f"python3 {target} || python {target} || true"
+
+
+def build_nested_hooks(meta: dict, target_key: str) -> dict:
+    """Claude / Codex dialect: nested hooks arrays, PascalCase events, the
+    env-var-rooted fallback-chain command, router included. Differs between the
+    two only in env_root, tool_matcher, and whether the description is present.
+    """
+    hooks_meta = meta["hooks"]
+    render = meta["targets"][target_key]["hooks_render"]
+    scripts = _hook_scripts(meta)
+    env_root = render["env_root"]
+
+    result: dict = {}
+    if render.get("description"):
+        result["description"] = hooks_meta["description"]
+    result["hooks"] = {
+        "UserPromptSubmit": [
+            {
+                "hooks": [
+                    {"type": "command", "command": _nested_command(env_root, scripts["router"])}
+                ]
+            }
+        ],
+        "SessionStart": [
+            {
+                "matcher": hooks_meta["session_start_matcher"],
+                "hooks": [
+                    {"type": "command", "command": _nested_command(env_root, scripts["context"])}
+                ],
+            }
+        ],
+        "PostToolUse": [
+            {
+                "matcher": render["tool_matcher"],
+                "hooks": [
+                    {"type": "command", "command": _nested_command(env_root, scripts["auth"])}
+                ],
+            }
+        ],
+    }
+    return result
+
+
+def build_copilot_hooks(meta: dict) -> dict:
+    """Copilot dialect: version 1, flat entries with bash/powershell variants,
+    PascalCase events, repo-relative paths, no router.
+    """
+    render = meta["targets"]["copilot"]["hooks_render"]
+    scripts = _hook_scripts(meta)
+
+    def entry(script: str, matcher: str | None) -> dict:
+        item: dict = {"type": "command"}
+        if matcher is not None:
+            item["matcher"] = matcher
+        item["bash"] = f"python3 hooks/{script}"
+        item["powershell"] = f"python hooks/{script}"
+        return item
+
+    return {
+        "version": 1,
+        "hooks": {
+            "SessionStart": [entry(scripts["context"], None)],
+            "PostToolUse": [entry(scripts["auth"], render["tool_matcher"])],
+        },
+    }
+
+
+def build_cursor_hooks(meta: dict) -> dict:
+    """Cursor dialect: version 1, flat entries with a single command plus the
+    --platform cursor flag, camelCase events, no router.
+    """
+    render = meta["targets"]["cursor"]["hooks_render"]
+    scripts = _hook_scripts(meta)
+    flag = render["platform_flag"]
+
+    def entry(script: str, matcher: str | None) -> dict:
+        item: dict = {"command": f"python3 hooks/{script} {flag}"}
+        if matcher is not None:
+            item["matcher"] = matcher
+        return item
+
+    return {
+        "version": 1,
+        "hooks": {
+            "sessionStart": [entry(scripts["context"], None)],
+            "postToolUse": [entry(scripts["auth"], render["tool_matcher"])],
+        },
+    }
+
+
+def generated_hook_files(meta: dict) -> dict:
+    """Map the generated hook-wiring files (repo-relative path -> canonical text)."""
+    return {
+        meta["targets"]["claude"]["hooks_render"]["out"]: _serialize_plugin_json(
+            build_nested_hooks(meta, "claude")
+        ),
+        meta["targets"]["codex"]["hooks_render"]["out"]: _serialize_plugin_json(
+            build_nested_hooks(meta, "codex")
+        ),
+        meta["targets"]["copilot"]["hooks_render"]["out"]: _serialize_plugin_json(
+            build_copilot_hooks(meta)
+        ),
+        meta["targets"]["cursor"]["hooks_render"]["out"]: _serialize_plugin_json(
+            build_cursor_hooks(meta)
+        ),
+    }
+
+
+def generate_hooks(repo_root: Path, meta: dict) -> int:
+    """Write each target's hook-wiring file from meta. Idempotent."""
+    files = generated_hook_files(meta)
+    for rel, text in files.items():
+        path = repo_root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+    return len(files)
+
+
+def check_generated_hooks(repo_root: Path, meta: dict) -> list[str]:
+    """Fail if any generated hook-wiring file drifts from what meta would produce."""
+    return _check_generated_files(repo_root, generated_hook_files(meta))
+
+
 def _skill_parent(skill_dir: Path) -> str | None:
     """The `parent:` declared in a skill's SKILL.md frontmatter, or None."""
     frontmatter = _read_frontmatter(skill_dir / "SKILL.md")
@@ -1441,6 +1585,11 @@ def main() -> None:
                 f"Generated {written_routing} routing file(s) from {META_FILE}"
             )
 
+            written_hooks = generate_hooks(repo_root, meta)
+            print(
+                f"Generated {written_hooks} hook-wiring file(s) from {META_FILE}"
+            )
+
         case "validate":
             ok = True
 
@@ -1519,6 +1668,17 @@ def main() -> None:
                         file=sys.stderr,
                     )
                     for err in pattern_errors:
+                        print(f"  - {err}", file=sys.stderr)
+                    ok = False
+
+                hook_drift = check_generated_hooks(repo_root, meta)
+                if hook_drift:
+                    print(
+                        "ERROR: generated hook-wiring files are out of date with "
+                        f"{META_FILE}:",
+                        file=sys.stderr,
+                    )
+                    for err in hook_drift:
                         print(f"  - {err}", file=sys.stderr)
                     ok = False
 

--- a/tests/hooks_generator_test.py
+++ b/tests/hooks_generator_test.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Tests for the hook-wiring generator (plugin.meta.json "hooks" -> 4 dialects).
+
+Three logical hooks (router/context/auth) render into four runtime dialects:
+Claude hooks.json, Codex, Copilot, Cursor. These tests pin byte-reproducible
+generation, that the router is wired only on Claude + Codex, and that every
+rendered event name is one the target platform actually fires (a wrong-case
+event would silently never run; the per-platform allow-lists are #151's).
+
+Stdlib-only; run with: python3 -m unittest discover -s tests -p "*_test.py"
+"""
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location("skills", _REPO / "scripts" / "skills.py")
+skills = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(skills)
+
+
+class GeneratedHooksTest(unittest.TestCase):
+    def setUp(self):
+        self.meta = skills.load_meta(_REPO)
+
+    def test_repo_hooks_are_canonical(self):
+        # The committed hook-wiring files match what the generator produces.
+        self.assertEqual(skills.check_generated_hooks(_REPO, self.meta), [])
+
+    def test_generate_roundtrips_clean(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            written = skills.generate_hooks(root, self.meta)
+            self.assertEqual(written, len(skills.generated_hook_files(self.meta)))
+            self.assertEqual(skills.check_generated_hooks(root, self.meta), [])
+
+    def test_drift_detected(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            skills.generate_hooks(root, self.meta)
+            target = root / "hooks" / "cursor-hooks.json"
+            data = json.loads(target.read_text())
+            data["version"] = 2
+            target.write_text(json.dumps(data, indent=2) + "\n")
+            self.assertTrue(skills.check_generated_hooks(root, self.meta))
+
+    def test_event_names_are_valid_per_platform(self):
+        cases = [
+            (skills.build_nested_hooks(self.meta, "claude"), skills._CLAUDE_EVENTS),
+            (skills.build_nested_hooks(self.meta, "codex"), skills._CODEX_EVENTS),
+            (skills.build_copilot_hooks(self.meta), skills._COPILOT_EVENTS),
+            (skills.build_cursor_hooks(self.meta), skills._CURSOR_EVENTS),
+        ]
+        for cfg, valid in cases:
+            for event in cfg["hooks"]:
+                self.assertIn(event, valid, f"event {event!r} is not documented for this platform")
+
+    def test_router_only_on_claude_and_codex(self):
+        for key in ("claude", "codex"):
+            self.assertIn(
+                "UserPromptSubmit", skills.build_nested_hooks(self.meta, key)["hooks"]
+            )
+        # The other two cannot inject context from a prompt-submit hook, so the
+        # router script must not be wired at all.
+        for blob in (
+            json.dumps(skills.build_copilot_hooks(self.meta)),
+            json.dumps(skills.build_cursor_hooks(self.meta)),
+        ):
+            self.assertNotIn("databricks-router.py", blob)
+
+    def test_wired_scripts_exist(self):
+        for script in skills._hook_scripts(self.meta).values():
+            self.assertTrue((_REPO / "hooks" / script).exists(), script)
+
+    def test_claude_hooks_has_description_codex_does_not(self):
+        self.assertIn("description", skills.build_nested_hooks(self.meta, "claude"))
+        self.assertNotIn("description", skills.build_nested_hooks(self.meta, "codex"))
+
+    def test_flat_dialects_declare_version_1(self):
+        self.assertEqual(skills.build_copilot_hooks(self.meta)["version"], 1)
+        self.assertEqual(skills.build_cursor_hooks(self.meta)["version"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> Stacked on #153 (base branch `simonfaltum/meta-plugin-routing`, which is itself stacked on #152). Merge #152 then #153 first; this PR's diff is just the hook-generation commit.

## Why

The three logical hooks (prompt router, session-context primer, auth-failure hinter) ship to four runtimes whose hook-wiring formats differ in schema shape, event-name casing, env-var convention, command form, tool matcher, and which hooks are wired. That meant four hand-maintained wiring files (`hooks.json`, `codex-hooks.json`, `copilot-hooks.json`, `cursor-hooks.json`) kept in sync by hand. This is the last phase of the meta-plugin work (P3); after it, *everything* the plugin ships flows from `plugin.meta.json`.

## Changes

**Before:** four hand-edited hook-wiring JSON files.

**Now:** a canonical `hooks` block in `plugin.meta.json` (description, session-start matcher, the three scripts) plus a per-target `hooks_render` config (dialect, `env_root`, `tool_matcher`, platform flag). `scripts/skills.py` renders each target's dialect:

- **Claude** (`hooks.json`): nested arrays, PascalCase events, `${CLAUDE_PLUGIN_ROOT}`, `python3 X || python X || true`, router wired, `Bash` matcher, has `description`.
- **Codex** (`codex-hooks.json`): same nested shape, `${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}`, `(?i)bash|shell|exec`, router wired, no `description`.
- **Copilot** (`copilot-hooks.json`): `version: 1`, flat `bash`/`powershell` entries, PascalCase events, no router.
- **Cursor** (`cursor-hooks.json`): `version: 1`, flat `command` + `--platform cursor`, camelCase events, no router.

All four regenerate **byte-identical** to the hand-authored files (the generated set drift-checks like the plugin manifests and routing files). The router is wired only on Claude + Codex (the other two cannot inject context from a prompt-submit hook).

Adds a drift check (`check_generated_hooks`, wired into `validate`) and `tests/hooks_generator_test.py`: round-trip, drift detection, router-only-on-Claude/Codex, and that every rendered event name is in the per-platform allow-list from #151 (`_CLAUDE/_CODEX/_COPILOT/_CURSOR_EVENTS`) so a wrong-case event can't silently never fire. Documented in `hooks/README.md`, `CLAUDE.md`, and `CONTRIBUTING.md`.

## Test plan

- [x] `scripts/skills.py generate` leaves the four hook files byte-identical (zero diff); only `plugin.meta.json` + `scripts/skills.py` + docs change.
- [x] `scripts/skills.py validate` green (now includes the hook drift check, plus #151's existing per-file hook-event-name + wiring checks run on the generated files).
- [x] 92 tests pass (8 new hook-generator tests), incl. the event-name-validity guard per runtime.
- [x] Generated event names confirmed in #151's allow-lists; router absent from Copilot/Cursor wiring.

This pull request and its description were written by Isaac.
