### PR TITLE
ci(release): push as the DECO-SDK-Tagging App so the release workflow can write to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,27 @@ jobs:
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
+    # release-is holds the DECO-SDK-Tagging GitHub App credentials below.
+    environment: "release-is"
     permissions:
       contents: write
     steps:
+      # Push as the DECO-SDK-Tagging App, not github-actions[bot]. main's
+      # rulesets require PR + merge queue and reject a direct bot push; the App
+      # is on the ruleset bypass list (branch + tag creation), so it can push
+      # the bump commit and the tag directly. Same pattern as databricks-sdk-go.
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ secrets.DECO_SDK_TAGGING_APP_ID }}
+          private-key: ${{ secrets.DECO_SDK_TAGGING_PRIVATE_KEY }}
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: main
+          # Persist the App token so the pushes below carry its credentials.
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -50,8 +65,10 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Commit as the App. The email must be the App's noreply address or
+          # the commit will not be verified.
+          git config user.name "Databricks SDK Release Bot"
+          git config user.email "DECO-SDK-Tagging[bot]@users.noreply.github.com"
           # metaplugin/plugin.meta.json is the source; bump_version.py regenerates
           # the full set from it: the four marketplace.json catalogs (Cursor's is
           # new), the routing files, the four hook-wiring dialects, manifest.json,
@@ -107,7 +124,7 @@ jobs:
 
       - name: Create release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           VERSION: ${{ inputs.version }}
         run: |
           gh release create "$VERSION" \


### PR DESCRIPTION
## Why

The Release workflow failed at the "Commit version bump" step. It pushed the bump commit to `main` as `github-actions[bot]`, and `main`'s rulesets (added 2026-06-19) now require changes to go through a PR + merge queue, so the push is rejected:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
- Changes must be made through a pull request.
- Changes must be made through the merge queue
! [remote rejected] HEAD -> main (push declined due to repository rule violations)
```

## Changes

Authenticate the release job as the **DECO-SDK-Tagging** GitHub App instead of the default token, mirroring `databricks-sdk-go`'s `tagging.yml`. That App is already on the branch and tag-creation ruleset bypass lists (Integration with `always` bypass), and its credentials already live in this repo's `release-is` environment, so it can push the bump commit and the tag directly. No PR/merge-queue redesign needed.

- Run the release job in the `release-is` environment (holds `DECO_SDK_TAGGING_APP_ID` / `DECO_SDK_TAGGING_PRIVATE_KEY`).
- Mint an App token with `actions/create-github-app-token` and check out with it, so the pushes carry the App's credentials.
- Commit as `Databricks SDK Release Bot` / `DECO-SDK-Tagging[bot]@users.noreply.github.com` (App email, so the commit is verified).
- Use the App token for `gh release create`.

Behavior is otherwise unchanged: bump `metaplugin/plugin.meta.json`, regenerate, validate, commit, tag, release.

## Test plan

- [x] `release.yml` parses as valid YAML.
- [x] Local dry-run of the generator + staging guard passes (`bump_version.py` then `skills.py validate`, stage the release.yml file set, confirm no unstaged leftovers).
- [ ] After merge: dispatch the Release workflow with a test version and confirm the bump commit, tag, and GitHub release are created (this is the live test of the App credential and the ruleset bypass).
- [ ] Install smoke test from the resulting tag (Claude at minimum).

This pull request and its description were written by Isaac.
