### PR TITLE
fix(lakebase): remove non-existent postgres reset-branch CLI invocation

### DIFF
--- a/plugins/databricks/claude/skills/databricks-lakebase/SKILL.md
+++ b/plugins/databricks/claude/skills/databricks-lakebase/SKILL.md
@@ -162,10 +162,13 @@ Branches require an expiration policy: `"no_expiry": true` for permanent, or `"t
 
 **Point-in-time branching:** Create from a past state (within restore window) for recovery. Run `databricks postgres create-branch -h` for time specification fields.
 
-**Reset:** Replaces branch data with latest from parent. Local changes are lost. Root branches and branches with children cannot be reset.
+**Reset:** Replaces branch data with the latest from parent -- a full overwrite, not a merge; local changes on the branch are lost. Root branches, branches with children, and protected branches cannot be reset.
+
+**No CLI or SDK support -- reset is UI-only.** Verified absent from `databricks postgres -h` (CLI v1.9.0) and from `WorkspaceClient().postgres` (databricks-sdk 0.120.0). Reset from the Branches page: kebab menu → **Reset from parent**.
 
 ```bash
-databricks postgres reset-branch projects/<PROJECT_ID>/branches/<BRANCH_ID> --profile <PROFILE>
+# ❌ WRONG: this command DOESN'T EXIST
+# databricks postgres reset-branch ...   ← no CLI equivalent; use the UI
 ```
 
 **Delete:** Protected branches must be unprotected first (`update-branch` to set `spec.is_protected` to `false`). Cannot delete branches with children. **Never delete the `production` branch.**

--- a/plugins/databricks/codex/skills/databricks-lakebase/SKILL.md
+++ b/plugins/databricks/codex/skills/databricks-lakebase/SKILL.md
@@ -162,10 +162,13 @@ Branches require an expiration policy: `"no_expiry": true` for permanent, or `"t
 
 **Point-in-time branching:** Create from a past state (within restore window) for recovery. Run `databricks postgres create-branch -h` for time specification fields.
 
-**Reset:** Replaces branch data with latest from parent. Local changes are lost. Root branches and branches with children cannot be reset.
+**Reset:** Replaces branch data with the latest from parent -- a full overwrite, not a merge; local changes on the branch are lost. Root branches, branches with children, and protected branches cannot be reset.
+
+**No CLI or SDK support -- reset is UI-only.** Verified absent from `databricks postgres -h` (CLI v1.9.0) and from `WorkspaceClient().postgres` (databricks-sdk 0.120.0). Reset from the Branches page: kebab menu → **Reset from parent**.
 
 ```bash
-databricks postgres reset-branch projects/<PROJECT_ID>/branches/<BRANCH_ID> --profile <PROFILE>
+# ❌ WRONG: this command DOESN'T EXIST
+# databricks postgres reset-branch ...   ← no CLI equivalent; use the UI
 ```
 
 **Delete:** Protected branches must be unprotected first (`update-branch` to set `spec.is_protected` to `false`). Cannot delete branches with children. **Never delete the `production` branch.**

--- a/plugins/databricks/copilot/skills/databricks-lakebase/SKILL.md
+++ b/plugins/databricks/copilot/skills/databricks-lakebase/SKILL.md
@@ -162,10 +162,13 @@ Branches require an expiration policy: `"no_expiry": true` for permanent, or `"t
 
 **Point-in-time branching:** Create from a past state (within restore window) for recovery. Run `databricks postgres create-branch -h` for time specification fields.
 
-**Reset:** Replaces branch data with latest from parent. Local changes are lost. Root branches and branches with children cannot be reset.
+**Reset:** Replaces branch data with the latest from parent -- a full overwrite, not a merge; local changes on the branch are lost. Root branches, branches with children, and protected branches cannot be reset.
+
+**No CLI or SDK support -- reset is UI-only.** Verified absent from `databricks postgres -h` (CLI v1.9.0) and from `WorkspaceClient().postgres` (databricks-sdk 0.120.0). Reset from the Branches page: kebab menu → **Reset from parent**.
 
 ```bash
-databricks postgres reset-branch projects/<PROJECT_ID>/branches/<BRANCH_ID> --profile <PROFILE>
+# ❌ WRONG: this command DOESN'T EXIST
+# databricks postgres reset-branch ...   ← no CLI equivalent; use the UI
 ```
 
 **Delete:** Protected branches must be unprotected first (`update-branch` to set `spec.is_protected` to `false`). Cannot delete branches with children. **Never delete the `production` branch.**

--- a/plugins/databricks/cursor/skills/databricks-lakebase/SKILL.md
+++ b/plugins/databricks/cursor/skills/databricks-lakebase/SKILL.md
@@ -162,10 +162,13 @@ Branches require an expiration policy: `"no_expiry": true` for permanent, or `"t
 
 **Point-in-time branching:** Create from a past state (within restore window) for recovery. Run `databricks postgres create-branch -h` for time specification fields.
 
-**Reset:** Replaces branch data with latest from parent. Local changes are lost. Root branches and branches with children cannot be reset.
+**Reset:** Replaces branch data with the latest from parent -- a full overwrite, not a merge; local changes on the branch are lost. Root branches, branches with children, and protected branches cannot be reset.
+
+**No CLI or SDK support -- reset is UI-only.** Verified absent from `databricks postgres -h` (CLI v1.9.0) and from `WorkspaceClient().postgres` (databricks-sdk 0.120.0). Reset from the Branches page: kebab menu → **Reset from parent**.
 
 ```bash
-databricks postgres reset-branch projects/<PROJECT_ID>/branches/<BRANCH_ID> --profile <PROFILE>
+# ❌ WRONG: this command DOESN'T EXIST
+# databricks postgres reset-branch ...   ← no CLI equivalent; use the UI
 ```
 
 **Delete:** Protected branches must be unprotected first (`update-branch` to set `spec.is_protected` to `false`). Cannot delete branches with children. **Never delete the `production` branch.**

--- a/skills/databricks-lakebase/SKILL.md
+++ b/skills/databricks-lakebase/SKILL.md
@@ -162,10 +162,13 @@ Branches require an expiration policy: `"no_expiry": true` for permanent, or `"t
 
 **Point-in-time branching:** Create from a past state (within restore window) for recovery. Run `databricks postgres create-branch -h` for time specification fields.
 
-**Reset:** Replaces branch data with latest from parent. Local changes are lost. Root branches and branches with children cannot be reset.
+**Reset:** Replaces branch data with the latest from parent -- a full overwrite, not a merge; local changes on the branch are lost. Root branches, branches with children, and protected branches cannot be reset.
+
+**No CLI or SDK support -- reset is UI-only.** Verified absent from `databricks postgres -h` (CLI v1.9.0) and from `WorkspaceClient().postgres` (databricks-sdk 0.120.0). Reset from the Branches page: kebab menu → **Reset from parent**.
 
 ```bash
-databricks postgres reset-branch projects/<PROJECT_ID>/branches/<BRANCH_ID> --profile <PROFILE>
+# ❌ WRONG: this command DOESN'T EXIST
+# databricks postgres reset-branch ...   ← no CLI equivalent; use the UI
 ```
 
 **Delete:** Protected branches must be unprotected first (`update-branch` to set `spec.is_protected` to `false`). Cannot delete branches with children. **Never delete the `production` branch.**


### PR DESCRIPTION
fix(lakebase): remove non-existent postgres reset-branch CLI invocation

Fixes #210

## Evidence

The documented command does not exist in the CLI:

```
$ databricks --version
Databricks CLI v1.9.0

$ databricks postgres reset-branch
Error: unknown command "reset-branch" for "databricks postgres"
```

`databricks postgres -h` lists every real subcommand (create/get/list/update/delete-*
for projects, branches, endpoints, databases, roles, plus catalog/CDF/synced-table
and credential commands) and `reset-branch` is absent from it.

It also has no SDK equivalent. Checked the installed `databricks-sdk` (v0.120.0)
two ways:

```
$ python3 -c "from databricks.sdk.service import postgres; print([n for n in dir(postgres) if 'eset' in n.lower()])"
[]

$ python3 -c "from databricks.sdk import WorkspaceClient as W; print([n for n in dir(W().postgres) if 'eset' in n.lower()])"
[]
```

Both empty. As a third, independent check, grepped the entire installed SDK package
source tree for `reset_branch` / `ResetBranch` / `reset-branch` — zero matches. No
reset method exists anywhere in the CLI or the SDK today.

## Before/after

```diff
-**Reset:** Replaces branch data with latest from parent. Local changes are lost. Root branches and branches with children cannot be reset.
+**Reset:** Replaces branch data with the latest from parent -- a full overwrite, not a merge; local changes on the branch are lost. Root branches, branches with children, and protected branches cannot be reset.
+
+**No CLI or SDK support -- reset is UI-only.** Verified absent from `databricks postgres -h` (CLI v1.9.0) and from `WorkspaceClient().postgres` (databricks-sdk 0.120.0). Reset from the Branches page: kebab menu → **Reset from parent**.

 ```bash
-databricks postgres reset-branch projects/<PROJECT_ID>/branches/<BRANCH_ID> --profile <PROFILE>
+# ❌ WRONG: this command DOESN'T EXIST
+# databricks postgres reset-branch ...   ← no CLI equivalent; use the UI
 ```
```

The negative-assertion block (`# ❌ WRONG: ... DOESN'T EXIST`) matches the existing
house style already used in `skills/databricks-core/SKILL.md`'s CLI cheat sheet.
Added deliberately, not just removed: agents that cached the previous skill version
already "know" the fake command, so an explicit negative signal is a stronger
correction than silent deletion.

## Why the section wasn't deleted

Branch reset is a real, documented capability — only the invocation was wrong.
Constraints, cross-checked against docs:

- Root branches can't be reset (no parent to reset to).
- Branches with children can't be reset (children must be deleted first).
- Protected branches can't be reset.
- The only supported path is the UI: Branches page → kebab menu → **Reset from
  parent**.

Sources:
- https://docs.databricks.com/aws/en/dev-tools/cli/reference/postgres-commands (full CLI subcommand list — no `reset-branch`)
- https://docs.databricks.com/aws/en/oltp/projects/manage-branches (reset semantics, constraints, UI path)

## Self-contradiction note

The file already instructs agents: "Do NOT guess command syntax. Discover available
commands dynamically: `databricks postgres -h`." The `reset-branch` invocation broke
that same rule — this PR corrects the file to comply with its own stated policy.

## Scope note (dates)

An earlier triage pass on this file flagged stale future-tense migration-date wording
("Automatic migration of Provisioned instances begins June 2026" / "Automatic
seamless upgrades ... begin June 2026") as a second defect. That wording is **already
gone** — it was superseded upstream in commit `45e41c1` (#208) with present-tense
phrasing ("is being migrated to Autoscaling over summer 2026, with no customer action
required"). I re-verified that current phrasing against
https://docs.databricks.com/aws/en/oltp/instances/, which states "Existing Provisioned
instances are being upgraded automatically to Autoscaling, starting in June 2026" —
consistent with the file as it stands today. No date-related change is included in
this PR because none was needed.

## Validation

- `python3 scripts/skills.py` (generate) — OK
- `python3 scripts/skills.py validate` — "Everything is up to date."
- `python3 -m unittest discover -s tests -p '*_test.py'` — 118 tests, OK
- 5 files changed: `skills/databricks-lakebase/SKILL.md` (source) + the four
  regenerated per-provider mirrors under `plugins/databricks/{claude,codex,copilot,cursor}/skills/databricks-lakebase/SKILL.md`,
  all byte-identical to the source file. No hand-edits to any generated file.

## Open questions

- No CLI/SDK reset method exists **as of CLI v1.9.0 / SDK v0.120.0** (checked
  locally, today). If Databricks ships one later, this section should be revisited
  to teach that path instead of the UI-only note.
- I could not verify GitHub's DCO check will pass for the commit's sign-off email
  (`dipayandas.data@gmail.com`) — the `gh api user/emails` verified-email check
  failed locally on missing OAuth scope (`user`), so it's unconfirmed whether that
  address is a verified email on the GitHub account that will open the PR.
