### PR TITLE
ci(validate): regenerate from source before validating (source-only mirror)

### DIFF
--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -35,6 +35,19 @@ jobs:
         with:
           python-version: '3.11'
 
+      # This repo is published as a source-only mirror from an internal source of
+      # truth. Generated artifacts (the plugins/ bundle, manifest.json, the
+      # marketplace catalogs, the rendered hook/routing files) are regenerated and
+      # committed only on release (see release.yml). Between releases a PR carries
+      # source changes with intentionally stale generated files, so regenerate
+      # from source here before validating. This is a DRY RUN: the regenerated
+      # files are never committed (CI checkouts are ephemeral). It lets `validate`
+      # and the generator tests run against a consistent tree, so a source change
+      # that breaks generation, frontmatter, routing, or a test fails at PR time
+      # instead of silently waiting until the next release.
+      - name: Regenerate from source (dry run; not committed)
+        run: python3 scripts/skills.py generate
+
       - name: Validate manifest is up to date
         run: python3 scripts/skills.py validate
 


### PR DESCRIPTION
## What

This repo is published as a **source-only mirror** from an internal source of truth. Generated artifacts (the `plugins/` bundle, `manifest.json`, the marketplace catalogs, the rendered hook/routing files) are regenerated and committed only on release (`release.yml`). Between releases, a PR carries source-only changes with intentionally stale committed artifacts.

`validate-manifest.yml` now runs `skills.py generate` (a dry run, **never committed**; CI checkouts are ephemeral) before `skills.py validate` and the generator tests, so the full suite runs against a consistent, freshly-generated tree.

## Why

Without this, a source-only PR (new source + stale committed generated files) fails `validate` (drift) and the generator tests, which would block the automated mirror. Regenerating first lets such a PR pass, while keeping the guard intact: a source change that breaks generation, frontmatter, routing, or any generator test still fails at PR time, instead of silently waiting until the next release surfaces it.

Because `release.yml` already regenerates before it validates, this makes the PR check equivalent to the release check (minus the expected, between-release committed-artifact drift), so nothing that would break a release slips through to release time.

## How verified

On the current tree (which carries the pre-existing app-design/apps bundle drift from #144): `python3 scripts/skills.py generate` → `python3 scripts/skills.py validate` reports `Everything is up to date` → `python3 -m unittest discover -s tests -p '*_test.py'` runs 111 tests, all passing.

This is part of wiring the source-only mirror from the internal monorepo; it pairs with the import + publish-pipeline work landing there.

This pull request and its description were written by Isaac.
