### PR TITLE
chore(release): bump plugin manifests to v0.2.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "databricks",
   "description": "Databricks skills for the CLI, Apps, Lakebase, Model Serving, Lakeflow Jobs, Spark Declarative Pipelines, Declarative Automation Bundles (DABs), and classic-to-serverless migration.",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "author": {
     "name": "Databricks",
     "url": "https://databricks.com"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "databricks",
   "description": "Databricks skills for the CLI, Apps, Lakebase, Model Serving, Lakeflow Jobs, Spark Declarative Pipelines, Declarative Automation Bundles (DABs), and classic-to-serverless migration.",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "author": {
     "name": "Databricks",
     "url": "https://databricks.com"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "databricks",
   "displayName": "Databricks Skills",
   "description": "Databricks skills for the CLI, Apps, Lakebase, Model Serving, Lakeflow Jobs, Spark Declarative Pipelines, Declarative Automation Bundles (DABs), and classic-to-serverless migration.",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "author": {
     "name": "Databricks"
   },

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "databricks",
   "displayName": "Databricks",
   "description": "Databricks skills for the CLI, Apps, Lakebase, Model Serving, Lakeflow Jobs, Spark Declarative Pipelines, Declarative Automation Bundles (DABs), and classic-to-serverless migration.",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "author": {
     "name": "Databricks",
     "url": "https://databricks.com"

--- a/metaplugin/plugin.meta.json
+++ b/metaplugin/plugin.meta.json
@@ -1,6 +1,6 @@
 {
   "//": "Single source of truth for the databricks plugin across all targets (Claude, Codex, Copilot, Cursor). Edit this file, then run `python3 scripts/skills.py generate`. The 4 plugin.json + 3 marketplace.json files are generated from here; CI fails on drift. Do not hand-edit the generated files.",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "name": "databricks",
   "description": "Databricks skills for the CLI, Apps, Lakebase, Model Serving, Lakeflow Jobs, Spark Declarative Pipelines, Declarative Automation Bundles (DABs), and classic-to-serverless migration.",
   "category": "development",


### PR DESCRIPTION
## What

Bumps the plugin version `0.2.4` → `0.2.5` in `metaplugin/plugin.meta.json` (the single source of truth) and regenerates all manifests from it. Only the four `plugin.json` files (Claude, Codex, Copilot, Cursor) carry the version string, so they are the only generated files that change.

This is the manual equivalent of the Release workflow's version-bump step, done via PR because the workflow's `git push origin HEAD:main` runs as `github-actions[bot]`, which is not a bypass actor on the protected `main` ruleset.

## Why

Claude Code's plugin marketplace keys updates on the `version` field in `.claude-plugin/plugin.json`. Without a bump, installed clients keep the cached copy and never pick up what landed since v0.2.4 (new Codex + Copilot plugin targets, the Cursor rename to `databricks`, single-source manifest generation, and synced skill content).

## After merge

The `v0.2.5` annotated tag and the GitHub release are cut from the squash-merged commit on `main`, with notes auto-generated via `--generate-notes`.

This pull request and its description were written by Isaac.
