### PR TITLE
docs(apps): recommend `databricks apps deploy` as the one-step deploy

### DIFF
--- a/skills/databricks-apps/SKILL.md
+++ b/skills/databricks-apps/SKILL.md
@@ -221,7 +221,7 @@ Databricks Apps supports any framework that runs as an HTTP server. LLMs already
 After deploying, verify the app is running:
 
 ```bash
-databricks apps get <app-name> --profile <PROFILE> -o json   # Check app_status.state: RUNNING
+databricks apps get <app-name> --profile <PROFILE> -o json   # Check app_status.state: RUNNING; the `url` field is the app's URL
 databricks apps logs <app-name> --follow --profile <PROFILE>  # Stream live logs (Ctrl+C to stop)
 ```
 

--- a/skills/databricks-apps/references/other-frameworks.md
+++ b/skills/databricks-apps/references/other-frameworks.md
@@ -89,7 +89,7 @@ env:
 
 ### databricks.yml — Bundle/Deployment Configuration
 - Defines the **app resource** for DABs (Declarative Automation Bundles)
-- `config:` section only takes effect after `bundle run`, NOT just `bundle deploy`
+- Deploy with `databricks apps deploy` — it applies `config:` and starts the app. A bare `bundle deploy` uploads code but leaves the app stopped.
 
 ```yaml
 # databricks.yml
@@ -120,7 +120,7 @@ targets:
 | Rule | Why |
 |------|-----|
 | Always provide BOTH `app.yaml` AND `databricks.yml` config | UI deployments use app.yaml; DABs uses databricks.yml |
-| Always run `bundle deploy` THEN `bundle run <app-name>` | `deploy` uploads code; `run` applies config and starts the app |
+| Deploy apps with `databricks apps deploy` (one command) | It validates, uploads code, applies config, and **starts** the app. A bare `bundle deploy` leaves it stopped. |
 | Never use `${var.xxx}` in config env values | Variables are NOT resolved in config — values appear literally |
 
 ## 3. Using OBO in Non-AppKit Apps

--- a/skills/databricks-apps/references/platform-guide.md
+++ b/skills/databricks-apps/references/platform-guide.md
@@ -106,16 +106,13 @@ env:
 ⚠️ **USER CONSENT REQUIRED** — always confirm with the user before deploying.
 
 ```bash
-# Option A: single command (recommended) — validates, deploys, and runs
+# Recommended — validates, deploys, and starts the app (returns its URL)
 databricks apps deploy -t <TARGET> --profile <PROFILE>
-
-# Option B: step by step
-databricks apps validate --profile <PROFILE>
-databricks bundle deploy -t <TARGET> --profile <PROFILE>
-databricks bundle run <APP_RESOURCE_NAME> -t <TARGET> --profile <PROFILE>
 ```
 
-❌ **Common mistake:** Running only `bundle deploy` and expecting the app to update. Deploy uploads code but does NOT apply config changes or restart the app. Use `databricks apps deploy` or add `bundle run` after `bundle deploy`.
+❌ **Common mistake:** Running only `databricks bundle deploy`. A bare `bundle deploy` uploads the app but creates it with `no_compute`, so it stays **stopped** with no URL. Use `databricks apps deploy` instead — or run `databricks bundle run <APP_RESOURCE_NAME>` after `bundle deploy`.
+
+> AppKit-scaffolded apps set `lifecycle.started: true` in `databricks.yml`, so even a bare `bundle deploy` starts them.
 
 ### ⚠️ Destructive Updates Warning
 
@@ -165,7 +162,7 @@ For long-running agent interactions, use **WebSockets** instead of SSE.
 | Error | Cause | Fix |
 |-------|-------|-----|
 | `PERMISSION_DENIED` after deploy | SP missing permissions | Grant SP access to all declared resources |
-| App deploys but config doesn't change | Only ran `bundle deploy` | Also run `bundle run <app-name>` |
+| App deployed but not running / config unchanged | Ran only `bundle deploy` (creates app with `no_compute`, stays stopped) | Use `databricks apps deploy` (deploys *and* starts); or run `bundle run <app-name>` after deploy |
 | `File is larger than 10485760 bytes` | Bundled dependencies | Use requirements.txt / package.json |
 | OBO scopes missing after deploy | Destructive update wiped them | Re-apply scopes after each deploy |
 | `${var.xxx}` appears literally in env | Variables not resolved in config | Use literal values, not bundle variables |

--- a/skills/databricks-dabs/references/deploy-and-run.md
+++ b/skills/databricks-dabs/references/deploy-and-run.md
@@ -94,7 +94,7 @@ databricks apps logs <app-name> --profile <profile-name>
 | ---------------------------------- | ----------------------------------------------------------------------- |
 | **Path resolution fails**          | Use `../src/` in resources/\*.yml, `./src/` in databricks.yml           |
 | **Hardcoded catalog in dashboard** | Use dataset_catalog parameter (CLI v0.281.0+)                           |
-| **App not starting after deploy**  | Apps require `databricks bundle run <resource_key>` to start            |
+| **App not starting after deploy**  | Use `databricks apps deploy` (deploys *and* starts the app); a bare `bundle deploy` leaves it stopped. Or run `databricks bundle run <resource_key>` after deploy. |
 | **App env vars not working**       | Environment variables go in `app.yaml` (source dir), not databricks.yml |
 | **Debugging any app issue**        | First step: `databricks apps logs <app-name>`                           |
 | **Variable shows as `${var.name}` literal** | Variable not declared in `databricks.yml` `variables:`, missing from the active target, or wrong syntax (use `${var.<name>}`) |


### PR DESCRIPTION
## What

For all app-related skills, recommend the single **`databricks apps deploy`** command instead of the bare `bundle deploy` + `bundle run` two-step.

`databricks apps deploy` validates, deploys, **and** starts the app (returning its URL) in one step. A plain `databricks bundle deploy` creates the app with `no_compute` and leaves it **stopped** — which is why agent runs were emitting a separate manual start step (e.g. "To start the deployed app: run `databricks apps start …`"). The bundle commands stay documented as an advanced/bundle-native fallback, and the "deploy leaves it stopped" reason is now stated once.

## Why

Follows up on the Slack discussion about why deploying an app took two CLI steps. Confirmed in the CLI source: `bundle deploy` uses `no_compute=true`; `apps deploy` runs the app; and `lifecycle.started: true` (databricks/cli#4672) flips `no_compute` off. The companion appkit PR bakes `lifecycle.started: true` into the scaffolding template so any deploy path leaves the app running.

## Changes

- `skills/databricks-apps/references/platform-guide.md` — Deployment Workflow now leads with `apps deploy`; the bundle two-step is an advanced note; Common Errors row updated.
- `skills/databricks-apps/references/other-frameworks.md` — Critical Rules + `config:` note recommend `apps deploy`.
- `skills/databricks-dabs/references/deploy-and-run.md` — app-scoped "App not starting after deploy" row points at `apps deploy` (generic job/pipeline guidance untouched).
- `skills/databricks-apps/SKILL.md` — note the `url` field from `apps get`.

`python3 scripts/skills.py validate` passes (docs-only; no manifest/metadata drift).

This pull request and its description were written by Isaac.