### PR TITLE
docs(skills): Lakebase app-attach guidance + create-update as the standard for app resource updates

### DIFF
--- a/skills/databricks-apps/SKILL.md
+++ b/skills/databricks-apps/SKILL.md
@@ -70,7 +70,9 @@ Before writing any SQL, use the parent `databricks-core` skill for data explorat
 If the user's app description involves storing or persisting data — forms, CRUD operations, user submissions, orders, todos, or other user-generated content — the app likely needs a Lakebase database.
 
 1. **Ask the user** whether the app needs persistent storage (Lakebase) before scaffolding. Do not silently add Lakebase.
-2. If confirmed, use the **`databricks-lakebase`** skill to create a Lakebase project and obtain the branch and database resource names.
+2. If confirmed, **ask whether to reuse an existing Lakebase project or create a new one** (same as the Genie flow below) — never create one silently. Use the **`databricks-lakebase`** skill to obtain the branch and database resource names:
+   - **Reusing:** list with `databricks postgres list-projects`, then `list-branches` / `list-databases`, and let the user pick the project, branch, and database; confirm which schema the app will own (a fresh/dedicated schema avoids the service-principal ownership conflict).
+   - **Creating:** create a new project (it auto-provisions a `production` branch + `databricks_postgres` database).
 3. Scaffold with `--features lakebase` and pass `--set lakebase.postgres.branch=<BRANCH_NAME> --set lakebase.postgres.database=<DATABASE_NAME>`.
 4. If the app **also** reads from Unity Catalog tables, proceed to the Data Access Decision Gate below to determine whether to add `--features analytics` or use Lakebase synced tables.
 

--- a/skills/databricks-apps/references/platform-guide.md
+++ b/skills/databricks-apps/references/platform-guide.md
@@ -114,13 +114,19 @@ databricks apps deploy -t <TARGET> --profile <PROFILE>
 
 > AppKit-scaffolded apps set `lifecycle.started: true` in `databricks.yml`, so even a bare `bundle deploy` starts them.
 
-### ⚠️ Destructive Updates Warning
+### Updating an app's resources/config: use `apps create-update`
 
-`databricks apps update` (and `bundle run`) performs a **full replacement**, not a merge:
-- Adding a new resource can silently **wipe** existing `user_api_scopes`
-- OBO permissions may be stripped on every deployment
+Always use `databricks apps create-update` to change an app's resources or config — for **every** app. The older `databricks apps update` is legacy and should not be used: it can't change resources for an app in a space, and `create-update` supersedes it. Pass everything in `--json` (only `APP_NAME` is positional) — the body is `{"update_mask": "...", "app": {...}}`, **not** `update_mask` as a separate arg:
 
-**Workaround:** After each deployment, verify OBO scopes are intact.
+```bash
+databricks apps create-update <APP_NAME> --json @update.json   # waits for completion; --no-wait to return early
+```
+
+⚠️ **`update_mask` scopes the change to the fields you list, and each listed field is replaced wholesale (not item-merged).** With `update_mask=resources` the entire `resources` array is replaced, so read the app's current resources and **merge** your new one in before submitting, or you'll detach the rest. Fields you don't list in the mask (e.g. `user_api_scopes`) are left untouched.
+
+For attaching a **Lakebase** database resource specifically — the `postgres` (Autoscaling
+project) vs legacy `database` (provisioned instance) resource key, and the exact
+`branch`/`database` JSON shape — see the **`databricks-lakebase`** skill.
 
 ## Runtime Environment
 

--- a/skills/databricks-lakebase/SKILL.md
+++ b/skills/databricks-lakebase/SKILL.md
@@ -77,7 +77,7 @@ databricks postgres <subcommand> -h       # Flags, args, JSON fields
 
 ## Create a Project
 
-> **Do NOT list projects before creating.**
+> **First decide: reuse or create.** When building or attaching to an app, ask the user whether to reuse an existing project/branch/database — list them with `databricks postgres list-projects` (then `list-branches` / `list-databases`), let the user pick, and confirm which schema the app will own — or create a new project. Only skip listing and create directly when the user explicitly asked for a brand-new project.
 
 ```bash
 databricks postgres create-project <PROJECT_ID> \
@@ -195,6 +195,45 @@ databricks apps init --name <APP_NAME> --features lakebase \
 ```
 
 For the full app workflow, use the **`databricks-apps`** skill.
+
+### Attach Lakebase to an existing app
+
+`apps init --features lakebase` (above) wires the database at scaffold time. To
+attach a project to an **existing** app, update its resources.
+
+**Use the `postgres` resource key for an Autoscaling project** — its fields are
+`branch` + `database` (full resource paths from the table above). The legacy
+`database` key (`instance_name` + `database_name`) is for **Provisioned**
+instances only; using it for an Autoscaling project fails with
+`Database instance <name> does not exist`. Get the exact paths from
+`list-branches` / `list-databases` (the DB name is often hyphenated, e.g.
+`databricks-postgres`).
+
+Update the app's resources with **`databricks apps create-update`** — the method to use for any app (the older `databricks apps update` is legacy and can't change resources for an app in a space). `update_mask=resources` replaces the whole `resources` array, so read the app's current resources and **merge** the new one in (or you'll detach the rest). Pass everything in `--json`; only `APP_NAME` is positional:
+
+```bash
+databricks apps create-update <APP_NAME> --json @update.json --profile <PROFILE>   # waits for completion; --no-wait to return early
+```
+
+```json
+{
+  "update_mask": "resources",
+  "app": {
+    "resources": [
+      {
+        "name": "postgres",
+        "postgres": {
+          "branch": "projects/<PROJECT_ID>/branches/<BRANCH_ID>",
+          "database": "projects/<PROJECT_ID>/branches/<BRANCH_ID>/databases/<DATABASE_ID>",
+          "permission": "CAN_CONNECT_AND_CREATE"
+        }
+      }
+    ]
+  }
+}
+```
+
+**Confirm the branch/database with the user — don't default to `production` silently.** The app's service principal must be able to create and **own** the schema(s) it uses there, so avoid a branch/database where those schema names are already owned by a user (the SP will hit `permission denied … 42501`) — a fresh/dedicated branch, or a new app-owned schema, is cleanest. See **Schema Permissions for Deployed Apps** below for the full ownership model.
 
 ### Schema Permissions for Deployed Apps
 


### PR DESCRIPTION
## What

Higher-level guidance for connecting Databricks Apps to Lakebase and for updating an app's resources.

- **`databricks-apps` (platform-guide):** use `databricks apps create-update` as the standard way to update an app's resources/config — required for an app in a space (plain `apps update` is rejected for resource changes) — with the full-replacement caveat: `update_mask=resources` replaces the entire `resources` array, so read the current resources and merge before submitting.
- **`databricks-lakebase`:** add "Attach Lakebase to an existing app" — attach via `create-update` using the **`postgres`** resource key (Autoscaling: `branch` + `database` paths), not the legacy `database` key (Provisioned-only); plus a note to confirm the branch/database with the user.
- **Reuse-vs-create for Lakebase projects** (mirrors the existing Genie flow) instead of creating one silently: `databricks-apps` asks whether to reuse an existing project or create a new one; `databricks-lakebase` replaces "Do NOT list projects before creating" with a reuse-or-create guard that lists projects/branches/databases for the user to pick.

This pull request and its description were written by Isaac.
