### PR TITLE
fix(skills): quote databricks-app-design description; guard skill frontmatter

### DIFF
--- a/scripts/skills.py
+++ b/scripts/skills.py
@@ -101,6 +101,7 @@ from skillsgen.validators import (
     _COPILOT_EVENTS,
     _check_hook_event_names,
     check_plugin_components,
+    check_skill_frontmatter,
     _HOOK_PY_RE,
     _check_hook_wiring,
     check_cursor_plugin,

--- a/scripts/skillsgen/cli.py
+++ b/scripts/skillsgen/cli.py
@@ -30,6 +30,7 @@ from skillsgen.validators import (
     check_cursor_plugin,
     check_plugin_components,
     check_routing_tables,
+    check_skill_frontmatter,
 )
 
 
@@ -100,6 +101,16 @@ def main() -> None:
                     file=sys.stderr,
                 )
                 for err in metadata_errors:
+                    print(f"  - {err}", file=sys.stderr)
+                ok = False
+
+            frontmatter_errors = check_skill_frontmatter(repo_root)
+            if frontmatter_errors:
+                print(
+                    "ERROR: skill SKILL.md frontmatter is invalid:",
+                    file=sys.stderr,
+                )
+                for err in frontmatter_errors:
                     print(f"  - {err}", file=sys.stderr)
                 ok = False
 

--- a/scripts/skillsgen/validators.py
+++ b/scripts/skillsgen/validators.py
@@ -158,16 +158,13 @@ def check_plugin_components(repo_root: Path) -> list[str]:
 
 
 def check_skill_frontmatter(repo_root: Path) -> list[str]:
-    """Validate every skill's SKILL.md frontmatter survives a strict YAML parser.
+    """Flag SKILL.md frontmatter that a strict YAML parser would reject.
 
-    This repo reads frontmatter with regex, not a YAML parser, so a malformed
-    `description` (e.g. an unquoted ':' that strict YAML reads as a mapping
-    separator) loads fine here but is silently dropped by strict-YAML skill
-    consumers. This is the skills/ + experimental/ counterpart to the commands/
-    description check in check_plugin_components.
-
-    Each SKILL.md must have frontmatter, carry a `description`, and not contain
-    an unquoted ':' in that description.
+    Checked with a regex, not yaml.safe_load, because this package is
+    stdlib-only (the protected CI runner has no pypi). The failure that bites in
+    practice: an unquoted ':' in `description`, which strict-YAML skill loaders
+    read as a mapping separator and silently drop. Skills counterpart to the
+    commands check in check_plugin_components.
 
     Returns a list of error strings (empty means all good).
     """

--- a/scripts/skillsgen/validators.py
+++ b/scripts/skillsgen/validators.py
@@ -5,6 +5,7 @@ import re
 from pathlib import Path
 
 from skillsgen.common import _norm_rel_path, _read_frontmatter
+from skillsgen.discovery import iter_all_skill_dirs
 
 
 # ---------------------------------------------------------------------------
@@ -153,6 +154,37 @@ def check_plugin_components(repo_root: Path) -> list[str]:
                     )
         _check_hook_event_names("hooks/hooks.json", hooks_cfg, _CLAUDE_EVENTS, errors)
 
+    return errors
+
+
+def check_skill_frontmatter(repo_root: Path) -> list[str]:
+    """Validate every skill's SKILL.md frontmatter survives a strict YAML parser.
+
+    This repo reads frontmatter with regex, not a YAML parser, so a malformed
+    `description` (e.g. an unquoted ':' that strict YAML reads as a mapping
+    separator) loads fine here but is silently dropped by strict-YAML skill
+    consumers. This is the skills/ + experimental/ counterpart to the commands/
+    description check in check_plugin_components.
+
+    Each SKILL.md must have frontmatter, carry a `description`, and not contain
+    an unquoted ':' in that description.
+
+    Returns a list of error strings (empty means all good).
+    """
+    errors: list[str] = []
+    for skill_dir in iter_all_skill_dirs(repo_root):
+        rel = (skill_dir / "SKILL.md").relative_to(repo_root)
+        frontmatter = _read_frontmatter(skill_dir / "SKILL.md")
+        if frontmatter is None:
+            errors.append(f"Skill '{rel}' is missing YAML frontmatter.")
+        elif not re.search(r"^description:\s*\S", frontmatter, re.MULTILINE):
+            errors.append(f"Skill '{rel}' frontmatter is missing a 'description'.")
+        elif re.search(r"^description:[ \t]*[^\s\"'>|].*:(?:\s|$)", frontmatter, re.MULTILINE):
+            errors.append(
+                f"Skill '{rel}' has an unquoted ':' in its description, which "
+                "strict YAML parsers reject (the skill is then silently dropped "
+                "at load time). Quote the whole description string."
+            )
     return errors
 
 

--- a/skills/databricks-app-design/SKILL.md
+++ b/skills/databricks-app-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: databricks-app-design
 parent: databricks-apps
-description: Design the UX of Databricks data apps — dashboards, KPI pages, reports, charts, tables, and Genie/chat data assistants — mapped to concrete AppKit components. Use when BUILDING or reviewing any UI that displays data or answers data questions: choosing genre, layout, charts, KPIs, semantic color, required states (loading/empty/error), IBCS notation, and AI-result trust (showing generated SQL/sources for Genie/chat). NOT for authoring managed AI/BI (Lakeview) dashboards (→ databricks-aibi-dashboards), non-data frontend (forms, settings, auth, marketing), or scaffolding/build/deploy (→ databricks-apps). Complements databricks-apps; use it alongside whenever the app has a dashboard, chart, table, KPI, report, or Genie/chat/AI surface.
+description: "Design the UX of Databricks data apps — dashboards, KPI pages, reports, charts, tables, and Genie/chat data assistants — mapped to concrete AppKit components. Use when BUILDING or reviewing any UI that displays data or answers data questions: choosing genre, layout, charts, KPIs, semantic color, required states (loading/empty/error), IBCS notation, and AI-result trust (showing generated SQL/sources for Genie/chat). NOT for authoring managed AI/BI (Lakeview) dashboards (→ databricks-aibi-dashboards), non-data frontend (forms, settings, auth, marketing), or scaffolding/build/deploy (→ databricks-apps). Complements databricks-apps; use it alongside whenever the app has a dashboard, chart, table, KPI, report, or Genie/chat/AI surface."
 metadata:
   version: 0.1.0
 ---

--- a/tests/skills_generator_test.py
+++ b/tests/skills_generator_test.py
@@ -200,6 +200,16 @@ class SkillFrontmatterTest(unittest.TestCase):
             )
             self.assertEqual(skills.check_skill_frontmatter(root), [])
 
+    def test_unquoted_no_colon_ok(self):
+        # The common, valid shape: a plain bare scalar with no colon. Guards
+        # against the regex over-matching and flagging legitimate descriptions.
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            self._make_skill(
+                root, "databricks-plain", "Use when building dashboards and charts."
+            )
+            self.assertEqual(skills.check_skill_frontmatter(root), [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/skills_generator_test.py
+++ b/tests/skills_generator_test.py
@@ -167,5 +167,39 @@ class MetaSkillCoverageTest(unittest.TestCase):
             self.assertTrue(any("keyword" in e for e in errors), errors)
 
 
+class SkillFrontmatterTest(unittest.TestCase):
+    def _make_skill(self, root: Path, name: str, description: str) -> None:
+        skill_dir = root / "skills" / name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: {description}\n---\n"
+        )
+
+    def test_repo_skills_are_clean(self):
+        # Pins the databricks-app-design fix and guards every shipped skill: no
+        # SKILL.md may carry a description a strict YAML parser would reject.
+        self.assertEqual(skills.check_skill_frontmatter(_REPO), [])
+
+    def test_unquoted_colon_flagged(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            self._make_skill(
+                root, "databricks-bad", "Use when answering questions: pick a chart."
+            )
+            errors = skills.check_skill_frontmatter(root)
+            self.assertTrue(
+                any("databricks-bad" in e and "unquoted ':'" in e for e in errors),
+                errors,
+            )
+
+    def test_quoted_colon_ok(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            self._make_skill(
+                root, "databricks-good", '"Use when answering questions: pick a chart."'
+            )
+            self.assertEqual(skills.check_skill_frontmatter(root), [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What
- **Quote the `description`** in `skills/databricks-app-design/SKILL.md`. It was an unquoted YAML scalar containing a colon (`...answers data questions: choosing genre...`), which strict-YAML loaders (e.g. `omnigents`) reject with *"mapping values are not allowed here"*, silently dropping the skill at load time. Every other skill with a colon in its description already quotes it.
- **Add `check_skill_frontmatter`** to `scripts/skills.py validate` so any skill (stable or experimental) with missing or unquoted-colon `description` frontmatter fails CI. Closes the gap that let this through — only `commands/` were checked before.

## Verify
- PyYAML 6.0.3 (the parser `omnigents` uses): fixed frontmatter parses; the old form raises the exact reported error.
- `python3 scripts/skills.py validate` → clean; exits non-zero on the reverted bug.
- Full test suite passes, incl. new `SkillFrontmatterTest`.

Manifest output is unchanged (the extractor strips outer quotes), so no regeneration is needed.

This pull request and its description were written by Isaac.